### PR TITLE
refactor(csharp): make CloudFetch pipeline protocol-agnostic

### DIFF
--- a/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
@@ -1,0 +1,199 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
+{
+    /// <summary>
+    /// Base class for result fetchers that extract common pipeline management logic.
+    /// Subclasses implement protocol-specific fetching logic (Thrift, REST, etc.).
+    /// </summary>
+    internal abstract class BaseResultFetcher : ICloudFetchResultFetcher
+    {
+        protected readonly BlockingCollection<IDownloadResult> _downloadQueue;
+        protected readonly ICloudFetchMemoryBufferManager _memoryManager;
+        protected volatile bool _hasMoreResults;
+        protected volatile bool _isCompleted;
+        protected Exception? _error;
+        private Task? _fetchTask;
+        private CancellationTokenSource? _cancellationTokenSource;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseResultFetcher"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The memory buffer manager.</param>
+        /// <param name="downloadQueue">The queue to add download tasks to.</param>
+        protected BaseResultFetcher(
+            ICloudFetchMemoryBufferManager memoryManager,
+            BlockingCollection<IDownloadResult> downloadQueue)
+        {
+            _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
+            _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
+            _hasMoreResults = true;
+            _isCompleted = false;
+        }
+
+        /// <inheritdoc />
+        public bool HasMoreResults => _hasMoreResults;
+
+        /// <inheritdoc />
+        public bool IsCompleted => _isCompleted;
+
+        /// <inheritdoc />
+        public bool HasError => _error != null;
+
+        /// <inheritdoc />
+        public Exception? Error => _error;
+
+        /// <inheritdoc />
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (_fetchTask != null)
+            {
+                throw new InvalidOperationException("Fetcher is already running.");
+            }
+
+            // Reset state
+            _hasMoreResults = true;
+            _isCompleted = false;
+            _error = null;
+            ResetState();
+
+            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _fetchTask = FetchResultsWrapperAsync(_cancellationTokenSource.Token);
+
+            // Wait for the fetch task to start
+            await Task.Yield();
+        }
+
+        /// <inheritdoc />
+        public async Task StopAsync()
+        {
+            if (_fetchTask == null)
+            {
+                return;
+            }
+
+            _cancellationTokenSource?.Cancel();
+
+            try
+            {
+                await _fetchTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when cancellation is requested
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error stopping fetcher: {ex.Message}");
+            }
+            finally
+            {
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+                _fetchTask = null;
+            }
+        }
+
+        /// <inheritdoc />
+        public abstract Task<IDownloadResult?> GetDownloadResultAsync(long offset, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Resets the fetcher state. Called at the beginning of StartAsync.
+        /// Subclasses can override to reset protocol-specific state.
+        /// </summary>
+        protected virtual void ResetState()
+        {
+            // Base implementation does nothing. Subclasses can override.
+        }
+
+        /// <summary>
+        /// Protocol-specific logic to fetch all results and populate the download queue.
+        /// This method must add IDownloadResult objects to _downloadQueue using AddDownloadResult().
+        /// It should also set _hasMoreResults appropriately and throw exceptions on error.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        protected abstract Task FetchAllResultsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Helper method for subclasses to add download results to the queue.
+        /// </summary>
+        /// <param name="result">The download result to add.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        protected void AddDownloadResult(IDownloadResult result, CancellationToken cancellationToken)
+        {
+            _downloadQueue.Add(result, cancellationToken);
+        }
+
+        private async Task FetchResultsWrapperAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await FetchAllResultsAsync(cancellationToken).ConfigureAwait(false);
+
+                // Add the end of results guard to the queue
+                _downloadQueue.Add(EndOfResultsGuard.Instance, cancellationToken);
+                _isCompleted = true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Expected when cancellation is requested
+                _isCompleted = true;
+
+                // Add the end of results guard to the queue
+                try
+                {
+                    _downloadQueue.TryAdd(EndOfResultsGuard.Instance, 0);
+                }
+                catch (Exception)
+                {
+                    // Ignore any errors when adding the guard
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Unhandled error in fetcher: {ex.Message}");
+                _error = ex;
+                _hasMoreResults = false;
+                _isCompleted = true;
+
+                // Add the end of results guard to the queue even in case of error
+                try
+                {
+                    _downloadQueue.TryAdd(EndOfResultsGuard.Instance, 0);
+                }
+                catch (Exception)
+                {
+                    // Ignore any errors when adding the guard in case of error
+                }
+            }
+        }
+    }
+}

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -266,14 +266,14 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Check if the URL is expired or about to expire
                         if (downloadResult.IsExpiredOrExpiringSoon(_urlExpirationBufferSeconds))
                         {
-                            // Get a refreshed URL before starting the download
-                            var refreshedLink = await _resultFetcher.GetUrlAsync(downloadResult.Link.StartRowOffset, cancellationToken);
-                            if (refreshedLink != null)
+                            // Get a refreshed download result before starting the download
+                            var refreshedResult = await _resultFetcher.GetDownloadResultAsync(downloadResult.StartRowOffset, cancellationToken);
+                            if (refreshedResult != null)
                             {
-                                // Update the download result with the refreshed link
-                                downloadResult.UpdateWithRefreshedLink(refreshedLink);
+                                // Update the download result with the refreshed URL
+                                downloadResult.UpdateWithRefreshedUrl(refreshedResult.FileUrl, refreshedResult.ExpirationTime, refreshedResult.HttpHeaders);
                                 activity?.AddEvent("cloudfetch.url_refreshed_before_download", [
-                                    new("offset", refreshedLink.StartRowOffset)
+                                    new("offset", refreshedResult.StartRowOffset)
                                 ]);
                             }
                         }
@@ -295,10 +295,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                                 if (t.IsFaulted)
                                 {
                                     Exception ex = t.Exception?.InnerException ?? new Exception("Unknown error");
-                                    string sanitizedUrl = SanitizeUrl(downloadResult.Link.FileLink);
+                                    string sanitizedUrl = SanitizeUrl(downloadResult.FileUrl);
                                     activity?.AddException(ex, [
                                         new("error.context", "cloudfetch.download_failed"),
-                                        new("offset", downloadResult.Link.StartRowOffset),
+                                        new("offset", downloadResult.StartRowOffset),
                                         new("sanitized_url", sanitizedUrl)
                                     ]);
 
@@ -369,15 +369,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         {
             await this.TraceActivityAsync(async activity =>
             {
-                string url = downloadResult.Link.FileLink;
-                string sanitizedUrl = SanitizeUrl(downloadResult.Link.FileLink);
+                string url = downloadResult.FileUrl;
+                string sanitizedUrl = SanitizeUrl(downloadResult.FileUrl);
                 byte[]? fileData = null;
 
                 // Use the size directly from the download result
                 long size = downloadResult.Size;
 
                 // Add tags to the Activity for filtering/searching
-                activity?.SetTag("cloudfetch.offset", downloadResult.Link.StartRowOffset);
+                activity?.SetTag("cloudfetch.offset", downloadResult.StartRowOffset);
                 activity?.SetTag("cloudfetch.sanitized_url", sanitizedUrl);
                 activity?.SetTag("cloudfetch.expected_size_bytes", size);
 
@@ -386,7 +386,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 
                 // Log download start
                 activity?.AddEvent("cloudfetch.download_start", [
-                new("offset", downloadResult.Link.StartRowOffset),
+                new("offset", downloadResult.StartRowOffset),
                     new("sanitized_url", sanitizedUrl),
                     new("expected_size_bytes", size),
                     new("expected_size_kb", size / 1024.0)
@@ -400,9 +400,21 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 {
                     try
                     {
+                        // Create HTTP request with optional custom headers
+                        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+                        // Add custom headers if provided
+                        if (downloadResult.HttpHeaders != null)
+                        {
+                            foreach (var header in downloadResult.HttpHeaders)
+                            {
+                                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                            }
+                        }
+
                         // Download the file directly
-                        using HttpResponseMessage response = await _httpClient.GetAsync(
-                            url,
+                        using HttpResponseMessage response = await _httpClient.SendAsync(
+                            request,
                             HttpCompletionOption.ResponseHeadersRead,
                             cancellationToken).ConfigureAwait(false);
 
@@ -417,16 +429,16 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                             }
 
                             // Try to refresh the URL
-                            var refreshedLink = await _resultFetcher.GetUrlAsync(downloadResult.Link.StartRowOffset, cancellationToken);
-                            if (refreshedLink != null)
+                            var refreshedResult = await _resultFetcher.GetDownloadResultAsync(downloadResult.StartRowOffset, cancellationToken);
+                            if (refreshedResult != null)
                             {
-                                // Update the download result with the refreshed link
-                                downloadResult.UpdateWithRefreshedLink(refreshedLink);
-                                url = refreshedLink.FileLink;
+                                // Update the download result with the refreshed URL
+                                downloadResult.UpdateWithRefreshedUrl(refreshedResult.FileUrl, refreshedResult.ExpirationTime, refreshedResult.HttpHeaders);
+                                url = refreshedResult.FileUrl;
                                 sanitizedUrl = SanitizeUrl(url);
 
                                 activity?.AddEvent("cloudfetch.url_refreshed_after_auth_error", [
-                                    new("offset", refreshedLink.StartRowOffset),
+                                    new("offset", refreshedResult.StartRowOffset),
                                     new("sanitized_url", sanitizedUrl)
                                 ]);
 
@@ -447,7 +459,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         if (contentLength.HasValue && contentLength.Value > 0)
                         {
                             activity?.AddEvent("cloudfetch.content_length", [
-                                new("offset", downloadResult.Link.StartRowOffset),
+                                new("offset", downloadResult.StartRowOffset),
                                 new("sanitized_url", sanitizedUrl),
                                 new("content_length_bytes", contentLength.Value),
                                 new("content_length_mb", contentLength.Value / 1024.0 / 1024.0)
@@ -463,7 +475,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Log the error and retry
                         activity?.AddException(ex, [
                             new("error.context", "cloudfetch.download_retry"),
-                            new("offset", downloadResult.Link.StartRowOffset),
+                            new("offset", downloadResult.StartRowOffset),
                             new("sanitized_url", SanitizeUrl(url)),
                             new("attempt", retry + 1),
                             new("max_retries", _maxRetries)
@@ -477,7 +489,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 {
                     stopwatch.Stop();
                     activity?.AddEvent("cloudfetch.download_failed_all_retries", [
-                        new("offset", downloadResult.Link.StartRowOffset),
+                        new("offset", downloadResult.StartRowOffset),
                         new("sanitized_url", sanitizedUrl),
                         new("max_retries", _maxRetries),
                         new("elapsed_time_ms", stopwatch.ElapsedMilliseconds)
@@ -508,7 +520,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         decompressStopwatch.Stop();
 
                         activity?.AddEvent("cloudfetch.decompression_complete", [
-                            new("offset", downloadResult.Link.StartRowOffset),
+                            new("offset", downloadResult.StartRowOffset),
                             new("sanitized_url", sanitizedUrl),
                             new("decompression_time_ms", decompressStopwatch.ElapsedMilliseconds),
                             new("compressed_size_bytes", actualSize),
@@ -525,7 +537,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         stopwatch.Stop();
                         activity?.AddException(ex, [
                             new("error.context", "cloudfetch.decompression"),
-                            new("offset", downloadResult.Link.StartRowOffset),
+                            new("offset", downloadResult.StartRowOffset),
                             new("sanitized_url", sanitizedUrl),
                             new("elapsed_time_ms", stopwatch.ElapsedMilliseconds)
                         ]);
@@ -544,7 +556,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 stopwatch.Stop();
                 double throughputMBps = (actualSize / 1024.0 / 1024.0) / (stopwatch.ElapsedMilliseconds / 1000.0);
                 activity?.AddEvent("cloudfetch.download_complete", [
-                    new("offset", downloadResult.Link.StartRowOffset),
+                    new("offset", downloadResult.StartRowOffset),
                     new("sanitized_url", sanitizedUrl),
                     new("actual_size_bytes", actualSize),
                     new("actual_size_kb", actualSize / 1024.0),

--- a/csharp/src/Reader/CloudFetch/CloudFetchResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchResultFetcher.cs
@@ -38,29 +38,24 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
     /// <summary>
     /// Fetches result chunks from the Thrift server and manages URL caching and refreshing.
     /// </summary>
-    internal class CloudFetchResultFetcher : ICloudFetchResultFetcher
+    internal class CloudFetchResultFetcher : BaseResultFetcher
     {
         private readonly IHiveServer2Statement _statement;
         private readonly IResponse _response;
         private readonly TFetchResultsResp? _initialResults;
-        private readonly ICloudFetchMemoryBufferManager _memoryManager;
-        private readonly BlockingCollection<IDownloadResult> _downloadQueue;
         private readonly SemaphoreSlim _fetchLock = new SemaphoreSlim(1, 1);
         private readonly ConcurrentDictionary<long, IDownloadResult> _urlsByOffset = new ConcurrentDictionary<long, IDownloadResult>();
         private readonly int _expirationBufferSeconds;
         private readonly IClock _clock;
         private long _startOffset;
-        private bool _hasMoreResults;
-        private bool _isCompleted;
-        private Task? _fetchTask;
-        private CancellationTokenSource? _cancellationTokenSource;
-        private Exception? _error;
         private long _batchSize;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchResultFetcher"/> class.
         /// </summary>
         /// <param name="statement">The HiveServer2 statement interface.</param>
+        /// <param name="response">The query response.</param>
+        /// <param name="initialResults">Initial results, if available.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
         /// <param name="downloadQueue">The queue to add download tasks to.</param>
         /// <param name="batchSize">The number of rows to fetch in each batch.</param>
@@ -75,89 +70,30 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             long batchSize,
             int expirationBufferSeconds = 60,
             IClock? clock = null)
+            : base(memoryManager, downloadQueue)
         {
             _statement = statement ?? throw new ArgumentNullException(nameof(statement));
             _response = response;
             _initialResults = initialResults;
-            _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
-            _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
             _batchSize = batchSize;
             _expirationBufferSeconds = expirationBufferSeconds;
             _clock = clock ?? new SystemClock();
-            _hasMoreResults = true;
-            _isCompleted = false;
         }
 
         /// <inheritdoc />
-        public bool HasMoreResults => _hasMoreResults;
-
-        /// <inheritdoc />
-        public bool IsCompleted => _isCompleted;
-
-        /// <inheritdoc />
-        public bool HasError => _error != null;
-
-        /// <inheritdoc />
-        public Exception? Error => _error;
-
-        /// <inheritdoc />
-        public async Task StartAsync(CancellationToken cancellationToken)
+        protected override void ResetState()
         {
-            if (_fetchTask != null)
-            {
-                throw new InvalidOperationException("Fetcher is already running.");
-            }
-
-            // Reset state
             _startOffset = 0;
-            _hasMoreResults = true;
-            _isCompleted = false;
-            _error = null;
             _urlsByOffset.Clear();
-
-            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _fetchTask = FetchResultsAsync(_cancellationTokenSource.Token);
-
-            // Wait for the fetch task to start
-            await Task.Yield();
         }
 
         /// <inheritdoc />
-        public async Task StopAsync()
-        {
-            if (_fetchTask == null)
-            {
-                return;
-            }
-
-            _cancellationTokenSource?.Cancel();
-
-            try
-            {
-                await _fetchTask.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected when cancellation is requested
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Error stopping fetcher: {ex.Message}");
-            }
-            finally
-            {
-                _cancellationTokenSource?.Dispose();
-                _cancellationTokenSource = null;
-                _fetchTask = null;
-            }
-        }
-        /// <inheritdoc />
-        public async Task<TSparkArrowResultLink?> GetUrlAsync(long offset, CancellationToken cancellationToken)
+        public override async Task<IDownloadResult?> GetDownloadResultAsync(long offset, CancellationToken cancellationToken)
         {
             // Check if we have a non-expired URL in the cache
             if (_urlsByOffset.TryGetValue(offset, out var cachedResult) && !cachedResult.IsExpiredOrExpiringSoon(_expirationBufferSeconds))
             {
-                return cachedResult.Link;
+                return cachedResult;
             }
 
             // Need to fetch or refresh the URL
@@ -192,11 +128,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                             new("url_length", refreshedLink.FileLink?.Length ?? 0)
                         ]);
 
-                        // Create a download result for the refreshed link
-                        var downloadResult = new DownloadResult(refreshedLink, _memoryManager);
+                        // Create a download result for the refreshed link using factory method
+                        var downloadResult = DownloadResult.FromThriftLink(refreshedLink, _memoryManager);
                         _urlsByOffset[offset] = downloadResult;
 
-                        return refreshedLink;
+                        return downloadResult;
                     }
                 }
 
@@ -210,12 +146,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         }
 
         /// <summary>
-        /// Gets all currently cached URLs.
+        /// Gets all currently cached download results.
         /// </summary>
-        /// <returns>A dictionary mapping offsets to their URL links.</returns>
-        public Dictionary<long, TSparkArrowResultLink> GetAllCachedUrls()
+        /// <returns>A dictionary mapping offsets to their download results.</returns>
+        public Dictionary<long, IDownloadResult> GetAllCachedResults()
         {
-            return _urlsByOffset.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Link);
+            return _urlsByOffset.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         /// <summary>
@@ -226,61 +162,38 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             _urlsByOffset.Clear();
         }
 
-        private async Task FetchResultsAsync(CancellationToken cancellationToken)
+        /// <inheritdoc />
+        protected override async Task FetchAllResultsAsync(CancellationToken cancellationToken)
         {
-            try
+            // Process direct results first, if available
+            if ((_statement.TryGetDirectResults(_response, out TSparkDirectResults? directResults)
+                && directResults!.ResultSet?.Results?.ResultLinks?.Count > 0)
+                || _initialResults?.Results?.ResultLinks?.Count > 0)
             {
-                // Process direct results first, if available
-                if ((_statement.TryGetDirectResults(_response, out TSparkDirectResults? directResults)
-                    && directResults!.ResultSet?.Results?.ResultLinks?.Count > 0)
-                    || _initialResults?.Results?.ResultLinks?.Count > 0)
-                {
-                    // Yield execution so the download queue doesn't get blocked before downloader is started
-                    await Task.Yield();
-                    ProcessDirectResultsAsync(cancellationToken);
-                }
-
-                // Continue fetching as needed
-                while (_hasMoreResults && !cancellationToken.IsCancellationRequested)
-                {
-                    try
-                    {
-                        // Fetch more results from the server
-                        await FetchNextResultBatchAsync(null, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                    {
-                        // Expected when cancellation is requested
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine($"Error fetching results: {ex.Message}");
-                        _error = ex;
-                        _hasMoreResults = false;
-                        throw;
-                    }
-                }
-
-                // Add the end of results guard to the queue
-                _downloadQueue.Add(EndOfResultsGuard.Instance, cancellationToken);
-                _isCompleted = true;
+                // Yield execution so the download queue doesn't get blocked before downloader is started
+                await Task.Yield();
+                ProcessDirectResultsAsync(cancellationToken);
             }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Unhandled error in fetcher: {ex.Message}");
-                _error = ex;
-                _hasMoreResults = false;
-                _isCompleted = true;
 
-                // Add the end of results guard to the queue even in case of error
+            // Continue fetching as needed
+            while (_hasMoreResults && !cancellationToken.IsCancellationRequested)
+            {
                 try
                 {
-                    _downloadQueue.TryAdd(EndOfResultsGuard.Instance, 0);
+                    // Fetch more results from the server
+                    await FetchNextResultBatchAsync(null, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // Ignore any errors when adding the guard in case of error
+                    // Expected when cancellation is requested
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error fetching results: {ex.Message}");
+                    _error = ex;
+                    _hasMoreResults = false;
+                    throw;
                 }
             }
         }
@@ -331,11 +244,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 // Process each link
                 foreach (var link in resultLinks)
                 {
-                    // Create download result
-                    var downloadResult = new DownloadResult(link, _memoryManager);
+                    // Create download result using factory method
+                    var downloadResult = DownloadResult.FromThriftLink(link, _memoryManager);
 
                     // Add to download queue and cache
-                    _downloadQueue.Add(downloadResult, cancellationToken);
+                    AddDownloadResult(downloadResult, cancellationToken);
                     _urlsByOffset[link.StartRowOffset] = downloadResult;
 
                     // Track the maximum offset for future fetches
@@ -379,11 +292,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             // Process each link
             foreach (var link in resultLinks)
             {
-                // Create download result
-                var downloadResult = new DownloadResult(link, _memoryManager);
+                // Create download result using factory method
+                var downloadResult = DownloadResult.FromThriftLink(link, _memoryManager);
 
                 // Add to download queue and cache
-                _downloadQueue.Add(downloadResult, cancellationToken);
+                AddDownloadResult(downloadResult, cancellationToken);
                 _urlsByOffset[link.StartRowOffset] = downloadResult;
 
                 // Track the maximum offset for future fetches

--- a/csharp/src/Reader/CloudFetch/DownloadResult.cs
+++ b/csharp/src/Reader/CloudFetch/DownloadResult.cs
@@ -22,6 +22,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Apache.Hive.Service.Rpc.Thrift;
@@ -38,22 +39,80 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         private Stream? _dataStream;
         private bool _isDisposed;
         private long _size;
+        private string _fileUrl;
+        private DateTime _expirationTime;
+        private IReadOnlyDictionary<string, string>? _httpHeaders;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DownloadResult"/> class.
         /// </summary>
-        /// <param name="link">The link information for this result.</param>
+        /// <param name="fileUrl">The URL for downloading the file.</param>
+        /// <param name="startRowOffset">The starting row offset for this result chunk.</param>
+        /// <param name="rowCount">The number of rows in this result chunk.</param>
+        /// <param name="byteCount">The size in bytes of this result chunk.</param>
+        /// <param name="expirationTime">The expiration time of the URL in UTC.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
-        public DownloadResult(TSparkArrowResultLink link, ICloudFetchMemoryBufferManager memoryManager)
+        /// <param name="httpHeaders">Optional HTTP headers for downloading the file.</param>
+        public DownloadResult(
+            string fileUrl,
+            long startRowOffset,
+            long rowCount,
+            long byteCount,
+            DateTime expirationTime,
+            ICloudFetchMemoryBufferManager memoryManager,
+            IReadOnlyDictionary<string, string>? httpHeaders = null)
         {
-            Link = link ?? throw new ArgumentNullException(nameof(link));
+            _fileUrl = fileUrl ?? throw new ArgumentNullException(nameof(fileUrl));
+            StartRowOffset = startRowOffset;
+            RowCount = rowCount;
+            ByteCount = byteCount;
+            _expirationTime = expirationTime;
             _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
+            _httpHeaders = httpHeaders;
             _downloadCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _size = link.BytesNum;
+            _size = byteCount;
+        }
+
+        /// <summary>
+        /// Creates a DownloadResult from a Thrift link for backward compatibility.
+        /// </summary>
+        /// <param name="link">The Thrift link information.</param>
+        /// <param name="memoryManager">The memory buffer manager.</param>
+        /// <returns>A new DownloadResult instance.</returns>
+        public static DownloadResult FromThriftLink(TSparkArrowResultLink link, ICloudFetchMemoryBufferManager memoryManager)
+        {
+            if (link == null) throw new ArgumentNullException(nameof(link));
+            if (memoryManager == null) throw new ArgumentNullException(nameof(memoryManager));
+
+            var expirationTime = DateTimeOffset.FromUnixTimeMilliseconds(link.ExpiryTime).UtcDateTime;
+
+            return new DownloadResult(
+                fileUrl: link.FileLink,
+                startRowOffset: link.StartRowOffset,
+                rowCount: link.RowCount,
+                byteCount: link.BytesNum,
+                expirationTime: expirationTime,
+                memoryManager: memoryManager,
+                httpHeaders: null);
         }
 
         /// <inheritdoc />
-        public TSparkArrowResultLink Link { get; private set; }
+        public string FileUrl => _fileUrl;
+
+        /// <inheritdoc />
+        public long StartRowOffset { get; }
+
+        /// <inheritdoc />
+        public long RowCount { get; }
+
+        /// <inheritdoc />
+        public long ByteCount { get; }
+
+        /// <inheritdoc />
+        public DateTime ExpirationTime => _expirationTime;
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, string>? HttpHeaders => _httpHeaders;
 
         /// <inheritdoc />
         public Stream DataStream
@@ -90,21 +149,22 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <returns>True if the URL is expired or about to expire, false otherwise.</returns>
         public bool IsExpiredOrExpiringSoon(int expirationBufferSeconds = 60)
         {
-            // Convert expiry time to DateTime
-            var expiryTime = DateTimeOffset.FromUnixTimeMilliseconds(Link.ExpiryTime).UtcDateTime;
-
             // Check if the URL is already expired or will expire soon
-            return DateTime.UtcNow.AddSeconds(expirationBufferSeconds) >= expiryTime;
+            return DateTime.UtcNow.AddSeconds(expirationBufferSeconds) >= _expirationTime;
         }
 
         /// <summary>
-        /// Updates this download result with a refreshed link.
+        /// Updates this download result with a refreshed URL and expiration time.
         /// </summary>
-        /// <param name="refreshedLink">The refreshed link information.</param>
-        public void UpdateWithRefreshedLink(TSparkArrowResultLink refreshedLink)
+        /// <param name="fileUrl">The refreshed file URL.</param>
+        /// <param name="expirationTime">The new expiration time.</param>
+        /// <param name="httpHeaders">Optional HTTP headers for the refreshed URL.</param>
+        public void UpdateWithRefreshedUrl(string fileUrl, DateTime expirationTime, IReadOnlyDictionary<string, string>? httpHeaders = null)
         {
             ThrowIfDisposed();
-            Link = refreshedLink ?? throw new ArgumentNullException(nameof(refreshedLink));
+            _fileUrl = fileUrl ?? throw new ArgumentNullException(nameof(fileUrl));
+            _expirationTime = expirationTime;
+            _httpHeaders = httpHeaders;
             RefreshAttempts++;
         }
 

--- a/csharp/src/Reader/CloudFetch/EndOfResultsGuard.cs
+++ b/csharp/src/Reader/CloudFetch/EndOfResultsGuard.cs
@@ -22,9 +22,9 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 {
@@ -46,7 +46,22 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         }
 
         /// <inheritdoc />
-        public TSparkArrowResultLink Link => throw new NotSupportedException("EndOfResultsGuard does not have a link.");
+        public string FileUrl => throw new NotSupportedException("EndOfResultsGuard does not have a file URL.");
+
+        /// <inheritdoc />
+        public long StartRowOffset => 0;
+
+        /// <inheritdoc />
+        public long RowCount => 0;
+
+        /// <inheritdoc />
+        public long ByteCount => 0;
+
+        /// <inheritdoc />
+        public DateTime ExpirationTime => DateTime.MinValue;
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, string>? HttpHeaders => null;
 
         /// <inheritdoc />
         public Stream DataStream => throw new NotSupportedException("EndOfResultsGuard does not have a data stream.");
@@ -70,7 +85,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         public void SetFailed(Exception exception) => throw new NotSupportedException("EndOfResultsGuard cannot fail.");
 
         /// <inheritdoc />
-        public void UpdateWithRefreshedLink(TSparkArrowResultLink refreshedLink) => throw new NotSupportedException("EndOfResultsGuard cannot be updated with a refreshed link.");
+        public void UpdateWithRefreshedUrl(string fileUrl, DateTime expirationTime, IReadOnlyDictionary<string, string>? httpHeaders = null) =>
+            throw new NotSupportedException("EndOfResultsGuard cannot be updated with a refreshed URL.");
 
         /// <inheritdoc />
         public bool IsExpiredOrExpiringSoon(int expirationBufferSeconds = 60) => false;

--- a/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
+++ b/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -60,16 +61,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                 .Returns(Task.CompletedTask);
 
             // Set up result fetcher defaults
-            _mockResultFetcher.Setup(f => f.GetUrlAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            _mockResultFetcher.Setup(f => f.GetDownloadResultAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((long offset, CancellationToken token) =>
                 {
-                    // Return a URL with the same offset
-                    return new TSparkArrowResultLink
+                    // Return a download result with the same offset
+                    var link = new TSparkArrowResultLink
                     {
                         StartRowOffset = offset,
                         FileLink = $"http://test.com/file{offset}",
+                        RowCount = 100,
+                        BytesNum = 1024,
                         ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds()
                     };
+                    return DownloadResult.FromThriftLink(link, _mockMemoryManager.Object);
                 });
         }
 
@@ -133,11 +137,13 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            string fileUrl = "http://test.com/file1";
+            DateTime expirationTime = DateTime.UtcNow.AddMinutes(30);
+
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(testContentBytes.Length);
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -221,11 +227,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            var fileUrl = "http://test.com/file1";
+            var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(1000); // Some arbitrary size
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -295,11 +302,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create test download results
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            var fileUrl = "http://test.com/file1";
+            var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -391,11 +399,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            var fileUrl = "http://test.com/file1";
+            var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -482,11 +491,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
             for (int i = 0; i < totalDownloads; i++)
             {
                 var mockDownloadResult = new Mock<IDownloadResult>();
-                var resultLink = new TSparkArrowResultLink {
-                    FileLink = $"http://test.com/file{i}",
-                    ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-                };
-                mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+                var fileUrl = $"http://test.com/file{i}";
+                var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+                mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+                mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+                mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+                mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
                 mockDownloadResult.Setup(r => r.Size).Returns(100);
                 mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
                 mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -550,7 +560,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
             // Arrange
             // Create a mock HTTP handler that returns a 403 error for the first request and success for the second
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
-            var requestCount = 0;
+            int requestCount = 0;
+            bool httpMockCalled = false;
 
             mockHttpMessageHandler
                 .Protected()
@@ -560,16 +571,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                     ItExpr.IsAny<CancellationToken>())
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, token) =>
                 {
+                    httpMockCalled = true;
                     await Task.Delay(1, token); // Small delay to simulate network
 
                     // First request fails with 403 Forbidden (expired URL)
                     if (requestCount == 0)
                     {
                         requestCount++;
+                        Console.WriteLine($"HTTP Mock: Returning 403 Forbidden for request #{requestCount-1}");
                         return new HttpResponseMessage(HttpStatusCode.Forbidden);
                     }
 
                     // Second request succeeds with the refreshed URL
+                    Console.WriteLine($"HTTP Mock: Returning 200 OK for request #{requestCount}");
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new StringContent("Test content")
@@ -580,25 +594,47 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                StartRowOffset = 0,
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds() // Set expiry in the past
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            string fileUrl = "http://test.com/file1";
+            DateTime expirationTime = DateTime.UtcNow.AddMinutes(-5); // Set expiry in the past
+
+            // Track refresh attempts
+            int refreshAttempts = 0;
+
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(() => refreshAttempts == 0 ? fileUrl : "http://test.com/file1-refreshed");
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
-            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
+            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(() => refreshAttempts);
             // Important: Set this to false so the initial URL refresh doesn't happen
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
 
+            // Setup UpdateWithRefreshedUrl to increment refresh attempts
+            mockDownloadResult.Setup(r => r.UpdateWithRefreshedUrl(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+                .Callback(() => refreshAttempts++);
+
+            // Setup SetCompleted to allow it to be called
+            mockDownloadResult.Setup(r => r.SetCompleted(It.IsAny<Stream>(), It.IsAny<long>()));
+
             // Setup URL refreshing - expect it to be called once during the HTTP 403 error handling
+            bool getDownloadResultCalled = false;
             var refreshedLink = new TSparkArrowResultLink {
                 StartRowOffset = 0,
                 FileLink = "http://test.com/file1-refreshed",
+                RowCount = 100,
+                BytesNum = 100,
                 ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set new expiry in the future
             };
-            _mockResultFetcher.Setup(f => f.GetUrlAsync(0, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(refreshedLink);
+            var refreshedResult = DownloadResult.FromThriftLink(refreshedLink, _mockMemoryManager.Object);
+            _mockResultFetcher.Setup(f => f.GetDownloadResultAsync(0, It.IsAny<CancellationToken>()))
+                .Callback(() => {
+                    getDownloadResultCalled = true;
+                    Console.WriteLine("GetDownloadResultAsync was called!");
+                })
+                .ReturnsAsync(refreshedResult);
 
             // Create the downloader and add the download to the queue
             var downloader = new CloudFetchDownloader(
@@ -617,18 +653,29 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
             await downloader.StartAsync(CancellationToken.None);
             _downloadQueue.Add(mockDownloadResult.Object);
 
-            // Wait for the download to be processed
-            await Task.Delay(200);
-
             // Add the end of results guard to complete the downloader
             _downloadQueue.Add(EndOfResultsGuard.Instance);
 
-            // Assert
-            // Verify that GetUrlAsync was called exactly once to refresh the URL
-            _mockResultFetcher.Verify(f => f.GetUrlAsync(0, It.IsAny<CancellationToken>()), Times.Once);
+            // Wait for the download to actually complete
+            var result = await downloader.GetNextDownloadedFileAsync(CancellationToken.None);
 
-            // Verify that UpdateWithRefreshedLink was called with the refreshed link
-            mockDownloadResult.Verify(r => r.UpdateWithRefreshedLink(refreshedLink), Times.Once);
+            // Debug output
+            Console.WriteLine($"HTTP Mock Called: {httpMockCalled}");
+            Console.WriteLine($"GetDownloadResultAsync Called: {getDownloadResultCalled}");
+            Console.WriteLine($"Request Count: {requestCount}");
+            Console.WriteLine($"Refresh Attempts: {refreshAttempts}");
+
+            // Assert
+            Assert.Same(mockDownloadResult.Object, result);
+
+            // Verify that GetDownloadResultAsync was called exactly once to refresh the URL
+            _mockResultFetcher.Verify(f => f.GetDownloadResultAsync(0, It.IsAny<CancellationToken>()), Times.Once);
+
+            // Verify that UpdateWithRefreshedUrl was called with the refreshed URL
+            mockDownloadResult.Verify(r => r.UpdateWithRefreshedUrl(
+                refreshedResult.FileUrl,
+                refreshedResult.ExpirationTime,
+                refreshedResult.HttpHeaders), Times.Once);
 
             // Cleanup
             await downloader.StopAsync();


### PR DESCRIPTION
Make the CloudFetch pipeline protocol-agnostic to support both Thrift and REST API implementations, enabling code reuse and easier addition of new protocols in the future.

Changes:
- Created BaseResultFetcher abstract class extracting common fetching logic
  - Background task management, error handling, queue management
  - Template method pattern with FetchAllResultsAsync() for protocol-specific logic
  - Reduces code duplication by ~175 lines across implementations

- Refactored CloudFetchResultFetcher to extend BaseResultFetcher
  - Reduced from 401 to 314 lines (22% reduction)
  - Kept Thrift-specific logic: URL caching, expiration, refresh
  - Removed duplicate background task and error handling code

- Made IDownloadResult protocol-agnostic
  - Replaced TSparkArrowResultLink with generic properties
  - Added FileUrl, StartRowOffset, RowCount, ByteCount, ExpirationTime, HttpHeaders
  - DownloadResult.FromThriftLink() factory method for backward compatibility

- Enhanced CloudFetchDownloader to support custom HTTP headers
  - Respects IDownloadResult.HttpHeaders property
  - Enables REST API authentication without code changes

Benefits:
- Enables REST API (Statement Execution API) to reuse CloudFetch pipeline
- No behavior changes to existing Thrift implementation
- Better separation of concerns and testability
