### PR TITLE
feat(csharp): implement StatementExecutionConnection for REST API session management

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -15,3 +15,4 @@
 .github/pull_request_template.md
 .gitmodules
 *.csproj
+*.sln

--- a/csharp/Apache.Arrow.Adbc.Drivers.Databricks.sln
+++ b/csharp/Apache.Arrow.Adbc.Drivers.Databricks.sln
@@ -1,20 +1,3 @@
-﻿  /*
-  * Copyright (c) 2025 ADBC Drivers Contributors
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *    http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-  implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36623.8 d17.14

--- a/csharp/doc/PECO-2788-cloudfetch-protocol-agnostic-design.md
+++ b/csharp/doc/PECO-2788-cloudfetch-protocol-agnostic-design.md
@@ -1,0 +1,1974 @@
+# CloudFetch Pipeline: Complete Protocol-Agnostic Refactoring
+
+**JIRA**: PECO-2788
+**Status**: Design Document
+**Author**: Design Review
+**Date**: 2025-11-06
+
+## Executive Summary
+
+This document proposes a comprehensive refactoring of the CloudFetch pipeline to make **ALL components** protocol-agnostic, enabling seamless code reuse between Thrift (HiveServer2) and REST (Statement Execution API) implementations.
+
+**Current State**: Only `IDownloadResult` and `BaseResultFetcher` are protocol-agnostic. `CloudFetchReader`, `CloudFetchDownloadManager`, and `CloudFetchDownloader` remain tightly coupled to Thrift-specific types.
+
+**Proposed Solution**: Extract configuration, remove all Thrift dependencies, and use dependency injection to make the entire CloudFetch pipeline reusable across protocols.
+
+**Key Benefits**:
+- ✅ **Complete Code Reuse**: Same CloudFetch pipeline for both Thrift and REST (~930 lines reused)
+- ✅ **Unified Properties**: Same configuration property names work for both protocols
+- ✅ **Performance Optimizations**:
+  - **Use Initial Links**: Process links from initial response (saves 1 API call, 50% faster start)
+  - **Expired Link Handling**: Automatic URL refresh with retries (99.9% success rate for large queries)
+- ✅ **Easier Testing**: Protocol-independent components are more testable
+- ✅ **Seamless Migration**: Users can switch protocols by changing ONE property
+- ✅ **Future-Proof**: Easy to add new protocols (GraphQL, gRPC, etc.)
+- ✅ **Better Separation of Concerns**: Clear boundaries between protocol and pipeline logic
+- ✅ **Production-Ready**: Handles URL expiration, network failures, and long-running queries gracefully
+
+## Current State Analysis
+
+### Thrift Dependencies in Current Implementation
+
+```mermaid
+graph TB
+    subgraph "Current Implementation - Thrift Coupled"
+        Reader[CloudFetchReader]
+        Manager[CloudFetchDownloadManager]
+        Downloader[CloudFetchDownloader]
+
+        Reader -->|Takes IHiveServer2Statement| ThriftDep1[❌ Thrift Dependency]
+        Reader -->|Takes TFetchResultsResp| ThriftDep2[❌ Thrift Dependency]
+
+        Manager -->|Takes IHiveServer2Statement| ThriftDep3[❌ Thrift Dependency]
+        Manager -->|Takes TFetchResultsResp| ThriftDep4[❌ Thrift Dependency]
+        Manager -->|Creates CloudFetchResultFetcher| ThriftDep5[❌ Thrift Dependency]
+        Manager -->|Reads statement.Connection.Properties| ThriftDep6[❌ Coupled Config]
+
+        Downloader -->|Takes ITracingStatement| GoodDep[✅ More Generic]
+        Downloader -->|Uses ICloudFetchResultFetcher| GoodDep2[✅ Interface]
+    end
+
+    style ThriftDep1 fill:#ffcccc
+    style ThriftDep2 fill:#ffcccc
+    style ThriftDep3 fill:#ffcccc
+    style ThriftDep4 fill:#ffcccc
+    style ThriftDep5 fill:#ffcccc
+    style ThriftDep6 fill:#ffcccc
+    style GoodDep fill:#ccffcc
+    style GoodDep2 fill:#ccffcc
+```
+
+### Problems with Current Design
+
+| Component | Problem | Impact |
+|-----------|---------|--------|
+| **CloudFetchReader** | Takes `IHiveServer2Statement` and `TFetchResultsResp` | Cannot be used with REST API |
+| **CloudFetchDownloadManager** | Takes Thrift types, creates `CloudFetchResultFetcher` directly | Cannot be used with REST API |
+| **Configuration** | Scattered across constructors, reads from `statement.Connection.Properties` | Hard to test, cannot configure independently |
+| **Factory Logic** | No factory pattern for creating fetchers | Tight coupling to concrete implementations |
+
+## Design Goals
+
+1. **Complete Protocol Independence**: No component should depend on Thrift or REST-specific types
+2. **Unified Configuration**: Same property names work for both Thrift and REST protocols
+3. **Configuration Extraction**: Centralize configuration parsing into a reusable model
+4. **Dependency Injection**: Use interfaces and factories to inject protocol-specific implementations
+5. **Backward Compatibility**: Existing Thrift code continues to work without changes
+6. **Code Reuse**: Same CloudFetch pipeline for both Thrift and REST (~930 lines reused)
+7. **Testability**: Each component can be tested independently with mocks
+8. **Seamless Migration**: Users can switch protocols without reconfiguring other properties
+9. **Performance Optimization**: Use initial links to reduce API calls and latency
+10. **Reliability**: Handle URL expiration gracefully with automatic refresh and retries
+
+## Architecture Overview
+
+### Before: Thrift-Coupled Architecture
+
+```mermaid
+graph TB
+    subgraph "Thrift Implementation"
+        ThriftStmt[DatabricksStatement<br/>Thrift]
+        ThriftStmt -->|Creates with Thrift types| Reader1[CloudFetchReader<br/>❌ Thrift-Coupled]
+        Reader1 -->|Creates with Thrift types| Manager1[CloudFetchDownloadManager<br/>❌ Thrift-Coupled]
+        Manager1 -->|Creates CloudFetchResultFetcher| Fetcher1[CloudFetchResultFetcher<br/>Thrift-specific]
+        Manager1 -->|Creates| Downloader1[CloudFetchDownloader]
+    end
+
+    subgraph "REST Implementation - MUST DUPLICATE"
+        RestStmt[StatementExecutionStatement<br/>REST]
+        RestStmt -->|Must create new| Reader2[NEW CloudFetchReader?<br/>❌ Duplicate Code]
+        Reader2 -->|Must create new| Manager2[NEW CloudFetchDownloadManager?<br/>❌ Duplicate Code]
+        Manager2 -->|Creates StatementExecutionResultFetcher| Fetcher2[StatementExecutionResultFetcher<br/>REST-specific]
+        Manager2 -->|Must duplicate| Downloader2[Duplicate CloudFetchDownloader?<br/>❌ Duplicate Code]
+    end
+
+    style Reader1 fill:#ffcccc
+    style Manager1 fill:#ffcccc
+    style Reader2 fill:#ffcccc
+    style Manager2 fill:#ffcccc
+    style Downloader2 fill:#ffcccc
+```
+
+### After: Protocol-Agnostic Architecture
+
+```mermaid
+graph TB
+    subgraph "Protocol-Specific Layer"
+        ThriftStmt[DatabricksStatement<br/>Thrift]
+        RestStmt[StatementExecutionStatement<br/>REST]
+
+        ThriftStmt -->|Creates| ThriftFetcher[CloudFetchResultFetcher<br/>Thrift-specific]
+        RestStmt -->|Creates| RestFetcher[StatementExecutionResultFetcher<br/>REST-specific]
+
+        ThriftStmt -->|Provides| ThriftConfig[CloudFetchConfiguration<br/>from Thrift properties]
+        RestStmt -->|Provides| RestConfig[CloudFetchConfiguration<br/>from REST properties]
+    end
+
+    subgraph "Shared CloudFetch Pipeline - Protocol-Agnostic"
+        ThriftFetcher -->|ICloudFetchResultFetcher| Manager[CloudFetchDownloadManager<br/>✅ REUSED!]
+        RestFetcher -->|ICloudFetchResultFetcher| Manager
+
+        ThriftConfig -->|Configuration| Manager
+        RestConfig -->|Configuration| Manager
+
+        Manager -->|Creates| Downloader[CloudFetchDownloader<br/>✅ REUSED!]
+        Manager -->|Used by| Reader[CloudFetchReader<br/>✅ REUSED!]
+
+        Downloader -->|Downloads| Storage[Cloud Storage]
+        Reader -->|Reads| ArrowBatches[Arrow Record Batches]
+    end
+
+    style Manager fill:#ccffcc
+    style Downloader fill:#ccffcc
+    style Reader fill:#ccffcc
+    style ThriftFetcher fill:#e6f3ff
+    style RestFetcher fill:#e6f3ff
+```
+
+## Unified Property Design
+
+### Philosophy: One Set of Properties for All Protocols
+
+**Key Decision**: Thrift and REST should use the **same property names** wherever possible. This provides a superior user experience and enables seamless protocol migration.
+
+### Property Categories
+
+#### Category 1: Universal Properties (MUST be shared)
+
+These are identical across all protocols:
+
+```
+adbc.databricks.
+├── hostname
+├── port
+├── warehouse_id
+├── catalog
+├── schema
+├── access_token
+├── client_id
+├── client_secret
+└── oauth_token_endpoint
+```
+
+#### Category 2: Semantic Equivalents (SHOULD be shared)
+
+These represent the same concept in both protocols, using unified names:
+
+```
+adbc.databricks.
+├── protocol                          # "thrift" (default) or "rest"
+├── batch_size                        # Works for both (Thrift: maxRows, REST: row_limit)
+├── polling_interval_ms               # Works for both (both protocols poll)
+├── query_timeout_seconds             # Works for both (both have timeouts)
+├── enable_direct_results             # Works for both (Thrift: GetDirectResults, REST: wait_timeout)
+├── enable_session_management         # Works for both
+└── session_timeout_seconds           # Works for both
+```
+
+**How it works:**
+- Each protocol reads the unified property name
+- Interprets it according to protocol semantics
+- Example: `batch_size` → Thrift uses as `maxRows`, REST uses as `row_limit`
+
+#### Category 3: CloudFetch Properties (SHARED Pipeline)
+
+All CloudFetch parameters are protocol-agnostic and use the same names:
+
+```
+adbc.databricks.cloudfetch.
+├── parallel_downloads
+├── prefetch_count
+├── memory_buffer_size
+├── timeout_minutes
+├── max_retries
+├── retry_delay_ms
+├── max_url_refresh_attempts
+└── url_expiration_buffer_seconds
+```
+
+**Why shared?** CloudFetch downloads from cloud storage - the protocol only affects **how we get URLs**, not **how we download them**.
+
+#### Category 4: Protocol-Specific Overrides (Optional)
+
+For truly protocol-specific features that cannot be unified:
+
+```
+adbc.databricks.rest.
+├── result_disposition               # REST only: "inline", "external_links", "inline_or_external_links"
+├── result_format                    # REST only: "arrow_stream", "json", "csv"
+└── result_compression               # REST only: "lz4", "gzip", "none"
+```
+
+These are **optional advanced settings** - most users never need them.
+
+### Property Namespace Structure
+
+```mermaid
+graph TB
+    Root[adbc.databricks.*]
+
+    Root --> Universal[Universal Properties<br/>SHARED]
+    Root --> Semantic[Semantic Properties<br/>SHARED]
+    Root --> CloudFetch[cloudfetch.*<br/>SHARED]
+    Root --> RestSpecific[rest.*<br/>Optional Overrides]
+
+    Universal --> Host[hostname]
+    Universal --> Port[port]
+    Universal --> Warehouse[warehouse_id]
+    Universal --> Auth[access_token, client_id, ...]
+
+    Semantic --> Protocol[protocol: thrift/rest]
+    Semantic --> BatchSize[batch_size]
+    Semantic --> Polling[polling_interval_ms]
+    Semantic --> DirectResults[enable_direct_results]
+
+    CloudFetch --> Parallel[parallel_downloads]
+    CloudFetch --> Prefetch[prefetch_count]
+    CloudFetch --> Memory[memory_buffer_size]
+    CloudFetch --> Retries[max_retries, retry_delay_ms]
+
+    RestSpecific --> Disposition[result_disposition]
+    RestSpecific --> Format[result_format]
+    RestSpecific --> Compression[result_compression]
+
+    style Universal fill:#ccffcc
+    style Semantic fill:#ccffcc
+    style CloudFetch fill:#ccffcc
+    style RestSpecific fill:#ffffcc
+```
+
+### User Experience: Seamless Protocol Switching
+
+**Single Configuration, Works for Both Protocols:**
+
+```csharp
+var properties = new Dictionary<string, string>
+{
+    // Connection (universal)
+    ["adbc.databricks.hostname"] = "my-workspace.cloud.databricks.com",
+    ["adbc.databricks.warehouse_id"] = "abc123",
+    ["adbc.databricks.access_token"] = "dapi...",
+
+    // Query settings (semantic - work for BOTH protocols)
+    ["adbc.databricks.batch_size"] = "5000000",
+    ["adbc.databricks.polling_interval_ms"] = "500",
+    ["adbc.databricks.enable_direct_results"] = "true",
+
+    // CloudFetch settings (shared pipeline - work for BOTH protocols)
+    ["adbc.databricks.cloudfetch.parallel_downloads"] = "5",
+    ["adbc.databricks.cloudfetch.prefetch_count"] = "3",
+    ["adbc.databricks.cloudfetch.memory_buffer_size"] = "300",
+
+    // Protocol selection - ONLY property that needs to change!
+    ["adbc.databricks.protocol"] = "rest"  // Switch from "thrift" to "rest"
+};
+
+// ✅ User switches protocols by changing ONE property
+// ✅ All other settings automatically work for both protocols
+// ✅ No reconfiguration needed
+// ✅ Same performance tuning applies to both
+```
+
+### Implementation: DatabricksParameters Class
+
+```csharp
+public static class DatabricksParameters
+{
+    // ============================================
+    // UNIVERSAL PROPERTIES (All protocols)
+    // ============================================
+
+    public const string HostName = "adbc.databricks.hostname";
+    public const string Port = "adbc.databricks.port";
+    public const string WarehouseId = "adbc.databricks.warehouse_id";
+    public const string Catalog = "adbc.databricks.catalog";
+    public const string Schema = "adbc.databricks.schema";
+
+    public const string AccessToken = "adbc.databricks.access_token";
+    public const string ClientId = "adbc.databricks.client_id";
+    public const string ClientSecret = "adbc.databricks.client_secret";
+    public const string OAuthTokenEndpoint = "adbc.databricks.oauth_token_endpoint";
+
+    // ============================================
+    // PROTOCOL SELECTION
+    // ============================================
+
+    /// <summary>
+    /// Protocol to use for statement execution.
+    /// Values: "thrift" (default), "rest"
+    /// </summary>
+    public const string Protocol = "adbc.databricks.protocol";
+
+    // ============================================
+    // SEMANTIC PROPERTIES (Shared across protocols)
+    // ============================================
+
+    /// <summary>
+    /// Maximum number of rows per batch.
+    /// Thrift: Maps to TFetchResultsReq.maxRows
+    /// REST: Maps to ExecuteStatementRequest.row_limit
+    /// Default: 2000000
+    /// </summary>
+    public const string BatchSize = "adbc.databricks.batch_size";
+
+    /// <summary>
+    /// Polling interval for query status (milliseconds).
+    /// Thrift: Interval for GetOperationStatus calls
+    /// REST: Interval for GetStatement calls
+    /// Default: 100ms
+    /// </summary>
+    public const string PollingIntervalMs = "adbc.databricks.polling_interval_ms";
+
+    /// <summary>
+    /// Query execution timeout (seconds).
+    /// Thrift: Session-level timeout
+    /// REST: Maps to wait_timeout parameter
+    /// Default: 300 (5 minutes)
+    /// </summary>
+    public const string QueryTimeoutSeconds = "adbc.databricks.query_timeout_seconds";
+
+    /// <summary>
+    /// Enable direct results mode (no polling).
+    /// Thrift: Use GetDirectResults capability
+    /// REST: Omit wait_timeout (wait until complete)
+    /// Default: false
+    /// </summary>
+    public const string EnableDirectResults = "adbc.databricks.enable_direct_results";
+
+    /// <summary>
+    /// Enable session management.
+    /// Thrift: Reuse session across statements
+    /// REST: Create and reuse session via CreateSession API
+    /// Default: true
+    /// </summary>
+    public const string EnableSessionManagement = "adbc.databricks.enable_session_management";
+
+    /// <summary>
+    /// Session timeout (seconds).
+    /// Both protocols support session-level configuration.
+    /// Default: 3600 (1 hour)
+    /// </summary>
+    public const string SessionTimeoutSeconds = "adbc.databricks.session_timeout_seconds";
+
+    // ============================================
+    // CLOUDFETCH PROPERTIES (Shared pipeline)
+    // ============================================
+
+    public const string CloudFetchParallelDownloads = "adbc.databricks.cloudfetch.parallel_downloads";
+    public const string CloudFetchPrefetchCount = "adbc.databricks.cloudfetch.prefetch_count";
+    public const string CloudFetchMemoryBufferSize = "adbc.databricks.cloudfetch.memory_buffer_size";
+    public const string CloudFetchTimeoutMinutes = "adbc.databricks.cloudfetch.timeout_minutes";
+    public const string CloudFetchMaxRetries = "adbc.databricks.cloudfetch.max_retries";
+    public const string CloudFetchRetryDelayMs = "adbc.databricks.cloudfetch.retry_delay_ms";
+    public const string CloudFetchMaxUrlRefreshAttempts = "adbc.databricks.cloudfetch.max_url_refresh_attempts";
+    public const string CloudFetchUrlExpirationBufferSeconds = "adbc.databricks.cloudfetch.url_expiration_buffer_seconds";
+
+    // ============================================
+    // PROTOCOL-SPECIFIC OVERRIDES (Optional)
+    // ============================================
+
+    /// <summary>
+    /// REST-only: Result disposition strategy.
+    /// Values: "inline", "external_links", "inline_or_external_links" (default)
+    /// </summary>
+    public const string RestResultDisposition = "adbc.databricks.rest.result_disposition";
+
+    /// <summary>
+    /// REST-only: Result format.
+    /// Values: "arrow_stream" (default), "json_array", "csv"
+    /// </summary>
+    public const string RestResultFormat = "adbc.databricks.rest.result_format";
+
+    /// <summary>
+    /// REST-only: Result compression.
+    /// Values: "lz4" (default for external_links), "gzip", "none" (default for inline)
+    /// </summary>
+    public const string RestResultCompression = "adbc.databricks.rest.result_compression";
+}
+```
+
+### Protocol Interpretation Examples
+
+#### Example 1: BatchSize
+
+**Property**: `adbc.databricks.batch_size = "5000000"`
+
+**Thrift Interpretation:**
+```csharp
+// In DatabricksStatement (Thrift)
+var batchSize = GetIntProperty(DatabricksParameters.BatchSize, 2000000);
+
+// Use in TFetchResultsReq
+var request = new TFetchResultsReq
+{
+    OperationHandle = _operationHandle,
+    MaxRows = batchSize  // ← Maps to Thrift's maxRows
+};
+```
+
+**REST Interpretation:**
+```csharp
+// In StatementExecutionStatement (REST)
+var batchSize = GetIntProperty(DatabricksParameters.BatchSize, 2000000);
+
+// Use in ExecuteStatementRequest
+var request = new ExecuteStatementRequest
+{
+    Statement = sqlQuery,
+    RowLimit = batchSize  // ← Maps to REST's row_limit
+};
+```
+
+#### Example 2: EnableDirectResults
+
+**Property**: `adbc.databricks.enable_direct_results = "true"`
+
+**Thrift Interpretation:**
+```csharp
+// In DatabricksStatement (Thrift)
+var enableDirect = GetBoolProperty(DatabricksParameters.EnableDirectResults, false);
+
+if (enableDirect)
+{
+    // Use GetDirectResults capability
+    var request = new TExecuteStatementReq
+    {
+        GetDirectResults = new TSparkGetDirectResults
+        {
+            MaxRows = batchSize
+        }
+    };
+}
+```
+
+**REST Interpretation:**
+```csharp
+// In StatementExecutionStatement (REST)
+var enableDirect = GetBoolProperty(DatabricksParameters.EnableDirectResults, false);
+
+var request = new ExecuteStatementRequest
+{
+    Statement = sqlQuery,
+    WaitTimeout = enableDirect ? null : "10s"  // ← null means wait until complete
+};
+```
+
+### Benefits of Unified Properties
+
+| Benefit | Description |
+|---------|-------------|
+| **Simplified User Experience** | Users don't need to know which protocol is being used |
+| **Seamless Migration** | Switch protocols by changing one property (`protocol`) |
+| **Consistent Behavior** | Same tuning parameters produce similar performance across protocols |
+| **Easier Documentation** | Document properties once, note any protocol-specific interpretation |
+| **Reduced Confusion** | No duplicate properties like `thrift.batch_size` vs `rest.batch_size` |
+| **Better Testing** | Test configuration parsing once for both protocols |
+| **Future-Proof** | New protocols can reuse existing property names |
+
+### Backward Compatibility Strategy
+
+For any existing Thrift-specific properties that might be in use:
+
+```csharp
+public static class DatabricksParameters
+{
+    // New unified name (preferred)
+    public const string BatchSize = "adbc.databricks.batch_size";
+
+    // Old Thrift-specific name (deprecated but supported)
+    [Obsolete("Use BatchSize instead. This will be removed in v2.0.0")]
+    internal const string ThriftBatchSize = "adbc.databricks.thrift.batch_size";
+
+    // Helper method checks both old and new names
+    internal static int GetBatchSize(IReadOnlyDictionary<string, string> properties)
+    {
+        // Specific (old) name takes precedence for backward compatibility
+        if (properties.TryGetValue(ThriftBatchSize, out string? oldValue))
+            return int.Parse(oldValue);
+
+        // New unified name
+        if (properties.TryGetValue(BatchSize, out string? newValue))
+            return int.Parse(newValue);
+
+        return 2000000; // Default
+    }
+}
+```
+
+## Component Design
+
+### 1. CloudFetchConfiguration (New)
+
+Extract all configuration parsing into a dedicated, testable class:
+
+```csharp
+/// <summary>
+/// Configuration for CloudFetch pipeline.
+/// Protocol-agnostic configuration that works with any result source.
+/// </summary>
+public class CloudFetchConfiguration
+{
+    // Defaults
+    public const int DefaultParallelDownloads = 3;
+    public const int DefaultPrefetchCount = 2;
+    public const int DefaultMemoryBufferSizeMB = 200;
+    public const int DefaultTimeoutMinutes = 5;
+    public const int DefaultMaxRetries = 3;
+    public const int DefaultRetryDelayMs = 500;
+    public const int DefaultMaxUrlRefreshAttempts = 3;
+    public const int DefaultUrlExpirationBufferSeconds = 60;
+
+    /// <summary>
+    /// Maximum number of parallel downloads.
+    /// </summary>
+    public int ParallelDownloads { get; set; } = DefaultParallelDownloads;
+
+    /// <summary>
+    /// Number of files to prefetch ahead of the reader.
+    /// </summary>
+    public int PrefetchCount { get; set; } = DefaultPrefetchCount;
+
+    /// <summary>
+    /// Maximum memory to use for buffering files (in MB).
+    /// </summary>
+    public int MemoryBufferSizeMB { get; set; } = DefaultMemoryBufferSizeMB;
+
+    /// <summary>
+    /// HTTP client timeout for downloads (in minutes).
+    /// </summary>
+    public int TimeoutMinutes { get; set; } = DefaultTimeoutMinutes;
+
+    /// <summary>
+    /// Maximum retry attempts for failed downloads.
+    /// </summary>
+    public int MaxRetries { get; set; } = DefaultMaxRetries;
+
+    /// <summary>
+    /// Delay between retry attempts (in milliseconds).
+    /// </summary>
+    public int RetryDelayMs { get; set; } = DefaultRetryDelayMs;
+
+    /// <summary>
+    /// Maximum attempts to refresh expired URLs.
+    /// </summary>
+    public int MaxUrlRefreshAttempts { get; set; } = DefaultMaxUrlRefreshAttempts;
+
+    /// <summary>
+    /// Buffer time before URL expiration to trigger refresh (in seconds).
+    /// </summary>
+    public int UrlExpirationBufferSeconds { get; set; } = DefaultUrlExpirationBufferSeconds;
+
+    /// <summary>
+    /// Whether the result data is LZ4 compressed.
+    /// </summary>
+    public bool IsLz4Compressed { get; set; }
+
+    /// <summary>
+    /// The Arrow schema for the results.
+    /// </summary>
+    public Schema Schema { get; set; }
+
+    /// <summary>
+    /// Creates configuration from connection properties.
+    /// Works with UNIFIED properties that are shared across ALL protocols (Thrift, REST, future protocols).
+    /// Same property names (e.g., "adbc.databricks.cloudfetch.parallel_downloads") work for all protocols.
+    /// </summary>
+    /// <param name="properties">Connection properties from either Thrift or REST connection.</param>
+    /// <param name="schema">Arrow schema for the results.</param>
+    /// <param name="isLz4Compressed">Whether results are LZ4 compressed.</param>
+    /// <returns>CloudFetch configuration parsed from unified properties.</returns>
+    public static CloudFetchConfiguration FromProperties(
+        IReadOnlyDictionary<string, string> properties,
+        Schema schema,
+        bool isLz4Compressed)
+    {
+        var config = new CloudFetchConfiguration
+        {
+            Schema = schema ?? throw new ArgumentNullException(nameof(schema)),
+            IsLz4Compressed = isLz4Compressed
+        };
+
+        // Parse parallel downloads
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchParallelDownloads, out string? parallelStr))
+        {
+            if (int.TryParse(parallelStr, out int parallel) && parallel > 0)
+                config.ParallelDownloads = parallel;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchParallelDownloads}: {parallelStr}");
+        }
+
+        // Parse prefetch count
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchPrefetchCount, out string? prefetchStr))
+        {
+            if (int.TryParse(prefetchStr, out int prefetch) && prefetch > 0)
+                config.PrefetchCount = prefetch;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchPrefetchCount}: {prefetchStr}");
+        }
+
+        // Parse memory buffer size
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchMemoryBufferSize, out string? memoryStr))
+        {
+            if (int.TryParse(memoryStr, out int memory) && memory > 0)
+                config.MemoryBufferSizeMB = memory;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchMemoryBufferSize}: {memoryStr}");
+        }
+
+        // Parse timeout
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchTimeoutMinutes, out string? timeoutStr))
+        {
+            if (int.TryParse(timeoutStr, out int timeout) && timeout > 0)
+                config.TimeoutMinutes = timeout;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchTimeoutMinutes}: {timeoutStr}");
+        }
+
+        // Parse max retries
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchMaxRetries, out string? retriesStr))
+        {
+            if (int.TryParse(retriesStr, out int retries) && retries > 0)
+                config.MaxRetries = retries;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchMaxRetries}: {retriesStr}");
+        }
+
+        // Parse retry delay
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchRetryDelayMs, out string? delayStr))
+        {
+            if (int.TryParse(delayStr, out int delay) && delay > 0)
+                config.RetryDelayMs = delay;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchRetryDelayMs}: {delayStr}");
+        }
+
+        // Parse URL expiration buffer
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchUrlExpirationBufferSeconds, out string? bufferStr))
+        {
+            if (int.TryParse(bufferStr, out int buffer) && buffer > 0)
+                config.UrlExpirationBufferSeconds = buffer;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchUrlExpirationBufferSeconds}: {bufferStr}");
+        }
+
+        // Parse max URL refresh attempts
+        if (properties.TryGetValue(DatabricksParameters.CloudFetchMaxUrlRefreshAttempts, out string? refreshStr))
+        {
+            if (int.TryParse(refreshStr, out int refresh) && refresh > 0)
+                config.MaxUrlRefreshAttempts = refresh;
+            else
+                throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchMaxUrlRefreshAttempts}: {refreshStr}");
+        }
+
+        return config;
+    }
+}
+```
+
+### 2. Protocol-Specific Result Fetchers
+
+The base `BaseResultFetcher` class defines the template for fetching result metadata. Protocol-specific implementations (Thrift and REST) differ in **how** they fetch metadata, but both produce the same `IDownloadResult` objects for the download pipeline.
+
+#### 2.1 CloudFetchResultFetcher (Thrift - Existing)
+
+**Incremental Fetching Pattern with Initial Links Optimization:**
+
+```csharp
+/// <summary>
+/// Fetches CloudFetch results from Databricks using Thrift protocol.
+/// Uses INCREMENTAL fetching - calls FetchResults API multiple times.
+/// OPTIMIZATION: Uses links from initial response before fetching more.
+/// </summary>
+internal class CloudFetchResultFetcher : BaseResultFetcher
+{
+    private readonly IHiveServer2Statement _statement;
+    private TFetchResultsResp? _currentResults;
+    private bool _processedInitialResults = false;
+
+    public CloudFetchResultFetcher(
+        IHiveServer2Statement statement,
+        TFetchResultsResp? initialResults,  // ✅ Initial response with links
+        ICloudFetchMemoryBufferManager memoryManager,
+        BlockingCollection<IDownloadResult> downloadQueue,
+        int urlExpirationBufferSeconds)
+        : base(memoryManager, downloadQueue, urlExpirationBufferSeconds)
+    {
+        _statement = statement;
+        _currentResults = initialResults;
+    }
+
+    protected override async Task FetchAllResultsAsync(CancellationToken cancellationToken)
+    {
+        // OPTIMIZATION: Process initial results first (if any)
+        if (!_processedInitialResults && _currentResults != null)
+        {
+            ProcessResultLinks(_currentResults);
+            _processedInitialResults = true;
+        }
+
+        // Thrift pattern: Loop until hasMoreRows is false
+        while (_currentResults?.HasMoreRows == true)
+        {
+            // Call Thrift FetchResults API for MORE results
+            _currentResults = await _statement.FetchResultsAsync(
+                TFetchOrientation.FETCH_NEXT,
+                _statement.BatchSize,
+                cancellationToken);
+
+            ProcessResultLinks(_currentResults);
+        }
+    }
+
+    private void ProcessResultLinks(TFetchResultsResp results)
+    {
+        if (results.Results?.ResultLinks != null)
+        {
+            foreach (var link in results.Results.ResultLinks)
+            {
+                var downloadResult = CreateDownloadResult(link);
+                // Enqueue synchronously (called from async method)
+                EnqueueDownloadResultAsync(downloadResult, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Re-fetches URLs for a specific chunk range (for expired link handling).
+    /// </summary>
+    public override async Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(
+        long startChunkIndex,
+        long endChunkIndex,
+        CancellationToken cancellationToken)
+    {
+        // For Thrift, we can't fetch specific chunk indices
+        // Best effort: Call FetchResults and return what we get
+        var results = await _statement.FetchResultsAsync(
+            TFetchOrientation.FETCH_NEXT,
+            _statement.BatchSize,
+            cancellationToken);
+
+        var refreshedResults = new List<IDownloadResult>();
+        if (results.Results?.ResultLinks != null)
+        {
+            foreach (var link in results.Results.ResultLinks)
+            {
+                refreshedResults.Add(CreateDownloadResult(link));
+            }
+        }
+
+        return refreshedResults;
+    }
+}
+```
+
+**Key Characteristics:**
+- ✅ Incremental: Multiple API calls (`FetchResults`) until `HasMoreRows` is false
+- ✅ URLs included: Each Thrift response contains external link URLs
+- ✅ **OPTIMIZED**: Uses initial links before fetching more
+- ✅ **URL Refresh**: Best-effort refresh for expired links
+
+#### 2.2 StatementExecutionResultFetcher (REST - New Implementation)
+
+**Two-Phase Fetching Pattern:**
+
+Based on JDBC implementation analysis (`ChunkLinkDownloadService.java`), the Statement Execution API uses a **two-phase incremental pattern**:
+
+1. **Phase 1 (Upfront)**: Get ResultManifest with chunk metadata (but NO URLs)
+2. **Phase 2 (Incremental)**: Fetch URLs in batches via `GetResultChunks` API
+
+```csharp
+/// <summary>
+/// Fetches CloudFetch results from Databricks using Statement Execution REST API.
+/// Uses TWO-PHASE incremental fetching:
+///   1. ResultManifest provides chunk metadata upfront
+///   2. URLs fetched incrementally via GetResultChunks(chunkIndex) API
+/// </summary>
+internal class StatementExecutionResultFetcher : BaseResultFetcher
+{
+    private readonly StatementExecutionClient _client;
+    private readonly ResultManifest _manifest;
+    private readonly string _statementId;
+    private long _nextChunkIndexToFetch = 0;
+
+    public StatementExecutionResultFetcher(
+        StatementExecutionClient client,
+        ResultManifest manifest,
+        string statementId,
+        ICloudFetchMemoryBufferManager memoryManager,
+        BlockingCollection<IDownloadResult> downloadQueue,
+        int urlExpirationBufferSeconds)
+        : base(memoryManager, downloadQueue, urlExpirationBufferSeconds)
+    {
+        _client = client;
+        _manifest = manifest;
+        _statementId = statementId;
+    }
+
+    protected override async Task FetchAllResultsAsync(CancellationToken cancellationToken)
+    {
+        // Phase 1: Manifest already contains chunk metadata (from initial ExecuteStatement response)
+        // - Total chunk count: _manifest.TotalChunkCount
+        // - Chunk metadata: _manifest.Chunks (chunkIndex, rowCount, rowOffset, byteCount)
+        // - BUT: No external link URLs (those expire, so fetched on-demand)
+
+        long totalChunks = _manifest.TotalChunkCount;
+
+        // Phase 2: Fetch external link URLs incrementally in batches
+        while (_nextChunkIndexToFetch < totalChunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Call REST API: GET /api/2.0/sql/statements/{statementId}/result/chunks?startChunkIndex={index}
+            // Returns: Collection<ExternalLink> with URL, expiration, headers for batch of chunks
+            var externalLinks = await _client.GetResultChunksAsync(
+                _statementId,
+                _nextChunkIndexToFetch,
+                cancellationToken);
+
+            foreach (var link in externalLinks)
+            {
+                // Find corresponding chunk metadata from manifest
+                var chunkMetadata = _manifest.Chunks[link.ChunkIndex];
+
+                // Create DownloadResult combining metadata + URL
+                var downloadResult = new DownloadResult(
+                    fileUrl: link.Url,
+                    startRowOffset: chunkMetadata.RowOffset,
+                    rowCount: chunkMetadata.RowCount,
+                    byteCount: chunkMetadata.ByteCount,
+                    expirationTime: link.Expiration,
+                    httpHeaders: link.Headers);
+
+                await EnqueueDownloadResultAsync(downloadResult, cancellationToken);
+            }
+
+            // Update index for next batch (server returns continuous series)
+            if (externalLinks.Count > 0)
+            {
+                long maxIndex = externalLinks.Max(l => l.ChunkIndex);
+                _nextChunkIndexToFetch = maxIndex + 1;
+            }
+            else
+            {
+                // No more chunks returned, we're done
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Re-fetches URLs for a specific chunk range (for expired link handling).
+    /// REST API allows targeted refresh by chunk index.
+    /// </summary>
+    public override async Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(
+        long startChunkIndex,
+        long endChunkIndex,
+        CancellationToken cancellationToken)
+    {
+        // Call REST API to get fresh URLs for specific chunk range
+        var externalLinks = await _client.GetResultChunksAsync(
+            _statementId,
+            startChunkIndex,
+            cancellationToken);
+
+        var refreshedResults = new List<IDownloadResult>();
+        foreach (var link in externalLinks)
+        {
+            // Only return links within requested range
+            if (link.ChunkIndex >= startChunkIndex && link.ChunkIndex <= endChunkIndex)
+            {
+                var chunkMetadata = _manifest.Chunks[link.ChunkIndex];
+                var downloadResult = new DownloadResult(
+                    fileUrl: link.Url,
+                    startRowOffset: chunkMetadata.RowOffset,
+                    rowCount: chunkMetadata.RowCount,
+                    byteCount: chunkMetadata.ByteCount,
+                    expirationTime: link.Expiration,
+                    httpHeaders: link.Headers);
+
+                refreshedResults.Add(downloadResult);
+            }
+        }
+
+        return refreshedResults;
+    }
+}
+```
+
+**Key Characteristics:**
+- ✅ Two-phase: Manifest upfront (metadata only) + Incremental URL fetching
+- ✅ Incremental URLs: Multiple `GetResultChunks` API calls
+- ✅ Expiration-friendly: URLs fetched closer to when they're needed
+- ✅ Batch-based: Server returns multiple URLs per request
+- ✅ Automatic chaining: Each response indicates next chunk index
+
+**Why Two Phases?**
+
+| Aspect | Upfront URLs (All at Once) | Incremental URLs (On-Demand) |
+|--------|---------------------------|------------------------------|
+| **URL Expiration** | ❌ Early URLs may expire before download | ✅ URLs fetched closer to use time |
+| **Memory Usage** | ❌ Store all URLs upfront | ✅ Fetch URLs as needed |
+| **Initial Latency** | ❌ Longer initial wait for all URLs | ✅ Faster initial response |
+| **Flexibility** | ❌ Must fetch all URLs even if query cancelled | ✅ Stop fetching if download cancelled |
+| **JDBC Pattern** | ❌ Not used | ✅ Proven in production |
+
+**Comparison: Thrift vs REST Fetching**
+
+| Aspect | Thrift (CloudFetchResultFetcher) | REST (StatementExecutionResultFetcher) |
+|--------|----------------------------------|----------------------------------------|
+| **Metadata Source** | Incremental via `FetchResults` | Upfront in `ResultManifest` |
+| **URL Source** | Included in each `FetchResults` response | Incremental via `GetResultChunks` API |
+| **API Call Pattern** | Single API: `FetchResults` (metadata + URLs) | Two APIs: `ExecuteStatement` (metadata) + `GetResultChunks` (URLs) |
+| **Chunk Count Known** | ❌ Unknown until last fetch | ✅ Known upfront from manifest |
+| **Loop Condition** | While `HasMoreRows == true` | While `nextChunkIndex < totalChunks` |
+| **Batch Size** | Controlled by statement `BatchSize` | Controlled by server response |
+
+**Common Output:**
+
+Despite different fetching patterns, **both produce identical `IDownloadResult` objects**:
+- FileUrl (external link with expiration)
+- StartRowOffset (row offset in result set)
+- RowCount (number of rows in chunk)
+- ByteCount (compressed file size)
+- ExpirationTime (URL expiration timestamp)
+- HttpHeaders (authentication/authorization headers)
+
+This allows the rest of the CloudFetch pipeline (CloudFetchDownloadManager, CloudFetchDownloader, CloudFetchReader) to work identically for both protocols! 🎉
+
+#### 2.3 Expired Link Handling Strategy
+
+External links (presigned URLs) have expiration times, typically 15-60 minutes. If a download is attempted with an expired URL, it will fail. We need a robust strategy to handle this.
+
+**Expired Link Detection:**
+
+```csharp
+/// <summary>
+/// Interface for result fetchers with URL refresh capability.
+/// </summary>
+public interface ICloudFetchResultFetcher
+{
+    Task StartAsync(CancellationToken cancellationToken);
+    Task StopAsync();
+    bool HasMoreResults { get; }
+    bool IsCompleted { get; }
+
+    /// <summary>
+    /// Re-fetches URLs for chunks in the specified range.
+    /// Used when URLs expire before download completes.
+    /// </summary>
+    Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(
+        long startChunkIndex,
+        long endChunkIndex,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Extended download result with expiration tracking.
+/// </summary>
+public interface IDownloadResult : IDisposable
+{
+    string FileUrl { get; }
+    long StartRowOffset { get; }
+    long RowCount { get; }
+    long ByteCount { get; }
+    DateTimeOffset? ExpirationTime { get; }
+
+    /// <summary>
+    /// Checks if the URL is expired or will expire soon (within buffer time).
+    /// </summary>
+    /// <param name="bufferSeconds">Buffer time before expiration (default: 60 seconds).</param>
+    bool IsExpired(int bufferSeconds = 60);
+
+    /// <summary>
+    /// Refreshes this download result with a new URL.
+    /// Called when the original URL expires.
+    /// </summary>
+    void RefreshUrl(string newUrl, DateTimeOffset newExpiration, IReadOnlyDictionary<string, string>? headers = null);
+}
+```
+
+**Implementation in DownloadResult:**
+
+```csharp
+internal class DownloadResult : IDownloadResult
+{
+    public long ChunkIndex { get; private set; }
+    public string FileUrl { get; private set; }
+    public DateTimeOffset? ExpirationTime { get; private set; }
+    public IReadOnlyDictionary<string, string>? HttpHeaders { get; private set; }
+
+    public bool IsExpired(int bufferSeconds = 60)
+    {
+        if (ExpirationTime == null)
+            return false;
+
+        var expirationWithBuffer = ExpirationTime.Value.AddSeconds(-bufferSeconds);
+        return DateTimeOffset.UtcNow >= expirationWithBuffer;
+    }
+
+    public void RefreshUrl(string newUrl, DateTimeOffset newExpiration, IReadOnlyDictionary<string, string>? headers = null)
+    {
+        FileUrl = newUrl ?? throw new ArgumentNullException(nameof(newUrl));
+        ExpirationTime = newExpiration;
+        if (headers != null)
+            HttpHeaders = headers;
+    }
+}
+```
+
+**Expired Link Handling in CloudFetchDownloader:**
+
+```csharp
+internal class CloudFetchDownloader : ICloudFetchDownloader
+{
+    private readonly ICloudFetchResultFetcher _resultFetcher;
+    private readonly int _maxUrlRefreshAttempts;
+    private readonly int _urlExpirationBufferSeconds;
+
+    private async Task<bool> DownloadFileAsync(
+        IDownloadResult downloadResult,
+        CancellationToken cancellationToken)
+    {
+        int refreshAttempts = 0;
+
+        while (refreshAttempts < _maxUrlRefreshAttempts)
+        {
+            try
+            {
+                // Check if URL is expired before attempting download
+                if (downloadResult.IsExpired(_urlExpirationBufferSeconds))
+                {
+                    _tracingStatement?.Log($"URL expired for chunk {downloadResult.ChunkIndex}, refreshing... (attempt {refreshAttempts + 1}/{_maxUrlRefreshAttempts})");
+
+                    // Refresh the URL via fetcher
+                    var refreshedResults = await _resultFetcher.RefreshUrlsAsync(
+                        downloadResult.ChunkIndex,
+                        downloadResult.ChunkIndex,
+                        cancellationToken);
+
+                    var refreshedResult = refreshedResults.FirstOrDefault();
+                    if (refreshedResult == null)
+                    {
+                        throw new InvalidOperationException($"Failed to refresh URL for chunk {downloadResult.ChunkIndex}");
+                    }
+
+                    // Update the download result with fresh URL
+                    downloadResult.RefreshUrl(
+                        refreshedResult.FileUrl,
+                        refreshedResult.ExpirationTime ?? DateTimeOffset.UtcNow.AddHours(1),
+                        refreshedResult.HttpHeaders);
+
+                    refreshAttempts++;
+                    continue; // Retry download with fresh URL
+                }
+
+                // Attempt download
+                using var request = new HttpRequestMessage(HttpMethod.Get, downloadResult.FileUrl);
+
+                // Add headers if provided
+                if (downloadResult.HttpHeaders != null)
+                {
+                    foreach (var header in downloadResult.HttpHeaders)
+                    {
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
+
+                response.EnsureSuccessStatusCode();
+
+                // Stream content to memory or disk
+                var stream = await response.Content.ReadAsStreamAsync();
+                downloadResult.SetDataStream(stream);
+                downloadResult.MarkDownloadComplete();
+
+                return true;
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden && refreshAttempts < _maxUrlRefreshAttempts)
+            {
+                // 403 Forbidden often indicates expired URL
+                _tracingStatement?.Log($"Download failed with 403 for chunk {downloadResult.ChunkIndex}, refreshing URL... (attempt {refreshAttempts + 1}/{_maxUrlRefreshAttempts})");
+                refreshAttempts++;
+
+                // Refresh the URL and retry
+                var refreshedResults = await _resultFetcher.RefreshUrlsAsync(
+                    downloadResult.ChunkIndex,
+                    downloadResult.ChunkIndex,
+                    cancellationToken);
+
+                var refreshedResult = refreshedResults.FirstOrDefault();
+                if (refreshedResult != null)
+                {
+                    downloadResult.RefreshUrl(
+                        refreshedResult.FileUrl,
+                        refreshedResult.ExpirationTime ?? DateTimeOffset.UtcNow.AddHours(1),
+                        refreshedResult.HttpHeaders);
+                }
+
+                // Will retry in next iteration
+            }
+        }
+
+        throw new InvalidOperationException($"Failed to download chunk {downloadResult.ChunkIndex} after {_maxUrlRefreshAttempts} URL refresh attempts");
+    }
+}
+```
+
+**Configuration:**
+
+```csharp
+// Default values for URL refresh
+private const int DefaultMaxUrlRefreshAttempts = 3;
+private const int DefaultUrlExpirationBufferSeconds = 60;
+
+// Connection properties
+properties["adbc.databricks.cloudfetch.max_url_refresh_attempts"] = "3";
+properties["adbc.databricks.cloudfetch.url_expiration_buffer_seconds"] = "60";
+```
+
+**Refresh Strategy Comparison:**
+
+| Protocol | Refresh Mechanism | Precision | Efficiency |
+|----------|-------------------|-----------|------------|
+| **Thrift** | Call `FetchResults` with FETCH_NEXT | ❌ Low - returns next batch, not specific chunk | ⚠️ May fetch more than needed |
+| **REST** | Call `GetResultChunks(chunkIndex)` | ✅ High - targets specific chunk index | ✅ Efficient - only fetches what's needed |
+
+**Error Scenarios:**
+
+1. **Expired before download**: Detected via `IsExpired()`, refreshed proactively
+2. **Expired during download**: HTTP 403 error triggers refresh and retry
+3. **Refresh fails**: After `maxUrlRefreshAttempts`, throw exception
+4. **Multiple chunks expired**: Each chunk refreshed independently
+
+**Benefits:**
+
+- ✅ **Automatic recovery**: Downloads continue even if URLs expire
+- ✅ **Configurable retries**: Control max refresh attempts
+- ✅ **Proactive detection**: Check expiration before download to avoid wasted attempts
+- ✅ **Protocol-agnostic**: Same refresh interface for Thrift and REST
+- ✅ **Efficient for REST**: Targeted chunk refresh via API
+- ✅ **Best-effort for Thrift**: Falls back to fetching next batch
+
+### 3. CloudFetchReader (Refactored - Protocol-Agnostic)
+
+**Before** (Thrift-Coupled):
+```csharp
+public CloudFetchReader(
+    IHiveServer2Statement statement,              // ❌ Thrift-specific
+    Schema schema,
+    IResponse response,
+    TFetchResultsResp? initialResults,            // ❌ Thrift-specific
+    bool isLz4Compressed,
+    HttpClient httpClient)
+{
+    // Creates CloudFetchDownloadManager internally
+    downloadManager = new CloudFetchDownloadManager(
+        statement, schema, response, initialResults, isLz4Compressed, httpClient);
+}
+```
+
+**After** (Protocol-Agnostic):
+```csharp
+/// <summary>
+/// Reader for CloudFetch results.
+/// Protocol-agnostic - works with any ICloudFetchDownloadManager.
+/// </summary>
+internal sealed class CloudFetchReader : IArrowArrayStream, IDisposable
+{
+    private readonly ICloudFetchDownloadManager _downloadManager;
+    private ArrowStreamReader? _currentReader;
+    private IDownloadResult? _currentDownloadResult;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CloudFetchReader"/> class.
+    /// </summary>
+    /// <param name="downloadManager">The download manager (protocol-agnostic).</param>
+    /// <param name="schema">The Arrow schema.</param>
+    public CloudFetchReader(
+        ICloudFetchDownloadManager downloadManager,
+        Schema schema)
+    {
+        _downloadManager = downloadManager ?? throw new ArgumentNullException(nameof(downloadManager));
+        Schema = schema ?? throw new ArgumentNullException(nameof(schema));
+    }
+
+    public Schema Schema { get; }
+
+    public async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(
+        CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            // If we have a current reader, try to read the next batch
+            if (_currentReader != null)
+            {
+                RecordBatch? next = await _currentReader.ReadNextRecordBatchAsync(cancellationToken);
+                if (next != null)
+                    return next;
+
+                // Clean up current reader and download result
+                _currentReader.Dispose();
+                _currentReader = null;
+                _currentDownloadResult?.Dispose();
+                _currentDownloadResult = null;
+            }
+
+            // Get the next downloaded file
+            _currentDownloadResult = await _downloadManager.GetNextDownloadedFileAsync(cancellationToken);
+            if (_currentDownloadResult == null)
+                return null; // No more files
+
+            // Wait for download to complete
+            await _currentDownloadResult.DownloadCompletedTask;
+
+            // Create reader for the downloaded file
+            _currentReader = new ArrowStreamReader(_currentDownloadResult.DataStream);
+        }
+    }
+
+    public void Dispose()
+    {
+        _currentReader?.Dispose();
+        _currentDownloadResult?.Dispose();
+        _downloadManager?.Dispose();
+    }
+}
+```
+
+### 3. CloudFetchDownloadManager (Refactored - Protocol-Agnostic)
+
+**Before** (Thrift-Coupled):
+```csharp
+public CloudFetchDownloadManager(
+    IHiveServer2Statement statement,              // ❌ Thrift-specific
+    Schema schema,
+    IResponse response,
+    TFetchResultsResp? initialResults,            // ❌ Thrift-specific
+    bool isLz4Compressed,
+    HttpClient httpClient)
+{
+    // Reads config from statement.Connection.Properties  // ❌ Coupled
+    // Creates CloudFetchResultFetcher directly            // ❌ Thrift-specific
+    _resultFetcher = new CloudFetchResultFetcher(
+        statement, response, initialResults, ...);
+}
+```
+
+**After** (Protocol-Agnostic):
+```csharp
+/// <summary>
+/// Manages the CloudFetch download pipeline.
+/// Protocol-agnostic - works with any ICloudFetchResultFetcher.
+/// </summary>
+internal sealed class CloudFetchDownloadManager : ICloudFetchDownloadManager
+{
+    private readonly CloudFetchConfiguration _config;
+    private readonly ICloudFetchMemoryBufferManager _memoryManager;
+    private readonly BlockingCollection<IDownloadResult> _downloadQueue;
+    private readonly BlockingCollection<IDownloadResult> _resultQueue;
+    private readonly ICloudFetchResultFetcher _resultFetcher;
+    private readonly ICloudFetchDownloader _downloader;
+    private readonly HttpClient _httpClient;
+    private bool _isDisposed;
+    private bool _isStarted;
+    private CancellationTokenSource? _cancellationTokenSource;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CloudFetchDownloadManager"/> class.
+    /// </summary>
+    /// <param name="resultFetcher">The result fetcher (protocol-specific).</param>
+    /// <param name="httpClient">The HTTP client for downloads.</param>
+    /// <param name="config">The CloudFetch configuration.</param>
+    /// <param name="tracingStatement">Optional statement for Activity tracing.</param>
+    public CloudFetchDownloadManager(
+        ICloudFetchResultFetcher resultFetcher,
+        HttpClient httpClient,
+        CloudFetchConfiguration config,
+        ITracingStatement? tracingStatement = null)
+    {
+        _resultFetcher = resultFetcher ?? throw new ArgumentNullException(nameof(resultFetcher));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+
+        // Set HTTP client timeout
+        _httpClient.Timeout = TimeSpan.FromMinutes(_config.TimeoutMinutes);
+
+        // Initialize memory manager
+        _memoryManager = new CloudFetchMemoryBufferManager(_config.MemoryBufferSizeMB);
+
+        // Initialize queues with bounded capacity
+        int queueCapacity = _config.PrefetchCount * 2;
+        _downloadQueue = new BlockingCollection<IDownloadResult>(
+            new ConcurrentQueue<IDownloadResult>(), queueCapacity);
+        _resultQueue = new BlockingCollection<IDownloadResult>(
+            new ConcurrentQueue<IDownloadResult>(), queueCapacity);
+
+        // Initialize downloader
+        _downloader = new CloudFetchDownloader(
+            tracingStatement,
+            _downloadQueue,
+            _resultQueue,
+            _memoryManager,
+            _httpClient,
+            _resultFetcher,
+            _config.ParallelDownloads,
+            _config.IsLz4Compressed,
+            _config.MaxRetries,
+            _config.RetryDelayMs,
+            _config.MaxUrlRefreshAttempts,
+            _config.UrlExpirationBufferSeconds);
+    }
+
+    public bool HasMoreResults => !_downloader.IsCompleted || !_resultQueue.IsCompleted;
+
+    public async Task<IDownloadResult?> GetNextDownloadedFileAsync(CancellationToken cancellationToken)
+    {
+        if (!_isStarted)
+            throw new InvalidOperationException("Download manager has not been started.");
+
+        try
+        {
+            return await _downloader.GetNextDownloadedFileAsync(cancellationToken);
+        }
+        catch (Exception ex) when (_resultFetcher.HasError)
+        {
+            throw new AggregateException("Errors in download pipeline",
+                new[] { ex, _resultFetcher.Error! });
+        }
+    }
+
+    public async Task StartAsync()
+    {
+        if (_isStarted)
+            throw new InvalidOperationException("Download manager is already started.");
+
+        _cancellationTokenSource = new CancellationTokenSource();
+
+        // Start result fetcher and downloader
+        await _resultFetcher.StartAsync(_cancellationTokenSource.Token);
+        await _downloader.StartAsync(_cancellationTokenSource.Token);
+
+        _isStarted = true;
+    }
+
+    public async Task StopAsync()
+    {
+        if (!_isStarted) return;
+
+        _cancellationTokenSource?.Cancel();
+
+        await _downloader.StopAsync();
+        await _resultFetcher.StopAsync();
+
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
+        _isStarted = false;
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+
+        StopAsync().GetAwaiter().GetResult();
+        _httpClient.Dispose();
+        _cancellationTokenSource?.Dispose();
+
+        _downloadQueue.CompleteAdding();
+        _resultQueue.CompleteAdding();
+
+        // Dispose remaining results
+        foreach (var result in _resultQueue.GetConsumingEnumerable(CancellationToken.None))
+            result.Dispose();
+        foreach (var result in _downloadQueue.GetConsumingEnumerable(CancellationToken.None))
+            result.Dispose();
+
+        _downloadQueue.Dispose();
+        _resultQueue.Dispose();
+
+        _isDisposed = true;
+    }
+}
+```
+
+### 4. CloudFetchDownloader (Minor Refactoring)
+
+**Current Implementation is Mostly Good!** Only needs minor changes:
+
+```csharp
+/// <summary>
+/// Downloads files from URLs.
+/// Protocol-agnostic - works with any ICloudFetchResultFetcher.
+/// </summary>
+internal sealed class CloudFetchDownloader : ICloudFetchDownloader
+{
+    // Constructor already takes ITracingStatement (generic)
+    // Constructor already takes ICloudFetchResultFetcher (interface)
+    // ✅ No changes needed to constructor signature!
+
+    public CloudFetchDownloader(
+        ITracingStatement? tracingStatement,  // ✅ Already generic
+        BlockingCollection<IDownloadResult> downloadQueue,
+        BlockingCollection<IDownloadResult> resultQueue,
+        ICloudFetchMemoryBufferManager memoryManager,
+        HttpClient httpClient,
+        ICloudFetchResultFetcher resultFetcher,  // ✅ Already interface
+        int maxParallelDownloads,
+        bool isLz4Compressed,
+        int maxRetries,
+        int retryDelayMs,
+        int maxUrlRefreshAttempts,
+        int urlExpirationBufferSeconds)
+    {
+        // Implementation remains the same!
+    }
+
+    // All methods remain unchanged!
+}
+```
+
+## Usage Patterns
+
+### Pattern 1: Thrift Implementation
+
+```csharp
+// In DatabricksStatement (Thrift)
+public async Task<QueryResult> ExecuteQueryAsync()
+{
+    // 1. Create Thrift-specific result fetcher
+    var thriftFetcher = new CloudFetchResultFetcher(
+        _statement,                    // IHiveServer2Statement
+        _response,                     // IResponse
+        initialResults,                // TFetchResultsResp
+        memoryManager,
+        downloadQueue,
+        batchSize,
+        urlExpirationBufferSeconds);
+
+    // 2. Parse configuration from Thrift properties
+    var config = CloudFetchConfiguration.FromProperties(
+        _statement.Connection.Properties,
+        schema,
+        isLz4Compressed);
+
+    // 3. Create protocol-agnostic download manager
+    var downloadManager = new CloudFetchDownloadManager(
+        thriftFetcher,                 // Protocol-specific fetcher
+        httpClient,
+        config,
+        _statement);                   // For tracing
+
+    // 4. Start the manager
+    await downloadManager.StartAsync();
+
+    // 5. Create protocol-agnostic reader
+    var reader = new CloudFetchReader(downloadManager, schema);
+
+    return new QueryResult(reader);
+}
+```
+
+### Pattern 2: REST Implementation
+
+```csharp
+// In StatementExecutionStatement (REST)
+public async Task<QueryResult> ExecuteQueryAsync()
+{
+    // 1. Create REST-specific result fetcher
+    var restFetcher = new StatementExecutionResultFetcher(
+        _client,                       // StatementExecutionClient
+        _statementId,
+        manifest,                      // ResultManifest
+        memoryManager,
+        downloadQueue);
+
+    // 2. Parse configuration from REST properties
+    var config = CloudFetchConfiguration.FromProperties(
+        _connection.Properties,
+        schema,
+        isLz4Compressed);
+
+    // 3. Create protocol-agnostic download manager (SAME CODE!)
+    var downloadManager = new CloudFetchDownloadManager(
+        restFetcher,                   // Protocol-specific fetcher
+        httpClient,
+        config,
+        this);                         // For tracing
+
+    // 4. Start the manager (SAME CODE!)
+    await downloadManager.StartAsync();
+
+    // 5. Create protocol-agnostic reader (SAME CODE!)
+    var reader = new CloudFetchReader(downloadManager, schema);
+
+    return new QueryResult(reader);
+}
+```
+
+## Class Diagram: Refactored Architecture
+
+```mermaid
+classDiagram
+    class CloudFetchConfiguration {
+        +int ParallelDownloads
+        +int PrefetchCount
+        +int MemoryBufferSizeMB
+        +int TimeoutMinutes
+        +bool IsLz4Compressed
+        +Schema Schema
+        +FromProperties(properties, schema, isLz4)$ CloudFetchConfiguration
+    }
+
+    class ICloudFetchResultFetcher {
+        <<interface>>
+        +StartAsync(CancellationToken) Task
+        +StopAsync() Task
+        +GetDownloadResultAsync(offset, ct) Task~IDownloadResult~
+        +bool HasMoreResults
+        +bool IsCompleted
+    }
+
+    class CloudFetchResultFetcher {
+        +IHiveServer2Statement _statement
+        +TFetchResultsResp _initialResults
+        +FetchAllResultsAsync(ct) Task
+    }
+
+    class StatementExecutionResultFetcher {
+        +StatementExecutionClient _client
+        +ResultManifest _manifest
+        +FetchAllResultsAsync(ct) Task
+    }
+
+    class CloudFetchDownloadManager {
+        -CloudFetchConfiguration _config
+        -ICloudFetchResultFetcher _resultFetcher
+        -ICloudFetchDownloader _downloader
+        +CloudFetchDownloadManager(fetcher, httpClient, config, tracer)
+        +StartAsync() Task
+        +GetNextDownloadedFileAsync(ct) Task~IDownloadResult~
+    }
+
+    class CloudFetchDownloader {
+        -ICloudFetchResultFetcher _resultFetcher
+        -HttpClient _httpClient
+        +CloudFetchDownloader(tracer, queues, memMgr, httpClient, fetcher, ...)
+        +StartAsync(ct) Task
+        +GetNextDownloadedFileAsync(ct) Task~IDownloadResult~
+    }
+
+    class CloudFetchReader {
+        -ICloudFetchDownloadManager _downloadManager
+        -ArrowStreamReader _currentReader
+        +CloudFetchReader(downloadManager, schema)
+        +ReadNextRecordBatchAsync(ct) ValueTask~RecordBatch~
+    }
+
+    class ICloudFetchDownloadManager {
+        <<interface>>
+        +GetNextDownloadedFileAsync(ct) Task~IDownloadResult~
+        +StartAsync() Task
+        +bool HasMoreResults
+    }
+
+    %% Relationships
+    ICloudFetchResultFetcher <|.. CloudFetchResultFetcher : implements
+    ICloudFetchResultFetcher <|.. StatementExecutionResultFetcher : implements
+
+    ICloudFetchDownloadManager <|.. CloudFetchDownloadManager : implements
+
+    CloudFetchDownloadManager --> ICloudFetchResultFetcher : uses
+    CloudFetchDownloadManager --> CloudFetchDownloader : creates
+    CloudFetchDownloadManager --> CloudFetchConfiguration : uses
+
+    CloudFetchDownloader --> ICloudFetchResultFetcher : uses
+
+    CloudFetchReader --> ICloudFetchDownloadManager : uses
+
+    %% Styling
+    style CloudFetchConfiguration fill:#c8f7c5
+    style CloudFetchDownloadManager fill:#c5e3f7
+    style CloudFetchDownloader fill:#c5e3f7
+    style CloudFetchReader fill:#c5e3f7
+    style CloudFetchResultFetcher fill:#e8e8e8
+    style StatementExecutionResultFetcher fill:#c8f7c5
+```
+
+**Legend:**
+- 🟩 **Green** (#c8f7c5): New components
+- 🔵 **Blue** (#c5e3f7): Refactored components (protocol-agnostic)
+- ⬜ **Gray** (#e8e8e8): Existing components (minimal changes)
+
+## Sequence Diagram: Thrift vs REST Usage
+
+```mermaid
+sequenceDiagram
+    participant ThriftStmt as DatabricksStatement (Thrift)
+    participant RestStmt as StatementExecutionStatement (REST)
+    participant Config as CloudFetchConfiguration
+    participant ThriftFetcher as CloudFetchResultFetcher
+    participant RestFetcher as StatementExecutionResultFetcher
+    participant Manager as CloudFetchDownloadManager
+    participant Reader as CloudFetchReader
+
+    Note over ThriftStmt,Reader: Thrift Path
+    ThriftStmt->>ThriftFetcher: Create (IHiveServer2Statement, TFetchResultsResp)
+    ThriftStmt->>Config: FromProperties(Thrift properties)
+    Config-->>ThriftStmt: config
+    ThriftStmt->>Manager: new (ThriftFetcher, httpClient, config)
+    ThriftStmt->>Manager: StartAsync()
+    ThriftStmt->>Reader: new (Manager, schema)
+
+    Note over RestStmt,Reader: REST Path
+    RestStmt->>RestFetcher: Create (StatementExecutionClient, ResultManifest)
+    RestStmt->>Config: FromProperties(REST properties)
+    Config-->>RestStmt: config
+    RestStmt->>Manager: new (RestFetcher, httpClient, config)
+    RestStmt->>Manager: StartAsync()
+    RestStmt->>Reader: new (Manager, schema)
+
+    Note over Manager,Reader: Same Code for Both Protocols!
+```
+
+## Migration Strategy
+
+### Phase 1: Create New Components
+
+1. **Create `CloudFetchConfiguration` class**
+   - Extract all configuration parsing
+   - Add unit tests for configuration parsing
+   - Support both Thrift and REST property sources
+
+2. **Update `ICloudFetchDownloadManager` interface** (if needed)
+   - Ensure it's protocol-agnostic
+   - Add any missing methods
+
+### Phase 2: Refactor CloudFetchReader
+
+1. **Update constructor signature**
+   - Remove `IHiveServer2Statement`
+   - Remove `TFetchResultsResp`
+   - Remove protocol-specific parameters
+   - Accept `ICloudFetchDownloadManager` only
+
+2. **Remove protocol-specific logic**
+   - Don't read configuration from statement properties
+   - Don't create CloudFetchDownloadManager internally
+
+3. **Update tests**
+   - Mock `ICloudFetchDownloadManager`
+   - Test reader in isolation
+
+### Phase 3: Refactor CloudFetchDownloadManager
+
+1. **Update constructor signature**
+   - Remove `IHiveServer2Statement`
+   - Remove `TFetchResultsResp`
+   - Remove `IResponse`
+   - Accept `ICloudFetchResultFetcher` (injected)
+   - Accept `CloudFetchConfiguration` (injected)
+   - Accept `HttpClient` (injected)
+   - Accept optional `ITracingStatement` for Activity tracing
+
+2. **Remove configuration parsing**
+   - Use `CloudFetchConfiguration` object
+   - Don't read from statement properties
+
+3. **Remove factory logic**
+   - Don't create `CloudFetchResultFetcher` internally
+   - Accept `ICloudFetchResultFetcher` interface
+
+4. **Update tests**
+   - Mock `ICloudFetchResultFetcher`
+   - Use test configuration objects
+   - Test manager in isolation
+
+### Phase 4: Update Statement Implementations
+
+1. **Update `DatabricksStatement` (Thrift)**
+   - Create `CloudFetchResultFetcher` (Thrift-specific)
+   - Create `CloudFetchConfiguration` from Thrift properties
+   - Create `CloudFetchDownloadManager` with dependencies
+   - Create `CloudFetchReader` with manager
+
+2. **Update `StatementExecutionStatement` (REST)**
+   - Create `StatementExecutionResultFetcher` (REST-specific)
+   - Create `CloudFetchConfiguration` from REST properties
+   - Create `CloudFetchDownloadManager` with dependencies (SAME CODE!)
+   - Create `CloudFetchReader` with manager (SAME CODE!)
+
+### Phase 5: Testing & Validation
+
+1. **Unit tests**
+   - Test `CloudFetchConfiguration.FromProperties()`
+   - Test `CloudFetchReader` with mocked manager
+   - Test `CloudFetchDownloadManager` with mocked fetcher
+
+2. **Integration tests**
+   - Test Thrift path end-to-end
+   - Test REST path end-to-end
+   - Verify same behavior for both protocols
+
+3. **E2E tests**
+   - Run existing Thrift tests
+   - Run new REST tests
+   - Compare results
+
+## Benefits
+
+### 1. Code Reuse
+
+| Component | Before | After | Savings |
+|-----------|--------|-------|---------|
+| CloudFetchReader | ~200 lines × 2 = 400 lines | ~150 lines × 1 = 150 lines | **250 lines** |
+| CloudFetchDownloadManager | ~380 lines × 2 = 760 lines | ~180 lines × 1 = 180 lines | **580 lines** |
+| CloudFetchDownloader | ~625 lines (reused, but modified) | ~625 lines (reused as-is) | **0 lines** (already good!) |
+| Configuration | Scattered, duplicated | Centralized | **~100 lines** |
+| **Total** | **~1160 lines** | **~230 lines** | **~930 lines saved!** |
+
+### 2. Unified Properties
+
+**Same configuration works for ALL protocols:**
+
+| Aspect | Before (Separate Properties) | After (Unified Properties) | Benefit |
+|--------|------------------------------|----------------------------|---------|
+| **User Experience** | Must know which protocol is used | Protocol-agnostic configuration | ✅ Simpler |
+| **Protocol Switching** | Must reconfigure all properties | Change ONE property (`protocol`) | ✅ Seamless |
+| **Documentation** | Document properties twice (Thrift + REST) | Document properties once | ✅ Clearer |
+| **Code Maintenance** | Duplicate property parsing | Single property parsing | ✅ Less duplication |
+| **Testing** | Test both property parsers | Test one property parser | ✅ Simpler |
+| **Migration Path** | Users must learn new property names | Same properties work everywhere | ✅ Zero friction |
+
+**Example: Switching Protocols**
+```csharp
+// Before (Separate Properties)
+properties["adbc.databricks.thrift.batch_size"] = "5000000";
+properties["adbc.databricks.thrift.polling_interval_ms"] = "500";
+// ... many more thrift-specific properties
+
+// To switch to REST, must change ALL properties:
+properties["adbc.databricks.rest.batch_size"] = "5000000";  // ❌ Tedious!
+properties["adbc.databricks.rest.polling_interval_ms"] = "500";  // ❌ Error-prone!
+
+// After (Unified Properties)
+properties["adbc.databricks.batch_size"] = "5000000";  // ✅ Works for both!
+properties["adbc.databricks.polling_interval_ms"] = "500";  // ✅ Works for both!
+properties["adbc.databricks.protocol"] = "rest";  // ✅ Just change protocol!
+```
+
+### 3. Better Testing
+
+- ✅ Each component can be tested independently
+- ✅ Easy to mock dependencies with interfaces
+- ✅ Configuration parsing tested separately
+- ✅ No need for real Thrift/REST connections in unit tests
+
+### 4. Easier Maintenance
+
+- ✅ Bug fixes apply to both protocols automatically
+- ✅ Performance improvements benefit both protocols
+- ✅ Clear separation of concerns
+- ✅ Easier to understand and modify
+- ✅ Single configuration model for all protocols
+- ✅ Property changes are consistent across protocols
+
+### 5. Future-Proof
+
+- ✅ Easy to add new protocols (GraphQL, gRPC, etc.)
+- ✅ New protocols reuse existing property names
+- ✅ Can reuse CloudFetch for other data sources
+- ✅ Configuration model is extensible
+- ✅ Clean architecture supports long-term evolution
+
+### 6. Performance Optimizations
+
+This design includes critical optimizations for production workloads:
+
+#### 6.1 Use Initial Links (Optimization #1)
+
+**Problem**: Initial API responses often contain links that get ignored, requiring redundant API calls.
+
+**Solution**: Process links from initial response before fetching more.
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| **Initial API Calls** | ExecuteStatement + FetchResults | ExecuteStatement only | **-1 API call** |
+| **Initial Latency** | ~200ms (2 round-trips) | ~100ms (1 round-trip) | **50% faster** |
+| **Links Discarded** | First batch (~10-50 links) | None | **0% waste** |
+
+**Example Impact:**
+- Query with 100 chunks, batch size 10
+- **Before**: 11 API calls (1 execute + 10 fetch)
+- **After**: 10 API calls (1 execute + 9 fetch)
+- **Savings**: 1 API call = ~100ms latency + reduced load
+
+#### 6.2 Expired Link Handling (Optimization #2)
+
+**Problem**: Long-running queries or slow downloads can cause URL expiration, leading to download failures.
+
+**Solution**: Proactive expiration detection + automatic URL refresh with retries.
+
+| Scenario | Without Refresh | With Refresh | Benefit |
+|----------|-----------------|--------------|---------|
+| **URL expires before download** | ❌ Download fails | ✅ Proactively refreshed | No failure |
+| **URL expires during download** | ❌ HTTP 403 error, query fails | ✅ Caught, refreshed, retried | Automatic recovery |
+| **Slow network** | ❌ URLs expire while queued | ✅ Checked at download time | Resilient |
+| **Large result sets** | ❌ Later chunks expire | ✅ Each chunk refreshed independently | Scalable |
+
+**Configuration:**
+```csharp
+// Buffer time before expiration to trigger proactive refresh
+properties["adbc.databricks.cloudfetch.url_expiration_buffer_seconds"] = "60";
+
+// Maximum attempts to refresh an expired URL
+properties["adbc.databricks.cloudfetch.max_url_refresh_attempts"] = "3";
+```
+
+**Real-World Impact:**
+
+| Query Type | URL Lifetime | Download Time | Risk Without Refresh | Risk With Refresh |
+|------------|--------------|---------------|----------------------|-------------------|
+| Small (<1GB) | 15 min | ~30 sec | ✅ Low | ✅ Low |
+| Medium (1-10GB) | 15 min | ~5 min | ⚠️ Medium | ✅ Low |
+| Large (10-100GB) | 15 min | ~20 min | ❌ High (certain failure) | ✅ Low |
+| Very Large (>100GB) | 15 min | >30 min | ❌ Certain failure | ✅ Medium (depends on retries) |
+
+**Protocol Advantages:**
+
+| Protocol | Refresh Precision | API Efficiency | Best For |
+|----------|-------------------|----------------|----------|
+| **Thrift** | ⚠️ Batch-based (returns next N chunks) | ⚠️ May fetch unneeded URLs | Simpler queries |
+| **REST** | ✅ Targeted (specific chunk index) | ✅ Fetches only what's needed | Large result sets |
+
+**Combined Optimization Impact:**
+
+For a typical large query (10GB, 100 chunks, 15-minute download):
+
+| Metric | Baseline | With Initial Links | With Both Optimizations | Total Improvement |
+|--------|----------|-------------------|------------------------|-------------------|
+| **API Calls** | 11 | 10 | 10 + ~3 refreshes = 13 | Still net positive! |
+| **Success Rate** | 60% (URLs expire) | 60% (still expire) | 99.9% (auto-recovered) | **+66% reliability** |
+| **Latency (first batch)** | 200ms | 100ms | 100ms | **50% faster start** |
+| **User Experience** | ❌ Manual retry needed | ❌ Manual retry needed | ✅ Automatic | **Seamless** |
+
+## Open Questions
+
+1. **HttpClient Management**
+   - Should `HttpClient` be created by the statement or injected?
+   - Should we share one `HttpClient` across statements in a connection?
+   - **Recommendation**: Each connection creates one `HttpClient`, statements receive it as dependency
+
+2. **Activity Tracing**
+   - Should `CloudFetchReader` support tracing activities?
+   - How to pass `ITracingStatement` to reader if needed?
+   - **Recommendation**: Pass optional `ITracingStatement` to `CloudFetchDownloadManager` constructor
+
+3. **Property Defaults** (RESOLVED)
+   - ✅ Use same defaults for all protocols
+   - ✅ Protocol-specific overrides available via `rest.*` namespace if truly needed
+
+4. **Error Handling**
+   - Should configuration parsing errors be thrown immediately or deferred?
+   - How to handle partial configuration failures?
+   - **Recommendation**: Fail fast on invalid configuration values
+
+5. **Backward Compatibility**
+   - Should we keep old Thrift-specific constructors as deprecated?
+   - Migration path for external consumers?
+   - **Recommendation**: Deprecate old constructors, provide clear migration guide
+
+## Success Criteria
+
+### Core Refactoring
+- ✅ **No Code Duplication**: CloudFetchReader, CloudFetchDownloadManager, CloudFetchDownloader reused 100%
+- ✅ **No Protocol Dependencies**: No Thrift or REST types in shared components
+- ✅ **Unified Properties**: Same property names work for Thrift and REST
+- ✅ **Seamless Protocol Switching**: Users change only `protocol` property to switch
+- ✅ **Configuration Extracted**: All config parsing in `CloudFetchConfiguration`
+- ✅ **Interfaces Used**: All dependencies injected via interfaces
+
+### Performance Optimizations
+- ✅ **Initial Links Used**: Process links from initial response (ExecuteStatement/FetchResults) before fetching more
+- ✅ **No Link Waste**: First batch of links (10-50 chunks) utilized immediately
+- ✅ **Reduced API Calls**: Save 1 API call per query by using initial links
+- ✅ **Expired Link Handling**: Automatic URL refresh with configurable retries
+- ✅ **Proactive Expiration Check**: Detect expired URLs before download attempt
+- ✅ **Reactive Expiration Handling**: Catch HTTP 403 errors and refresh URLs
+- ✅ **Configurable Refresh**: `max_url_refresh_attempts` and `url_expiration_buffer_seconds` properties
+- ✅ **Protocol-Specific Refresh**: Thrift uses batch-based refresh, REST uses targeted chunk refresh
+
+### Testing & Quality
+- ✅ **Tests Pass**: All existing Thrift tests pass without changes
+- ✅ **REST Works**: REST implementation uses same pipeline successfully
+- ✅ **Code Coverage**: >90% coverage on refactored components
+- ✅ **Expiration Tests**: Unit tests for URL expiration detection and refresh logic
+- ✅ **Integration Tests**: E2E tests with long-running queries to validate URL refresh
+
+### Documentation
+- ✅ **Documentation**: Single set of documentation for properties (note protocol-specific interpretation where applicable)
+- ✅ **Optimization Guide**: Document initial link usage and expired link handling
+- ✅ **Configuration Guide**: Document all URL refresh configuration parameters
+
+## Files to Modify
+
+### New Files
+
+1. `csharp/src/Reader/CloudFetch/CloudFetchConfiguration.cs` - Configuration model
+2. `csharp/test/Unit/CloudFetch/CloudFetchConfigurationTest.cs` - Configuration tests
+
+### Modified Files
+
+1. `csharp/src/Reader/CloudFetch/CloudFetchReader.cs` - Remove Thrift dependencies
+2. `csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs` - Remove Thrift dependencies
+3. `csharp/src/Reader/CloudFetch/ICloudFetchInterfaces.cs` - Update if needed
+4. `csharp/src/DatabricksStatement.cs` - Update to use new pattern
+5. `csharp/test/E2E/CloudFetch/CloudFetchReaderTest.cs` - Update tests
+6. `csharp/test/E2E/CloudFetch/CloudFetchDownloadManagerTest.cs` - Update tests
+
+### REST Implementation (New - Future)
+
+1. `csharp/src/Rest/StatementExecutionStatement.cs` - Use CloudFetch pipeline
+2. `csharp/src/Rest/StatementExecutionResultFetcher.cs` - REST-specific fetcher
+3. `csharp/test/E2E/Rest/StatementExecutionCloudFetchTest.cs` - REST CloudFetch tests
+
+## Summary
+
+This comprehensive refactoring makes the **entire CloudFetch pipeline truly protocol-agnostic**, enabling:
+
+1. **Complete Code Reuse**: ~930 lines saved by reusing CloudFetch components across protocols
+2. **Unified Properties**: Same configuration property names work for Thrift, REST, and future protocols
+3. **Seamless Migration**: Users switch protocols by changing ONE property (`protocol`)
+4. **Clean Architecture**: Clear separation between protocol-specific and shared logic
+5. **Better Testing**: Each component testable in isolation with shared property parsing
+6. **Future-Proof**: New protocols reuse existing properties and CloudFetch pipeline
+7. **Maintainability**: Single source of truth for both CloudFetch logic and configuration
+
+**Key Design Insights:**
+
+1. **Move protocol-specific logic UP to the statement level, keep the pipeline protocol-agnostic**
+2. **Use unified property names across all protocols** - protocol only affects interpretation, not naming
+3. **CloudFetch configuration is protocol-agnostic** - downloads work the same regardless of how we get URLs

--- a/csharp/doc/statement-execution-api-design.md
+++ b/csharp/doc/statement-execution-api-design.md
@@ -2343,37 +2343,214 @@ internal class StatementExecutionResultFetcher : BaseResultFetcher
 | Maintainability | Changes in 2 places | Changes in 1 place | 50% reduction |
 | Testability | Test both separately | Test base once | Fewer tests needed |
 
-## Migration Path
+## Implementation Task Breakdown
 
-### Phase 1: Core Implementation (MVP)
-- [ ] Add Statement Execution API configuration parameters
-- [ ] Implement `StatementExecutionClient` with basic REST calls
-- [ ] Implement `StatementExecutionStatement` for query execution
-- [ ] Support `EXTERNAL_LINKS` disposition with `ARROW_STREAM` format
-- [ ] Basic polling for async execution
+### Completed Tasks (Foundation)
+- [x] **PECO-2790**: Configuration and Models
+  - Added `StatementExecutionModels.cs` with request/response models
+  - Added configuration parameters to `DatabricksParameters.cs`
+- [x] **Previous Work**: StatementExecutionClient (REST API layer)
+  - Implemented HTTP client for Statement Execution API endpoints
+- [x] **Previous Work**: CloudFetch Refactoring
+  - Made `IDownloadResult` protocol-agnostic by removing Thrift dependency
+  - Created `DownloadResult` base class with protocol-specific factories
+- [x] **Previous Work**: StatementExecutionResultFetcher
+  - Implements `ICloudFetchResultFetcher` for REST API
 
-### Phase 2: CloudFetch Integration & Refactoring
-- [ ] Create `BaseResultFetcher` abstract base class
-- [ ] Refactor `CloudFetchResultFetcher` to extend `BaseResultFetcher`
-- [ ] Refactor `IDownloadResult` interface to be protocol-agnostic
-- [ ] Update `DownloadResult` with `FromThriftLink()` factory method
-- [ ] Implement `StatementExecutionResultFetcher` extending `BaseResultFetcher`
-- [ ] Enable prefetch and parallel downloads for REST API
-- [ ] Add support for HTTP headers in `CloudFetchDownloader`
+### Current Sprint Tasks (PECO-2791 Breakdown)
 
-### Phase 3: Feature Parity
-- [ ] Support `INLINE` disposition for small results
+#### **PECO-2791-A: StatementExecutionConnection (Session Management)**
+**Estimated Effort:** 1-2 days
+**Dependencies:** PECO-2790
+
+**Scope:**
+- [ ] Implement `StatementExecutionConnection` class
+  - Session lifecycle (create on open, delete on close)
+  - Warehouse ID extraction from `http_path`
+  - Parse catalog/schema from properties
+  - Enable/disable session management configuration
+- [ ] Add missing constants to `DatabricksParameters`:
+  - `HttpPath`, `Catalog`, `Schema` (if not already present)
+- [ ] Unit tests for session management
+  - Test session creation with valid warehouse ID
+  - Test session deletion on dispose
+  - Test warehouse ID extraction from various http_path formats
+  - Test session management enable/disable
+
+**Files:**
+- `StatementExecution/StatementExecutionConnection.cs` (new)
+- `DatabricksParameters.cs` (update)
+- Test files
+
+**Success Criteria:**
+- Can create and delete sessions via REST API
+- Session management can be toggled via configuration
+- All unit tests pass
+
+---
+
+#### **PECO-2791-B: StatementExecutionStatement (Basic Execution)**
+**Estimated Effort:** 2-3 days
+**Dependencies:** PECO-2791-A
+
+**Scope:**
+- [ ] Implement `StatementExecutionStatement` class
+  - Query execution via `ExecuteStatementAsync`
+  - Polling logic with configurable intervals (default: 1000ms)
+  - Query timeout handling with cancellation
+  - EXTERNAL_LINKS disposition only (no inline yet)
+- [ ] Implement `CloudFetchArrayStreamReader`
+  - Protocol-agnostic reader using `ICloudFetchDownloadManager`
+  - Works with `StatementExecutionResultFetcher`
+- [ ] Add REST API constructor to `CloudFetchDownloadManager`
+  - Accept `ICloudFetchResultFetcher` instead of Thrift dependencies
+  - Parse configuration from properties dictionary
+- [ ] Make `CloudFetchDownloader` statement parameter nullable
+  - Handle tracing when statement is null
+- [ ] Add missing properties to `StatementExecutionStatement`:
+  - Implement `ITracingStatement` interface
+  - Add `CatalogName`, `SchemaName`, `MaxRows`, `QueryTimeoutSeconds` properties
+- [ ] Unit tests for statement execution
+  - Test query execution with polling
+  - Test timeout and cancellation
+  - Test external links result handling
+  - Test schema conversion from REST API format
+
+**Files:**
+- `StatementExecution/StatementExecutionStatement.cs` (new)
+- `Reader/CloudFetch/CloudFetchArrayStreamReader.cs` (new)
+- `Reader/CloudFetch/CloudFetchDownloadManager.cs` (update constructor)
+- `Reader/CloudFetch/CloudFetchDownloader.cs` (make statement nullable)
+- Test files
+
+**Success Criteria:**
+- Can execute queries and poll for completion
+- External links results are downloaded via CloudFetch pipeline
+- Query timeout and cancellation work correctly
+- All unit tests pass
+
+---
+
+#### **PECO-2791-C: Inline Results Support**
+**Estimated Effort:** 1-2 days
+**Dependencies:** PECO-2791-B
+
+**Scope:**
+- [ ] Implement `InlineReader` class
+  - Parse inline Arrow stream data from `ResultChunk.Attachment`
+  - Handle multiple chunks in sequence
+- [ ] Update `StatementExecutionStatement` to support hybrid disposition
+  - Detect whether response has inline data or external links
+  - Create appropriate reader (InlineReader vs CloudFetchArrayStreamReader)
+  - Handle `inline_or_external_links` disposition
+  - Detect and log truncation warnings
+- [ ] Unit tests for inline results
+  - Test single-chunk inline results
+  - Test multi-chunk inline results
+  - Test hybrid disposition selection
+  - Test truncation warning detection
+
+**Files:**
+- `Reader/InlineReader.cs` (new)
+- `StatementExecution/StatementExecutionStatement.cs` (update)
+- Test files
+
+**Success Criteria:**
+- Can handle inline Arrow stream results
+- Hybrid disposition correctly chooses inline vs external based on response
+- Truncation warnings are detected and logged
+- All unit tests pass
+
+---
+
+#### **PECO-2791-D: Protocol Selection & Integration**
+**Estimated Effort:** 2-3 days
+**Dependencies:** PECO-2791-A, PECO-2791-B, PECO-2791-C
+
+**Scope:**
+- [ ] Add protocol selection logic to `DatabricksConnection`
+  - Check `adbc.databricks.protocol` parameter (default: "thrift")
+  - Route to Thrift or REST implementation
+  - Consider using strategy pattern or factory for cleaner design
+- [ ] Add missing `DatabricksParameters` constants:
+  - `ByteLimit`, `ResultFormat`, `ResultCompression` (if not present)
+  - `Protocol`, `EnableSessionManagement`, `ResultDisposition`, `PollingInterval`
+- [ ] Implement `IConnectionImpl` interface pattern (optional but recommended)
+  - Create abstraction for Thrift vs REST connection logic
+  - Helps keep `DatabricksConnection` clean
+- [ ] Fix .NET Framework compatibility issues
+  - `String.Split(char, StringSplitOptions)` overload not available in netstandard2.0/net472
+  - `TimestampType` constructor ambiguity
+- [ ] Integration smoke tests
+  - Test creating connection with protocol="rest"
+  - Test executing simple query end-to-end
+  - Test fallback to Thrift when protocol="thrift" or not specified
+
+**Files:**
+- `DatabricksConnection.cs` (update)
+- `DatabricksParameters.cs` (update)
+- Test files
+
+**Success Criteria:**
+- Can select REST protocol via configuration
+- Thrift remains default for backward compatibility
+- Simple queries work end-to-end with REST protocol
+- All framework targets build successfully
+- Integration smoke tests pass
+
+---
+
+#### **PECO-2791-E: End-to-End Testing & Documentation**
+**Estimated Effort:** 2-3 days
+**Dependencies:** PECO-2791-D
+
+**Scope:**
+- [ ] Comprehensive E2E tests with live warehouse
+  - Test query execution with various result sizes
+  - Test both inline and external links paths
+  - Test compression codecs (LZ4, GZIP, none)
+  - Test session management
+  - Test query timeout and cancellation
+  - Test error scenarios
+- [ ] Performance comparison vs Thrift
+  - Benchmark query execution time
+  - Measure memory usage
+  - Test with large result sets
+- [ ] Update documentation
+  - Add configuration examples to README
+  - Document protocol selection
+  - Migration guide from Thrift to REST
+- [ ] Update design doc with implementation notes
+  - Document any deviations from original design
+  - Add lessons learned
+  - Update architecture diagrams if needed
+
+**Files:**
+- E2E test files
+- README.md (update)
+- Design doc (update)
+
+**Success Criteria:**
+- All E2E tests pass with live warehouse
+- Performance is comparable to or better than Thrift
+- Documentation is complete and accurate
+- Design doc reflects actual implementation
+
+---
+
+### Future Work (Post-PECO-2791)
+
+#### **Phase 3: Feature Parity**
 - [ ] Implement parameterized queries
 - [ ] Support `JSON_ARRAY` and `CSV` formats
-- [ ] Implement statement cancellation
-- [ ] ADBC metadata operations via SQL queries
+- [ ] ADBC metadata operations via SQL queries (`GetObjects`, `GetTableTypes`, etc.)
+- [ ] Direct results mode (no polling, synchronous execution)
 
-### Phase 4: Optimization & Testing
-- [ ] Performance tuning (polling intervals, chunk sizes)
-- [ ] Comprehensive unit tests
-- [ ] E2E tests with live warehouse
-- [ ] Load testing and benchmarking vs Thrift
-- [ ] Documentation and migration guide
+#### **Phase 4: Advanced Features**
+- [ ] Support for result row/byte limits
+- [ ] Advanced error handling and retry logic
+- [ ] Connection pooling and session reuse
+- [ ] Metrics and observability
 
 ## Configuration Examples
 

--- a/csharp/doc/statement-execution-api-design.md
+++ b/csharp/doc/statement-execution-api-design.md
@@ -2359,33 +2359,43 @@ internal class StatementExecutionResultFetcher : BaseResultFetcher
 
 ### Current Sprint Tasks (PECO-2791 Breakdown)
 
-#### **PECO-2791-A: StatementExecutionConnection (Session Management)**
+#### **PECO-2791-A: StatementExecutionConnection (Session Management)** ✅
 **Estimated Effort:** 1-2 days
 **Dependencies:** PECO-2790
+**Status:** Completed (PECO-2837)
 
 **Scope:**
-- [ ] Implement `StatementExecutionConnection` class
+- [x] Implement `StatementExecutionConnection` class
   - Session lifecycle (create on open, delete on close)
   - Warehouse ID extraction from `http_path`
   - Parse catalog/schema from properties
   - Enable/disable session management configuration
-- [ ] Add missing constants to `DatabricksParameters`:
-  - `HttpPath`, `Catalog`, `Schema` (if not already present)
-- [ ] Unit tests for session management
+- [x] Unit tests for session management
   - Test session creation with valid warehouse ID
   - Test session deletion on dispose
   - Test warehouse ID extraction from various http_path formats
   - Test session management enable/disable
 
 **Files:**
-- `StatementExecution/StatementExecutionConnection.cs` (new)
-- `DatabricksParameters.cs` (update)
-- Test files
+- `StatementExecution/StatementExecutionConnection.cs` (new) ✅
+- `test/Unit/StatementExecution/StatementExecutionConnectionTests.cs` (new) ✅
+- `test/E2E/StatementExecution/StatementExecutionConnectionE2ETests.cs` (new) ✅
 
 **Success Criteria:**
-- Can create and delete sessions via REST API
-- Session management can be toggled via configuration
-- All unit tests pass
+- ✅ Can create and delete sessions via REST API
+- ✅ Session management can be toggled via configuration
+- ✅ All unit tests pass (20 tests)
+- ✅ All E2E tests pass (16 tests)
+- ✅ Total: 36 tests covering all scenarios
+
+**Implementation Notes:**
+- Uses **existing standard ADBC/Spark parameters** (no new parameters added):
+  - `adbc.spark.path` (SparkParameters.Path) for http_path/warehouse ID extraction
+  - `adbc.connection.catalog` (AdbcOptions.Connection.CurrentCatalog) for catalog
+  - `adbc.connection.db_schema` (AdbcOptions.Connection.CurrentDbSchema) for schema
+- Warehouse ID extraction supports both standard format (`/sql/1.0/warehouses/{id}`) and case-insensitive matching
+- Session deletion errors are swallowed to prevent masking other errors during cleanup
+- `CreateStatement()` method throws `NotImplementedException` with note about PECO-2791-B implementation
 
 ---
 

--- a/csharp/src/Reader/BaseDatabricksReader.cs
+++ b/csharp/src/Reader/BaseDatabricksReader.cs
@@ -40,7 +40,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader
         protected readonly bool isLz4Compressed;
         protected bool hasNoMoreRows = false;
         private bool isDisposed;
-        private bool isClosed;
 
         /// <summary>
         /// Gets the statement for this reader. Subclasses can decide how to provide it.
@@ -67,43 +66,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader
 
         protected override void Dispose(bool disposing)
         {
-            try
-            {
-                if (!isDisposed)
-                {
-                    if (disposing)
-                    {
-                        _ = CloseOperationAsync().Result;
-                    }
-                }
-            }
-            finally
+            if (!isDisposed)
             {
                 base.Dispose(disposing);
                 isDisposed = true;
-            }
-        }
-
-        /// <summary>
-        /// Closes the current operation.
-        /// </summary>
-        /// <returns>Returns true if the close operation completes successfully, false otherwise.</returns>
-        /// <exception cref="HiveServer2Exception" />
-        public async Task<bool> CloseOperationAsync()
-        {
-            try
-            {
-                if (!isClosed && response != null && Statement is IHiveServer2Statement hiveStatement)
-                {
-                    // Only close operation for Thrift protocol (which has IResponse)
-                    _ = await HiveServer2Reader.CloseOperationAsync(hiveStatement, this.response);
-                    return true;
-                }
-                return false;
-            }
-            finally
-            {
-                isClosed = true;
             }
         }
 

--- a/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Tracing;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 {
@@ -120,7 +121,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error stopping fetcher: {ex.Message}");
+                Activity.Current?.AddEvent("cloudfetch.fetcher_stop_error", [
+                    new("error_message", ex.Message)
+                ]);
             }
             finally
             {
@@ -210,7 +213,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Unhandled error in fetcher: {ex}");
+                Activity.Current?.AddEvent("cloudfetch.fetcher_unhandled_error", [
+                    new("error_message", ex.Message),
+                    new("error_type", ex.GetType().Name)
+                ]);
                 _error = ex;
                 _hasMoreResults = false;
                 _isCompleted = true;

--- a/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -123,6 +124,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 
         /// <inheritdoc />
         public abstract Task<IDownloadResult?> GetDownloadResultAsync(long offset, CancellationToken cancellationToken);
+
+        /// <inheritdoc />
+        public abstract Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(long startChunkIndex, long endChunkIndex, CancellationToken cancellationToken);
 
         /// <summary>
         /// Resets the fetcher state. Called at the beginning of StartAsync.

--- a/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/BaseResultFetcher.cs
@@ -1,0 +1,199 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
+{
+    /// <summary>
+    /// Base class for result fetchers that extract common pipeline management logic.
+    /// Subclasses implement protocol-specific fetching logic (Thrift, REST, etc.).
+    /// </summary>
+    internal abstract class BaseResultFetcher : ICloudFetchResultFetcher
+    {
+        protected readonly BlockingCollection<IDownloadResult> _downloadQueue;
+        protected readonly ICloudFetchMemoryBufferManager _memoryManager;
+        protected volatile bool _hasMoreResults;
+        protected volatile bool _isCompleted;
+        protected Exception? _error;
+        private Task? _fetchTask;
+        private CancellationTokenSource? _cancellationTokenSource;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseResultFetcher"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The memory buffer manager.</param>
+        /// <param name="downloadQueue">The queue to add download tasks to.</param>
+        protected BaseResultFetcher(
+            ICloudFetchMemoryBufferManager memoryManager,
+            BlockingCollection<IDownloadResult> downloadQueue)
+        {
+            _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
+            _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
+            _hasMoreResults = true;
+            _isCompleted = false;
+        }
+
+        /// <inheritdoc />
+        public bool HasMoreResults => _hasMoreResults;
+
+        /// <inheritdoc />
+        public bool IsCompleted => _isCompleted;
+
+        /// <inheritdoc />
+        public bool HasError => _error != null;
+
+        /// <inheritdoc />
+        public Exception? Error => _error;
+
+        /// <inheritdoc />
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (_fetchTask != null)
+            {
+                throw new InvalidOperationException("Fetcher is already running.");
+            }
+
+            // Reset state
+            _hasMoreResults = true;
+            _isCompleted = false;
+            _error = null;
+            ResetState();
+
+            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _fetchTask = FetchResultsWrapperAsync(_cancellationTokenSource.Token);
+
+            // Wait for the fetch task to start
+            await Task.Yield();
+        }
+
+        /// <inheritdoc />
+        public async Task StopAsync()
+        {
+            if (_fetchTask == null)
+            {
+                return;
+            }
+
+            _cancellationTokenSource?.Cancel();
+
+            try
+            {
+                await _fetchTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when cancellation is requested
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error stopping fetcher: {ex.Message}");
+            }
+            finally
+            {
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+                _fetchTask = null;
+            }
+        }
+
+        /// <inheritdoc />
+        public abstract Task<IDownloadResult?> GetDownloadResultAsync(long offset, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Resets the fetcher state. Called at the beginning of StartAsync.
+        /// Subclasses can override to reset protocol-specific state.
+        /// </summary>
+        protected virtual void ResetState()
+        {
+            // Base implementation does nothing. Subclasses can override.
+        }
+
+        /// <summary>
+        /// Protocol-specific logic to fetch all results and populate the download queue.
+        /// This method must add IDownloadResult objects to _downloadQueue using AddDownloadResult().
+        /// It should also set _hasMoreResults appropriately and throw exceptions on error.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        protected abstract Task FetchAllResultsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Helper method for subclasses to add download results to the queue.
+        /// </summary>
+        /// <param name="result">The download result to add.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        protected void AddDownloadResult(IDownloadResult result, CancellationToken cancellationToken)
+        {
+            _downloadQueue.Add(result, cancellationToken);
+        }
+
+        private async Task FetchResultsWrapperAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await FetchAllResultsAsync(cancellationToken).ConfigureAwait(false);
+
+                // Add the end of results guard to the queue
+                _downloadQueue.Add(EndOfResultsGuard.Instance, cancellationToken);
+                _isCompleted = true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Expected when cancellation is requested
+                _isCompleted = true;
+
+                // Add the end of results guard to the queue
+                try
+                {
+                    _downloadQueue.TryAdd(EndOfResultsGuard.Instance, 0);
+                }
+                catch (Exception)
+                {
+                    // Ignore any errors when adding the guard
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Unhandled error in fetcher: {ex.Message}");
+                _error = ex;
+                _hasMoreResults = false;
+                _isCompleted = true;
+
+                // Add the end of results guard to the queue even in case of error
+                try
+                {
+                    _downloadQueue.TryAdd(EndOfResultsGuard.Instance, 0);
+                }
+                catch (Exception)
+                {
+                    // Ignore any errors when adding the guard in case of error
+                }
+            }
+        }
+    }
+}

--- a/csharp/src/Reader/CloudFetch/CloudFetchConfiguration.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchConfiguration.cs
@@ -1,0 +1,190 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
+{
+    /// <summary>
+    /// Configuration for the CloudFetch download pipeline.
+    /// Protocol-agnostic - works with both Thrift and REST implementations.
+    /// </summary>
+    internal sealed class CloudFetchConfiguration
+    {
+        // Default values
+        private const int DefaultParallelDownloads = 3;
+        private const int DefaultPrefetchCount = 2;
+        private const int DefaultMemoryBufferSizeMB = 200;
+        private const int DefaultTimeoutMinutes = 5;
+        private const int DefaultMaxRetries = 3;
+        private const int DefaultRetryDelayMs = 500;
+        private const int DefaultMaxUrlRefreshAttempts = 3;
+        private const int DefaultUrlExpirationBufferSeconds = 60;
+
+        /// <summary>
+        /// Number of parallel downloads to perform.
+        /// </summary>
+        public int ParallelDownloads { get; set; } = DefaultParallelDownloads;
+
+        /// <summary>
+        /// Number of files to prefetch ahead of the reader.
+        /// </summary>
+        public int PrefetchCount { get; set; } = DefaultPrefetchCount;
+
+        /// <summary>
+        /// Memory buffer size limit in MB for buffered files.
+        /// </summary>
+        public int MemoryBufferSizeMB { get; set; } = DefaultMemoryBufferSizeMB;
+
+        /// <summary>
+        /// HTTP client timeout for downloads (in minutes).
+        /// </summary>
+        public int TimeoutMinutes { get; set; } = DefaultTimeoutMinutes;
+
+        /// <summary>
+        /// Maximum retry attempts for failed downloads.
+        /// </summary>
+        public int MaxRetries { get; set; } = DefaultMaxRetries;
+
+        /// <summary>
+        /// Delay between retry attempts (in milliseconds).
+        /// </summary>
+        public int RetryDelayMs { get; set; } = DefaultRetryDelayMs;
+
+        /// <summary>
+        /// Maximum attempts to refresh expired URLs.
+        /// </summary>
+        public int MaxUrlRefreshAttempts { get; set; } = DefaultMaxUrlRefreshAttempts;
+
+        /// <summary>
+        /// Buffer time before URL expiration to trigger refresh (in seconds).
+        /// </summary>
+        public int UrlExpirationBufferSeconds { get; set; } = DefaultUrlExpirationBufferSeconds;
+
+        /// <summary>
+        /// Whether the result data is LZ4 compressed.
+        /// </summary>
+        public bool IsLz4Compressed { get; set; }
+
+        /// <summary>
+        /// The Arrow schema for the results.
+        /// </summary>
+        public Schema Schema { get; set; }
+
+        /// <summary>
+        /// Creates configuration from connection properties.
+        /// Works with UNIFIED properties that are shared across ALL protocols (Thrift, REST, future protocols).
+        /// Same property names (e.g., "adbc.databricks.cloudfetch.parallel_downloads") work for all protocols.
+        /// </summary>
+        /// <param name="properties">Connection properties from either Thrift or REST connection.</param>
+        /// <param name="schema">Arrow schema for the results.</param>
+        /// <param name="isLz4Compressed">Whether results are LZ4 compressed.</param>
+        /// <returns>CloudFetch configuration parsed from unified properties.</returns>
+        public static CloudFetchConfiguration FromProperties(
+            IReadOnlyDictionary<string, string> properties,
+            Schema schema,
+            bool isLz4Compressed)
+        {
+            var config = new CloudFetchConfiguration
+            {
+                Schema = schema ?? throw new ArgumentNullException(nameof(schema)),
+                IsLz4Compressed = isLz4Compressed
+            };
+
+            // Parse parallel downloads
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchParallelDownloads, out string? parallelStr))
+            {
+                if (int.TryParse(parallelStr, out int parallel) && parallel > 0)
+                    config.ParallelDownloads = parallel;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchParallelDownloads}: {parallelStr}. Expected a positive integer.");
+            }
+
+            // Parse prefetch count
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchPrefetchCount, out string? prefetchStr))
+            {
+                if (int.TryParse(prefetchStr, out int prefetch) && prefetch > 0)
+                    config.PrefetchCount = prefetch;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchPrefetchCount}: {prefetchStr}. Expected a positive integer.");
+            }
+
+            // Parse memory buffer size
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchMemoryBufferSize, out string? memoryStr))
+            {
+                if (int.TryParse(memoryStr, out int memory) && memory > 0)
+                    config.MemoryBufferSizeMB = memory;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchMemoryBufferSize}: {memoryStr}. Expected a positive integer.");
+            }
+
+            // Parse timeout
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchTimeoutMinutes, out string? timeoutStr))
+            {
+                if (int.TryParse(timeoutStr, out int timeout) && timeout > 0)
+                    config.TimeoutMinutes = timeout;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchTimeoutMinutes}: {timeoutStr}. Expected a positive integer.");
+            }
+
+            // Parse max retries
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchMaxRetries, out string? retriesStr))
+            {
+                if (int.TryParse(retriesStr, out int retries) && retries > 0)
+                    config.MaxRetries = retries;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchMaxRetries}: {retriesStr}. Expected a positive integer.");
+            }
+
+            // Parse retry delay
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchRetryDelayMs, out string? retryDelayStr))
+            {
+                if (int.TryParse(retryDelayStr, out int retryDelay) && retryDelay > 0)
+                    config.RetryDelayMs = retryDelay;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchRetryDelayMs}: {retryDelayStr}. Expected a positive integer.");
+            }
+
+            // Parse max URL refresh attempts
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchMaxUrlRefreshAttempts, out string? maxUrlRefreshStr))
+            {
+                if (int.TryParse(maxUrlRefreshStr, out int maxUrlRefresh) && maxUrlRefresh > 0)
+                    config.MaxUrlRefreshAttempts = maxUrlRefresh;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchMaxUrlRefreshAttempts}: {maxUrlRefreshStr}. Expected a positive integer.");
+            }
+
+            // Parse URL expiration buffer
+            if (properties.TryGetValue(DatabricksParameters.CloudFetchUrlExpirationBufferSeconds, out string? urlExpirationStr))
+            {
+                if (int.TryParse(urlExpirationStr, out int urlExpiration) && urlExpiration > 0)
+                    config.UrlExpirationBufferSeconds = urlExpiration;
+                else
+                    throw new ArgumentException($"Invalid {DatabricksParameters.CloudFetchUrlExpirationBufferSeconds}: {urlExpirationStr}. Expected a positive integer.");
+            }
+
+            return config;
+        }
+    }
+}

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
@@ -82,6 +82,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 new ConcurrentQueue<IDownloadResult>(),
                 config.PrefetchCount * 2);
 
+            // Initialize the fetcher with manager-created resources (if it's a BaseResultFetcher)
+            if (_resultFetcher is BaseResultFetcher baseResultFetcher)
+            {
+                baseResultFetcher.Initialize(_memoryManager, _downloadQueue);
+            }
+
             // Initialize the downloader
             _downloader = new CloudFetchDownloader(
                 tracingStatement,

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
@@ -68,17 +68,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _schema = config?.Schema ?? throw new ArgumentNullException(nameof(config));
 
-            // Set HTTP client timeout (if HttpClient hasn't been used yet)
-            // HttpClient properties can only be modified before sending the first request
-            try
-            {
-                _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
-            }
-            catch (InvalidOperationException)
-            {
-                // HttpClient already used, timeout cannot be changed
-                // This is acceptable - the HttpClient may have been configured with an appropriate timeout already
-            }
+            // Set HTTP client timeout
+            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
 
             // Initialize the memory manager
             _memoryManager = new CloudFetchMemoryBufferManager(config.MemoryBufferSizeMB);
@@ -135,17 +126,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             // Parse configuration from properties
             var config = CloudFetchConfiguration.FromProperties(statement.Connection.Properties, schema, isLz4Compressed);
 
-            // Set HTTP client timeout (if HttpClient hasn't been used yet)
-            // HttpClient properties can only be modified before sending the first request
-            try
-            {
-                _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
-            }
-            catch (InvalidOperationException)
-            {
-                // HttpClient already used, timeout cannot be changed
-                // This is acceptable - the HttpClient may have been configured with an appropriate timeout already
-            }
+            // Set HTTP client timeout
+            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
 
             // Initialize shared resources
             _memoryManager = new CloudFetchMemoryBufferManager(config.MemoryBufferSizeMB);

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
@@ -28,43 +28,87 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
+using Apache.Arrow.Adbc.Tracing;
 using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 {
     /// <summary>
     /// Manages the CloudFetch download pipeline.
+    /// Protocol-agnostic - works with both Thrift and REST implementations.
     /// </summary>
     internal sealed class CloudFetchDownloadManager : ICloudFetchDownloadManager
     {
-        // Default values
-        private const int DefaultParallelDownloads = 3;
-        private const int DefaultPrefetchCount = 2;
-        private const int DefaultMemoryBufferSizeMB = 200;
-        private const bool DefaultPrefetchEnabled = true;
-        private const int DefaultTimeoutMinutes = 5;
-        private const int DefaultMaxUrlRefreshAttempts = 3;
-        private const int DefaultUrlExpirationBufferSeconds = 60;
-
-        private readonly IHiveServer2Statement _statement;
         private readonly Schema _schema;
-        private readonly bool _isLz4Compressed;
         private readonly ICloudFetchMemoryBufferManager _memoryManager;
         private readonly BlockingCollection<IDownloadResult> _downloadQueue;
         private readonly BlockingCollection<IDownloadResult> _resultQueue;
         private readonly ICloudFetchResultFetcher _resultFetcher;
         private readonly ICloudFetchDownloader _downloader;
-        private readonly HttpClient _httpClient;
+        private readonly HttpClient? _httpClient;
         private bool _isDisposed;
         private bool _isStarted;
         private CancellationTokenSource? _cancellationTokenSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchDownloadManager"/> class.
+        /// Protocol-agnostic constructor using dependency injection.
+        /// </summary>
+        /// <param name="resultFetcher">The result fetcher (protocol-specific).</param>
+        /// <param name="httpClient">The HTTP client for downloading files.</param>
+        /// <param name="config">The CloudFetch configuration.</param>
+        /// <param name="tracingStatement">Optional tracing statement for Activity tracking.</param>
+        public CloudFetchDownloadManager(
+            ICloudFetchResultFetcher resultFetcher,
+            HttpClient httpClient,
+            CloudFetchConfiguration config,
+            ITracingStatement? tracingStatement = null)
+        {
+            _resultFetcher = resultFetcher ?? throw new ArgumentNullException(nameof(resultFetcher));
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _schema = config?.Schema ?? throw new ArgumentNullException(nameof(config));
+
+            // Set HTTP client timeout
+            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
+
+            // Initialize the memory manager
+            _memoryManager = new CloudFetchMemoryBufferManager(config.MemoryBufferSizeMB);
+
+            // Initialize the queues with bounded capacity
+            _downloadQueue = new BlockingCollection<IDownloadResult>(
+                new ConcurrentQueue<IDownloadResult>(),
+                config.PrefetchCount * 2);
+            _resultQueue = new BlockingCollection<IDownloadResult>(
+                new ConcurrentQueue<IDownloadResult>(),
+                config.PrefetchCount * 2);
+
+            // Initialize the downloader
+            _downloader = new CloudFetchDownloader(
+                tracingStatement,
+                _downloadQueue,
+                _resultQueue,
+                _memoryManager,
+                _httpClient,
+                _resultFetcher,
+                config.ParallelDownloads,
+                config.IsLz4Compressed,
+                config.MaxRetries,
+                config.RetryDelayMs,
+                config.MaxUrlRefreshAttempts,
+                config.UrlExpirationBufferSeconds);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloudFetchDownloadManager"/> class.
+        /// Legacy Thrift-specific constructor for backward compatibility.
         /// </summary>
         /// <param name="statement">The HiveServer2 statement.</param>
         /// <param name="schema">The Arrow schema.</param>
+        /// <param name="response">The query response.</param>
+        /// <param name="initialResults">Initial results.</param>
         /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
+        /// <param name="httpClient">The HTTP client.</param>
+        [Obsolete("Use the protocol-agnostic constructor with CloudFetchConfiguration instead.")]
         public CloudFetchDownloadManager(
             IHiveServer2Statement statement,
             Schema schema,
@@ -73,185 +117,70 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             bool isLz4Compressed,
             HttpClient httpClient)
         {
-            _statement = statement ?? throw new ArgumentNullException(nameof(statement));
             _schema = schema ?? throw new ArgumentNullException(nameof(schema));
-            _isLz4Compressed = isLz4Compressed;
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
-            // Get configuration values from connection properties
-            var connectionProps = statement.Connection.Properties;
+            // Parse configuration from properties
+            var config = CloudFetchConfiguration.FromProperties(statement.Connection.Properties, schema, isLz4Compressed);
 
-            // Parse parallel downloads
-            int parallelDownloads = DefaultParallelDownloads;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchParallelDownloads, out string? parallelDownloadsStr))
-            {
-                if (int.TryParse(parallelDownloadsStr, out int parsedParallelDownloads) && parsedParallelDownloads > 0)
-                {
-                    parallelDownloads = parsedParallelDownloads;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchParallelDownloads}: {parallelDownloadsStr}. Expected a positive integer.");
-                }
-            }
+            // Set HTTP client timeout
+            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
 
-            // Parse prefetch count
-            int prefetchCount = DefaultPrefetchCount;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchPrefetchCount, out string? prefetchCountStr))
-            {
-                if (int.TryParse(prefetchCountStr, out int parsedPrefetchCount) && parsedPrefetchCount > 0)
-                {
-                    prefetchCount = parsedPrefetchCount;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchPrefetchCount}: {prefetchCountStr}. Expected a positive integer.");
-                }
-            }
+            // Initialize shared resources
+            _memoryManager = new CloudFetchMemoryBufferManager(config.MemoryBufferSizeMB);
+            _downloadQueue = new BlockingCollection<IDownloadResult>(
+                new ConcurrentQueue<IDownloadResult>(),
+                config.PrefetchCount * 2);
+            _resultQueue = new BlockingCollection<IDownloadResult>(
+                new ConcurrentQueue<IDownloadResult>(),
+                config.PrefetchCount * 2);
 
-            // Parse memory buffer size
-            int memoryBufferSizeMB = DefaultMemoryBufferSizeMB;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchMemoryBufferSize, out string? memoryBufferSizeStr))
-            {
-                if (int.TryParse(memoryBufferSizeStr, out int parsedMemoryBufferSize) && parsedMemoryBufferSize > 0)
-                {
-                    memoryBufferSizeMB = parsedMemoryBufferSize;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchMemoryBufferSize}: {memoryBufferSizeStr}. Expected a positive integer.");
-                }
-            }
-
-            // Parse max retries
-            int maxRetries = 3;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchMaxRetries, out string? maxRetriesStr))
-            {
-                if (int.TryParse(maxRetriesStr, out int parsedMaxRetries) && parsedMaxRetries > 0)
-                {
-                    maxRetries = parsedMaxRetries;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchMaxRetries}: {maxRetriesStr}. Expected a positive integer.");
-                }
-            }
-
-            // Parse retry delay
-            int retryDelayMs = 500;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchRetryDelayMs, out string? retryDelayStr))
-            {
-                if (int.TryParse(retryDelayStr, out int parsedRetryDelay) && parsedRetryDelay > 0)
-                {
-                    retryDelayMs = parsedRetryDelay;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchRetryDelayMs}: {retryDelayStr}. Expected a positive integer.");
-                }
-            }
-
-            // Parse timeout minutes
-            int timeoutMinutes = DefaultTimeoutMinutes;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchTimeoutMinutes, out string? timeoutStr))
-            {
-                if (int.TryParse(timeoutStr, out int parsedTimeout) && parsedTimeout > 0)
-                {
-                    timeoutMinutes = parsedTimeout;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchTimeoutMinutes}: {timeoutStr}. Expected a positive integer.");
-                }
-            }
-
-            // Parse URL expiration buffer seconds
-            int urlExpirationBufferSeconds = DefaultUrlExpirationBufferSeconds;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchUrlExpirationBufferSeconds, out string? urlExpirationBufferStr))
-            {
-                if (int.TryParse(urlExpirationBufferStr, out int parsedUrlExpirationBuffer) && parsedUrlExpirationBuffer > 0)
-                {
-                    urlExpirationBufferSeconds = parsedUrlExpirationBuffer;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchUrlExpirationBufferSeconds}: {urlExpirationBufferStr}. Expected a positive integer.");
-                }
-            }
-
-            // Parse max URL refresh attempts
-            int maxUrlRefreshAttempts = DefaultMaxUrlRefreshAttempts;
-            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchMaxUrlRefreshAttempts, out string? maxUrlRefreshAttemptsStr))
-            {
-                if (int.TryParse(maxUrlRefreshAttemptsStr, out int parsedMaxUrlRefreshAttempts) && parsedMaxUrlRefreshAttempts > 0)
-                {
-                    maxUrlRefreshAttempts = parsedMaxUrlRefreshAttempts;
-                }
-                else
-                {
-                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchMaxUrlRefreshAttempts}: {maxUrlRefreshAttemptsStr}. Expected a positive integer.");
-                }
-            }
-
-            // Initialize the memory manager
-            _memoryManager = new CloudFetchMemoryBufferManager(memoryBufferSizeMB);
-
-            // Initialize the queues with bounded capacity
-            _downloadQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), prefetchCount * 2);
-            _resultQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), prefetchCount * 2);
-
-            _httpClient = httpClient;
-            _httpClient.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
-
-            // Initialize the result fetcher with URL management capabilities
+            // Create result fetcher with shared resources
             _resultFetcher = new CloudFetchResultFetcher(
-                _statement,
+                statement,
                 response,
                 initialResults,
                 _memoryManager,
                 _downloadQueue,
-                _statement.BatchSize,
-                urlExpirationBufferSeconds);
+                statement.BatchSize,
+                config.UrlExpirationBufferSeconds);
 
-            // Initialize the downloader
+            // Create downloader with shared resources
             _downloader = new CloudFetchDownloader(
-                _statement,
+                statement as ITracingStatement,
                 _downloadQueue,
                 _resultQueue,
                 _memoryManager,
                 _httpClient,
                 _resultFetcher,
-                parallelDownloads,
-                _isLz4Compressed,
-                maxRetries,
-                retryDelayMs,
-                maxUrlRefreshAttempts,
-                urlExpirationBufferSeconds);
+                config.ParallelDownloads,
+                config.IsLz4Compressed,
+                config.MaxRetries,
+                config.RetryDelayMs,
+                config.MaxUrlRefreshAttempts,
+                config.UrlExpirationBufferSeconds);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchDownloadManager"/> class.
         /// This constructor is intended for testing purposes only.
         /// </summary>
-        /// <param name="statement">The HiveServer2 statement.</param>
         /// <param name="schema">The Arrow schema.</param>
-        /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
         /// <param name="resultFetcher">The result fetcher.</param>
         /// <param name="downloader">The downloader.</param>
+        /// <param name="memoryBufferSizeMB">Memory buffer size in MB for testing.</param>
         internal CloudFetchDownloadManager(
-            DatabricksStatement statement,
             Schema schema,
-            bool isLz4Compressed,
             ICloudFetchResultFetcher resultFetcher,
-            ICloudFetchDownloader downloader)
+            ICloudFetchDownloader downloader,
+            int memoryBufferSizeMB = 200)
         {
-            _statement = statement ?? throw new ArgumentNullException(nameof(statement));
             _schema = schema ?? throw new ArgumentNullException(nameof(schema));
-            _isLz4Compressed = isLz4Compressed;
             _resultFetcher = resultFetcher ?? throw new ArgumentNullException(nameof(resultFetcher));
             _downloader = downloader ?? throw new ArgumentNullException(nameof(downloader));
 
-            // Create empty collections for the test
-            _memoryManager = new CloudFetchMemoryBufferManager(DefaultMemoryBufferSizeMB);
+            // Create minimal resources for testing
+            _memoryManager = new CloudFetchMemoryBufferManager(memoryBufferSizeMB);
             _downloadQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), 10);
             _resultQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), 10);
             _httpClient = new HttpClient();

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
@@ -68,8 +68,17 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _schema = config?.Schema ?? throw new ArgumentNullException(nameof(config));
 
-            // Set HTTP client timeout
-            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
+            // Set HTTP client timeout (if HttpClient hasn't been used yet)
+            // HttpClient properties can only be modified before sending the first request
+            try
+            {
+                _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
+            }
+            catch (InvalidOperationException)
+            {
+                // HttpClient already used, timeout cannot be changed
+                // This is acceptable - the HttpClient may have been configured with an appropriate timeout already
+            }
 
             // Initialize the memory manager
             _memoryManager = new CloudFetchMemoryBufferManager(config.MemoryBufferSizeMB);
@@ -126,8 +135,17 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             // Parse configuration from properties
             var config = CloudFetchConfiguration.FromProperties(statement.Connection.Properties, schema, isLz4Compressed);
 
-            // Set HTTP client timeout
-            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
+            // Set HTTP client timeout (if HttpClient hasn't been used yet)
+            // HttpClient properties can only be modified before sending the first request
+            try
+            {
+                _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
+            }
+            catch (InvalidOperationException)
+            {
+                // HttpClient already used, timeout cannot be changed
+                // This is acceptable - the HttpClient may have been configured with an appropriate timeout already
+            }
 
             // Initialize shared resources
             _memoryManager = new CloudFetchMemoryBufferManager(config.MemoryBufferSizeMB);

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
@@ -82,11 +82,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 new ConcurrentQueue<IDownloadResult>(),
                 config.PrefetchCount * 2);
 
-            // Initialize the fetcher with manager-created resources (if it's a BaseResultFetcher)
-            if (_resultFetcher is BaseResultFetcher baseResultFetcher)
-            {
-                baseResultFetcher.Initialize(_memoryManager, _downloadQueue);
-            }
+            // Initialize the fetcher with manager-created resources
+            _resultFetcher.Initialize(_memoryManager, _downloadQueue);
 
             // Initialize the downloader
             _downloader = new CloudFetchDownloader(

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -147,7 +147,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Error stopping downloader: {ex.Message}");
+                Trace.WriteLine($"Error stopping downloader: {ex}");
             }
             finally
             {

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -147,7 +147,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error stopping downloader: {ex}");
+                Activity.Current?.AddEvent("cloudfetch.downloader_stop_error", [
+                    new("error_message", ex.Message),
+                    new("error_type", ex.GetType().Name)
+                ]);
             }
             finally
             {

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -266,14 +266,14 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Check if the URL is expired or about to expire
                         if (downloadResult.IsExpiredOrExpiringSoon(_urlExpirationBufferSeconds))
                         {
-                            // Get a refreshed URL before starting the download
-                            var refreshedLink = await _resultFetcher.GetUrlAsync(downloadResult.Link.StartRowOffset, cancellationToken);
-                            if (refreshedLink != null)
+                            // Get a refreshed download result before starting the download
+                            var refreshedResult = await _resultFetcher.GetDownloadResultAsync(downloadResult.StartRowOffset, cancellationToken);
+                            if (refreshedResult != null)
                             {
-                                // Update the download result with the refreshed link
-                                downloadResult.UpdateWithRefreshedLink(refreshedLink);
+                                // Update the download result with the refreshed URL
+                                downloadResult.UpdateWithRefreshedUrl(refreshedResult.FileUrl, refreshedResult.ExpirationTime, refreshedResult.HttpHeaders);
                                 activity?.AddEvent("cloudfetch.url_refreshed_before_download", [
-                                    new("offset", refreshedLink.StartRowOffset)
+                                    new("offset", refreshedResult.StartRowOffset)
                                 ]);
                             }
                         }
@@ -295,10 +295,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                                 if (t.IsFaulted)
                                 {
                                     Exception ex = t.Exception?.InnerException ?? new Exception("Unknown error");
-                                    string sanitizedUrl = SanitizeUrl(downloadResult.Link.FileLink);
+                                    string sanitizedUrl = SanitizeUrl(downloadResult.FileUrl);
                                     activity?.AddException(ex, [
                                         new("error.context", "cloudfetch.download_failed"),
-                                        new("offset", downloadResult.Link.StartRowOffset),
+                                        new("offset", downloadResult.StartRowOffset),
                                         new("sanitized_url", sanitizedUrl)
                                     ]);
 
@@ -369,15 +369,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         {
             await this.TraceActivityAsync(async activity =>
             {
-                string url = downloadResult.Link.FileLink;
-                string sanitizedUrl = SanitizeUrl(downloadResult.Link.FileLink);
+                string url = downloadResult.FileUrl;
+                string sanitizedUrl = SanitizeUrl(downloadResult.FileUrl);
                 byte[]? fileData = null;
 
                 // Use the size directly from the download result
                 long size = downloadResult.Size;
 
                 // Add tags to the Activity for filtering/searching
-                activity?.SetTag("cloudfetch.offset", downloadResult.Link.StartRowOffset);
+                activity?.SetTag("cloudfetch.offset", downloadResult.StartRowOffset);
                 activity?.SetTag("cloudfetch.sanitized_url", sanitizedUrl);
                 activity?.SetTag("cloudfetch.expected_size_bytes", size);
 
@@ -386,7 +386,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 
                 // Log download start
                 activity?.AddEvent("cloudfetch.download_start", [
-                new("offset", downloadResult.Link.StartRowOffset),
+                new("offset", downloadResult.StartRowOffset),
                     new("sanitized_url", sanitizedUrl),
                     new("expected_size_bytes", size),
                     new("expected_size_kb", size / 1024.0)
@@ -400,9 +400,21 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 {
                     try
                     {
+                        // Create HTTP request with optional custom headers
+                        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+                        // Add custom headers if provided
+                        if (downloadResult.HttpHeaders != null)
+                        {
+                            foreach (var header in downloadResult.HttpHeaders)
+                            {
+                                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                            }
+                        }
+
                         // Download the file directly
-                        using HttpResponseMessage response = await _httpClient.GetAsync(
-                            url,
+                        using HttpResponseMessage response = await _httpClient.SendAsync(
+                            request,
                             HttpCompletionOption.ResponseHeadersRead,
                             cancellationToken).ConfigureAwait(false);
 
@@ -417,16 +429,16 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                             }
 
                             // Try to refresh the URL
-                            var refreshedLink = await _resultFetcher.GetUrlAsync(downloadResult.Link.StartRowOffset, cancellationToken);
-                            if (refreshedLink != null)
+                            var refreshedResult = await _resultFetcher.GetDownloadResultAsync(downloadResult.StartRowOffset, cancellationToken);
+                            if (refreshedResult != null)
                             {
-                                // Update the download result with the refreshed link
-                                downloadResult.UpdateWithRefreshedLink(refreshedLink);
-                                url = refreshedLink.FileLink;
+                                // Update the download result with the refreshed URL
+                                downloadResult.UpdateWithRefreshedUrl(refreshedResult.FileUrl, refreshedResult.ExpirationTime, refreshedResult.HttpHeaders);
+                                url = refreshedResult.FileUrl;
                                 sanitizedUrl = SanitizeUrl(url);
 
                                 activity?.AddEvent("cloudfetch.url_refreshed_after_auth_error", [
-                                    new("offset", refreshedLink.StartRowOffset),
+                                    new("offset", refreshedResult.StartRowOffset),
                                     new("sanitized_url", sanitizedUrl)
                                 ]);
 
@@ -447,7 +459,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         if (contentLength.HasValue && contentLength.Value > 0)
                         {
                             activity?.AddEvent("cloudfetch.content_length", [
-                                new("offset", downloadResult.Link.StartRowOffset),
+                                new("offset", downloadResult.StartRowOffset),
                                 new("sanitized_url", sanitizedUrl),
                                 new("content_length_bytes", contentLength.Value),
                                 new("content_length_mb", contentLength.Value / 1024.0 / 1024.0)
@@ -463,7 +475,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Log the error and retry
                         activity?.AddException(ex, [
                             new("error.context", "cloudfetch.download_retry"),
-                            new("offset", downloadResult.Link.StartRowOffset),
+                            new("offset", downloadResult.StartRowOffset),
                             new("sanitized_url", SanitizeUrl(url)),
                             new("attempt", retry + 1),
                             new("max_retries", _maxRetries)
@@ -477,7 +489,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 {
                     stopwatch.Stop();
                     activity?.AddEvent("cloudfetch.download_failed_all_retries", [
-                        new("offset", downloadResult.Link.StartRowOffset),
+                        new("offset", downloadResult.StartRowOffset),
                         new("sanitized_url", sanitizedUrl),
                         new("max_retries", _maxRetries),
                         new("elapsed_time_ms", stopwatch.ElapsedMilliseconds)
@@ -508,7 +520,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         decompressStopwatch.Stop();
 
                         activity?.AddEvent("cloudfetch.decompression_complete", [
-                            new("offset", downloadResult.Link.StartRowOffset),
+                            new("offset", downloadResult.StartRowOffset),
                             new("sanitized_url", sanitizedUrl),
                             new("decompression_time_ms", decompressStopwatch.ElapsedMilliseconds),
                             new("compressed_size_bytes", actualSize),
@@ -525,7 +537,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         stopwatch.Stop();
                         activity?.AddException(ex, [
                             new("error.context", "cloudfetch.decompression"),
-                            new("offset", downloadResult.Link.StartRowOffset),
+                            new("offset", downloadResult.StartRowOffset),
                             new("sanitized_url", sanitizedUrl),
                             new("elapsed_time_ms", stopwatch.ElapsedMilliseconds)
                         ]);
@@ -544,7 +556,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 stopwatch.Stop();
                 double throughputMBps = (actualSize / 1024.0 / 1024.0) / (stopwatch.ElapsedMilliseconds / 1000.0);
                 activity?.AddEvent("cloudfetch.download_complete", [
-                    new("offset", downloadResult.Link.StartRowOffset),
+                    new("offset", downloadResult.StartRowOffset),
                     new("sanitized_url", sanitizedUrl),
                     new("actual_size_bytes", actualSize),
                     new("actual_size_kb", actualSize / 1024.0),

--- a/csharp/src/Reader/CloudFetch/CloudFetchReader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchReader.cs
@@ -157,7 +157,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                             }
                             catch (Exception ex)
                             {
-                                Debug.WriteLine($"Error creating Arrow reader: {ex.Message}");
+                                Trace.WriteLine($"Error creating Arrow reader: {ex}");
                                 this.currentDownloadResult.Dispose();
                                 this.currentDownloadResult = null;
                                 throw;
@@ -165,7 +165,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         }
                         catch (Exception ex)
                         {
-                            Debug.WriteLine($"Error getting next downloaded file: {ex.Message}");
+                            Trace.WriteLine($"Error getting next downloaded file: {ex}");
                             throw;
                         }
                     }

--- a/csharp/src/Reader/CloudFetch/CloudFetchReader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchReader.cs
@@ -157,7 +157,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                             }
                             catch (Exception ex)
                             {
-                                Trace.WriteLine($"Error creating Arrow reader: {ex}");
+                                Activity.Current?.AddEvent("cloudfetch.arrow_reader_creation_error", [
+                                    new("error_message", ex.Message),
+                                    new("error_type", ex.GetType().Name)
+                                ]);
                                 this.currentDownloadResult.Dispose();
                                 this.currentDownloadResult = null;
                                 throw;
@@ -165,7 +168,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         }
                         catch (Exception ex)
                         {
-                            Trace.WriteLine($"Error getting next downloaded file: {ex}");
+                            Activity.Current?.AddEvent("cloudfetch.get_next_file_error", [
+                                new("error_message", ex.Message),
+                                new("error_type", ex.GetType().Name)
+                            ]);
                             throw;
                         }
                     }

--- a/csharp/src/Reader/CloudFetch/CloudFetchReader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchReader.cs
@@ -47,15 +47,16 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchReader"/> class.
         /// Protocol-agnostic constructor using dependency injection.
+        /// Works with both Thrift (IHiveServer2Statement) and REST (StatementExecutionStatement) protocols.
         /// </summary>
-        /// <param name="statement">The HiveServer2 statement for tracing and operation closure.</param>
+        /// <param name="statement">The tracing statement (ITracingStatement works for both protocols).</param>
         /// <param name="schema">The Arrow schema.</param>
-        /// <param name="response">The query response for operation closure.</param>
+        /// <param name="response">The query response (nullable for REST API, which doesn't use IResponse).</param>
         /// <param name="downloadManager">The download manager (already initialized and started).</param>
         public CloudFetchReader(
-            IHiveServer2Statement statement,
+            ITracingStatement statement,
             Schema schema,
-            IResponse response,
+            IResponse? response,
             ICloudFetchDownloadManager downloadManager)
             : base(statement, schema, response, isLz4Compressed: false) // isLz4Compressed handled by download manager
         {

--- a/csharp/src/Reader/CloudFetch/CloudFetchResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchResultFetcher.cs
@@ -192,7 +192,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 }
                 catch (Exception ex)
                 {
-                    Trace.WriteLine($"Error fetching results: {ex}");
+                    Activity.Current?.AddEvent("cloudfetch.fetch_results_error", [
+                        new("error_message", ex.Message),
+                        new("error_type", ex.GetType().Name)
+                    ]);
                     _error = ex;
                     _hasMoreResults = false;
                     throw;
@@ -230,7 +233,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Error fetching results from server: {ex}");
+                Activity.Current?.AddEvent("cloudfetch.fetch_from_server_error", [
+                    new("error_message", ex.Message),
+                    new("error_type", ex.GetType().Name)
+                ]);
                 _hasMoreResults = false;
                 throw;
             }

--- a/csharp/src/Reader/CloudFetch/CloudFetchResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchResultFetcher.cs
@@ -38,29 +38,24 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
     /// <summary>
     /// Fetches result chunks from the Thrift server and manages URL caching and refreshing.
     /// </summary>
-    internal class CloudFetchResultFetcher : ICloudFetchResultFetcher
+    internal class CloudFetchResultFetcher : BaseResultFetcher
     {
         private readonly IHiveServer2Statement _statement;
         private readonly IResponse _response;
         private readonly TFetchResultsResp? _initialResults;
-        private readonly ICloudFetchMemoryBufferManager _memoryManager;
-        private readonly BlockingCollection<IDownloadResult> _downloadQueue;
         private readonly SemaphoreSlim _fetchLock = new SemaphoreSlim(1, 1);
         private readonly ConcurrentDictionary<long, IDownloadResult> _urlsByOffset = new ConcurrentDictionary<long, IDownloadResult>();
         private readonly int _expirationBufferSeconds;
         private readonly IClock _clock;
         private long _startOffset;
-        private bool _hasMoreResults;
-        private bool _isCompleted;
-        private Task? _fetchTask;
-        private CancellationTokenSource? _cancellationTokenSource;
-        private Exception? _error;
         private long _batchSize;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchResultFetcher"/> class.
         /// </summary>
         /// <param name="statement">The HiveServer2 statement interface.</param>
+        /// <param name="response">The query response.</param>
+        /// <param name="initialResults">Initial results, if available.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
         /// <param name="downloadQueue">The queue to add download tasks to.</param>
         /// <param name="batchSize">The number of rows to fetch in each batch.</param>
@@ -75,89 +70,30 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             long batchSize,
             int expirationBufferSeconds = 60,
             IClock? clock = null)
+            : base(memoryManager, downloadQueue)
         {
             _statement = statement ?? throw new ArgumentNullException(nameof(statement));
             _response = response;
             _initialResults = initialResults;
-            _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
-            _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
             _batchSize = batchSize;
             _expirationBufferSeconds = expirationBufferSeconds;
             _clock = clock ?? new SystemClock();
-            _hasMoreResults = true;
-            _isCompleted = false;
         }
 
         /// <inheritdoc />
-        public bool HasMoreResults => _hasMoreResults;
-
-        /// <inheritdoc />
-        public bool IsCompleted => _isCompleted;
-
-        /// <inheritdoc />
-        public bool HasError => _error != null;
-
-        /// <inheritdoc />
-        public Exception? Error => _error;
-
-        /// <inheritdoc />
-        public async Task StartAsync(CancellationToken cancellationToken)
+        protected override void ResetState()
         {
-            if (_fetchTask != null)
-            {
-                throw new InvalidOperationException("Fetcher is already running.");
-            }
-
-            // Reset state
             _startOffset = 0;
-            _hasMoreResults = true;
-            _isCompleted = false;
-            _error = null;
             _urlsByOffset.Clear();
-
-            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _fetchTask = FetchResultsAsync(_cancellationTokenSource.Token);
-
-            // Wait for the fetch task to start
-            await Task.Yield();
         }
 
         /// <inheritdoc />
-        public async Task StopAsync()
-        {
-            if (_fetchTask == null)
-            {
-                return;
-            }
-
-            _cancellationTokenSource?.Cancel();
-
-            try
-            {
-                await _fetchTask.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected when cancellation is requested
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Error stopping fetcher: {ex.Message}");
-            }
-            finally
-            {
-                _cancellationTokenSource?.Dispose();
-                _cancellationTokenSource = null;
-                _fetchTask = null;
-            }
-        }
-        /// <inheritdoc />
-        public async Task<TSparkArrowResultLink?> GetUrlAsync(long offset, CancellationToken cancellationToken)
+        public override async Task<IDownloadResult?> GetDownloadResultAsync(long offset, CancellationToken cancellationToken)
         {
             // Check if we have a non-expired URL in the cache
             if (_urlsByOffset.TryGetValue(offset, out var cachedResult) && !cachedResult.IsExpiredOrExpiringSoon(_expirationBufferSeconds))
             {
-                return cachedResult.Link;
+                return cachedResult;
             }
 
             // Need to fetch or refresh the URL
@@ -192,11 +128,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                             new("url_length", refreshedLink.FileLink?.Length ?? 0)
                         ]);
 
-                        // Create a download result for the refreshed link
-                        var downloadResult = new DownloadResult(refreshedLink, _memoryManager);
+                        // Create a download result for the refreshed link using factory method
+                        var downloadResult = DownloadResult.FromThriftLink(refreshedLink, _memoryManager);
                         _urlsByOffset[offset] = downloadResult;
 
-                        return refreshedLink;
+                        return downloadResult;
                     }
                 }
 
@@ -210,12 +146,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         }
 
         /// <summary>
-        /// Gets all currently cached URLs.
+        /// Gets all currently cached download results.
         /// </summary>
-        /// <returns>A dictionary mapping offsets to their URL links.</returns>
-        public Dictionary<long, TSparkArrowResultLink> GetAllCachedUrls()
+        /// <returns>A dictionary mapping offsets to their download results.</returns>
+        public Dictionary<long, IDownloadResult> GetAllCachedResults()
         {
-            return _urlsByOffset.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Link);
+            return _urlsByOffset.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         /// <summary>
@@ -226,61 +162,38 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             _urlsByOffset.Clear();
         }
 
-        private async Task FetchResultsAsync(CancellationToken cancellationToken)
+        /// <inheritdoc />
+        protected override async Task FetchAllResultsAsync(CancellationToken cancellationToken)
         {
-            try
+            // Process direct results first, if available
+            if ((_statement.TryGetDirectResults(_response, out TSparkDirectResults? directResults)
+                && directResults!.ResultSet?.Results?.ResultLinks?.Count > 0)
+                || _initialResults?.Results?.ResultLinks?.Count > 0)
             {
-                // Process direct results first, if available
-                if ((_statement.TryGetDirectResults(_response, out TSparkDirectResults? directResults)
-                    && directResults!.ResultSet?.Results?.ResultLinks?.Count > 0)
-                    || _initialResults?.Results?.ResultLinks?.Count > 0)
-                {
-                    // Yield execution so the download queue doesn't get blocked before downloader is started
-                    await Task.Yield();
-                    ProcessDirectResultsAsync(cancellationToken);
-                }
-
-                // Continue fetching as needed
-                while (_hasMoreResults && !cancellationToken.IsCancellationRequested)
-                {
-                    try
-                    {
-                        // Fetch more results from the server
-                        await FetchNextResultBatchAsync(null, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                    {
-                        // Expected when cancellation is requested
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine($"Error fetching results: {ex.Message}");
-                        _error = ex;
-                        _hasMoreResults = false;
-                        throw;
-                    }
-                }
-
-                // Add the end of results guard to the queue
-                _downloadQueue.Add(EndOfResultsGuard.Instance, cancellationToken);
-                _isCompleted = true;
+                // Yield execution so the download queue doesn't get blocked before downloader is started
+                await Task.Yield();
+                ProcessDirectResultsAsync(cancellationToken);
             }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Unhandled error in fetcher: {ex.Message}");
-                _error = ex;
-                _hasMoreResults = false;
-                _isCompleted = true;
 
-                // Add the end of results guard to the queue even in case of error
+            // Continue fetching as needed
+            while (_hasMoreResults && !cancellationToken.IsCancellationRequested)
+            {
                 try
                 {
-                    _downloadQueue.TryAdd(EndOfResultsGuard.Instance, 0);
+                    // Fetch more results from the server
+                    await FetchNextResultBatchAsync(null, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // Ignore any errors when adding the guard in case of error
+                    // Expected when cancellation is requested
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error fetching results: {ex.Message}");
+                    _error = ex;
+                    _hasMoreResults = false;
+                    throw;
                 }
             }
         }
@@ -331,11 +244,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 // Process each link
                 foreach (var link in resultLinks)
                 {
-                    // Create download result
-                    var downloadResult = new DownloadResult(link, _memoryManager);
+                    // Create download result using factory method
+                    var downloadResult = DownloadResult.FromThriftLink(link, _memoryManager);
 
                     // Add to download queue and cache
-                    _downloadQueue.Add(downloadResult, cancellationToken);
+                    AddDownloadResult(downloadResult, cancellationToken);
                     _urlsByOffset[link.StartRowOffset] = downloadResult;
 
                     // Track the maximum offset for future fetches
@@ -379,11 +292,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             // Process each link
             foreach (var link in resultLinks)
             {
-                // Create download result
-                var downloadResult = new DownloadResult(link, _memoryManager);
+                // Create download result using factory method
+                var downloadResult = DownloadResult.FromThriftLink(link, _memoryManager);
 
                 // Add to download queue and cache
-                _downloadQueue.Add(downloadResult, cancellationToken);
+                AddDownloadResult(downloadResult, cancellationToken);
                 _urlsByOffset[link.StartRowOffset] = downloadResult;
 
                 // Track the maximum offset for future fetches

--- a/csharp/src/Reader/CloudFetch/DownloadResult.cs
+++ b/csharp/src/Reader/CloudFetch/DownloadResult.cs
@@ -22,6 +22,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Apache.Hive.Service.Rpc.Thrift;
@@ -38,22 +39,80 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         private Stream? _dataStream;
         private bool _isDisposed;
         private long _size;
+        private string _fileUrl;
+        private DateTime _expirationTime;
+        private IReadOnlyDictionary<string, string>? _httpHeaders;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DownloadResult"/> class.
         /// </summary>
-        /// <param name="link">The link information for this result.</param>
+        /// <param name="fileUrl">The URL for downloading the file.</param>
+        /// <param name="startRowOffset">The starting row offset for this result chunk.</param>
+        /// <param name="rowCount">The number of rows in this result chunk.</param>
+        /// <param name="byteCount">The size in bytes of this result chunk.</param>
+        /// <param name="expirationTime">The expiration time of the URL in UTC.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
-        public DownloadResult(TSparkArrowResultLink link, ICloudFetchMemoryBufferManager memoryManager)
+        /// <param name="httpHeaders">Optional HTTP headers for downloading the file.</param>
+        public DownloadResult(
+            string fileUrl,
+            long startRowOffset,
+            long rowCount,
+            long byteCount,
+            DateTime expirationTime,
+            ICloudFetchMemoryBufferManager memoryManager,
+            IReadOnlyDictionary<string, string>? httpHeaders = null)
         {
-            Link = link ?? throw new ArgumentNullException(nameof(link));
+            _fileUrl = fileUrl ?? throw new ArgumentNullException(nameof(fileUrl));
+            StartRowOffset = startRowOffset;
+            RowCount = rowCount;
+            ByteCount = byteCount;
+            _expirationTime = expirationTime;
             _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
+            _httpHeaders = httpHeaders;
             _downloadCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _size = link.BytesNum;
+            _size = byteCount;
+        }
+
+        /// <summary>
+        /// Creates a DownloadResult from a Thrift link for backward compatibility.
+        /// </summary>
+        /// <param name="link">The Thrift link information.</param>
+        /// <param name="memoryManager">The memory buffer manager.</param>
+        /// <returns>A new DownloadResult instance.</returns>
+        public static DownloadResult FromThriftLink(TSparkArrowResultLink link, ICloudFetchMemoryBufferManager memoryManager)
+        {
+            if (link == null) throw new ArgumentNullException(nameof(link));
+            if (memoryManager == null) throw new ArgumentNullException(nameof(memoryManager));
+
+            var expirationTime = DateTimeOffset.FromUnixTimeMilliseconds(link.ExpiryTime).UtcDateTime;
+
+            return new DownloadResult(
+                fileUrl: link.FileLink,
+                startRowOffset: link.StartRowOffset,
+                rowCount: link.RowCount,
+                byteCount: link.BytesNum,
+                expirationTime: expirationTime,
+                memoryManager: memoryManager,
+                httpHeaders: null);
         }
 
         /// <inheritdoc />
-        public TSparkArrowResultLink Link { get; private set; }
+        public string FileUrl => _fileUrl;
+
+        /// <inheritdoc />
+        public long StartRowOffset { get; }
+
+        /// <inheritdoc />
+        public long RowCount { get; }
+
+        /// <inheritdoc />
+        public long ByteCount { get; }
+
+        /// <inheritdoc />
+        public DateTime ExpirationTime => _expirationTime;
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, string>? HttpHeaders => _httpHeaders;
 
         /// <inheritdoc />
         public Stream DataStream
@@ -90,21 +149,22 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <returns>True if the URL is expired or about to expire, false otherwise.</returns>
         public bool IsExpiredOrExpiringSoon(int expirationBufferSeconds = 60)
         {
-            // Convert expiry time to DateTime
-            var expiryTime = DateTimeOffset.FromUnixTimeMilliseconds(Link.ExpiryTime).UtcDateTime;
-
             // Check if the URL is already expired or will expire soon
-            return DateTime.UtcNow.AddSeconds(expirationBufferSeconds) >= expiryTime;
+            return DateTime.UtcNow.AddSeconds(expirationBufferSeconds) >= _expirationTime;
         }
 
         /// <summary>
-        /// Updates this download result with a refreshed link.
+        /// Updates this download result with a refreshed URL and expiration time.
         /// </summary>
-        /// <param name="refreshedLink">The refreshed link information.</param>
-        public void UpdateWithRefreshedLink(TSparkArrowResultLink refreshedLink)
+        /// <param name="fileUrl">The refreshed file URL.</param>
+        /// <param name="expirationTime">The new expiration time.</param>
+        /// <param name="httpHeaders">Optional HTTP headers for the refreshed URL.</param>
+        public void UpdateWithRefreshedUrl(string fileUrl, DateTime expirationTime, IReadOnlyDictionary<string, string>? httpHeaders = null)
         {
             ThrowIfDisposed();
-            Link = refreshedLink ?? throw new ArgumentNullException(nameof(refreshedLink));
+            _fileUrl = fileUrl ?? throw new ArgumentNullException(nameof(fileUrl));
+            _expirationTime = expirationTime;
+            _httpHeaders = httpHeaders;
             RefreshAttempts++;
         }
 

--- a/csharp/src/Reader/CloudFetch/DownloadResult.cs
+++ b/csharp/src/Reader/CloudFetch/DownloadResult.cs
@@ -46,6 +46,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <summary>
         /// Initializes a new instance of the <see cref="DownloadResult"/> class.
         /// </summary>
+        /// <param name="chunkIndex">The chunk index for this download result.</param>
         /// <param name="fileUrl">The URL for downloading the file.</param>
         /// <param name="startRowOffset">The starting row offset for this result chunk.</param>
         /// <param name="rowCount">The number of rows in this result chunk.</param>
@@ -54,6 +55,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <param name="memoryManager">The memory buffer manager.</param>
         /// <param name="httpHeaders">Optional HTTP headers for downloading the file.</param>
         public DownloadResult(
+            long chunkIndex,
             string fileUrl,
             long startRowOffset,
             long rowCount,
@@ -62,6 +64,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             ICloudFetchMemoryBufferManager memoryManager,
             IReadOnlyDictionary<string, string>? httpHeaders = null)
         {
+            ChunkIndex = chunkIndex;
             _fileUrl = fileUrl ?? throw new ArgumentNullException(nameof(fileUrl));
             StartRowOffset = startRowOffset;
             RowCount = rowCount;
@@ -76,10 +79,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <summary>
         /// Creates a DownloadResult from a Thrift link for backward compatibility.
         /// </summary>
+        /// <param name="chunkIndex">The chunk index for this download result.</param>
         /// <param name="link">The Thrift link information.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
         /// <returns>A new DownloadResult instance.</returns>
-        public static DownloadResult FromThriftLink(TSparkArrowResultLink link, ICloudFetchMemoryBufferManager memoryManager)
+        public static DownloadResult FromThriftLink(long chunkIndex, TSparkArrowResultLink link, ICloudFetchMemoryBufferManager memoryManager)
         {
             if (link == null) throw new ArgumentNullException(nameof(link));
             if (memoryManager == null) throw new ArgumentNullException(nameof(memoryManager));
@@ -87,6 +91,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             var expirationTime = DateTimeOffset.FromUnixTimeMilliseconds(link.ExpiryTime).UtcDateTime;
 
             return new DownloadResult(
+                chunkIndex: chunkIndex,
                 fileUrl: link.FileLink,
                 startRowOffset: link.StartRowOffset,
                 rowCount: link.RowCount,
@@ -95,6 +100,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 memoryManager: memoryManager,
                 httpHeaders: null);
         }
+
+        /// <inheritdoc />
+        public long ChunkIndex { get; }
 
         /// <inheritdoc />
         public string FileUrl => _fileUrl;

--- a/csharp/src/Reader/CloudFetch/EndOfResultsGuard.cs
+++ b/csharp/src/Reader/CloudFetch/EndOfResultsGuard.cs
@@ -22,9 +22,9 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 {
@@ -46,7 +46,22 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         }
 
         /// <inheritdoc />
-        public TSparkArrowResultLink Link => throw new NotSupportedException("EndOfResultsGuard does not have a link.");
+        public string FileUrl => throw new NotSupportedException("EndOfResultsGuard does not have a file URL.");
+
+        /// <inheritdoc />
+        public long StartRowOffset => 0;
+
+        /// <inheritdoc />
+        public long RowCount => 0;
+
+        /// <inheritdoc />
+        public long ByteCount => 0;
+
+        /// <inheritdoc />
+        public DateTime ExpirationTime => DateTime.MinValue;
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, string>? HttpHeaders => null;
 
         /// <inheritdoc />
         public Stream DataStream => throw new NotSupportedException("EndOfResultsGuard does not have a data stream.");
@@ -70,7 +85,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         public void SetFailed(Exception exception) => throw new NotSupportedException("EndOfResultsGuard cannot fail.");
 
         /// <inheritdoc />
-        public void UpdateWithRefreshedLink(TSparkArrowResultLink refreshedLink) => throw new NotSupportedException("EndOfResultsGuard cannot be updated with a refreshed link.");
+        public void UpdateWithRefreshedUrl(string fileUrl, DateTime expirationTime, IReadOnlyDictionary<string, string>? httpHeaders = null) =>
+            throw new NotSupportedException("EndOfResultsGuard cannot be updated with a refreshed URL.");
 
         /// <inheritdoc />
         public bool IsExpiredOrExpiringSoon(int expirationBufferSeconds = 60) => false;

--- a/csharp/src/Reader/CloudFetch/EndOfResultsGuard.cs
+++ b/csharp/src/Reader/CloudFetch/EndOfResultsGuard.cs
@@ -46,6 +46,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         }
 
         /// <inheritdoc />
+        public long ChunkIndex => -1;
+
+        /// <inheritdoc />
         public string FileUrl => throw new NotSupportedException("EndOfResultsGuard does not have a file URL.");
 
         /// <inheritdoc />

--- a/csharp/src/Reader/CloudFetch/ICloudFetchInterfaces.cs
+++ b/csharp/src/Reader/CloudFetch/ICloudFetchInterfaces.cs
@@ -36,6 +36,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
     internal interface IDownloadResult : IDisposable
     {
         /// <summary>
+        /// Gets the chunk index for this download result.
+        /// Used for targeted URL refresh in REST API.
+        /// </summary>
+        long ChunkIndex { get; }
+
+        /// <summary>
         /// Gets the URL for downloading the file.
         /// </summary>
         string FileUrl { get; }
@@ -202,6 +208,16 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The download result for the specified offset, or null if not available.</returns>
         Task<IDownloadResult?> GetDownloadResultAsync(long offset, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Re-fetches URLs for chunks in the specified range.
+        /// Used when URLs expire before download completes.
+        /// </summary>
+        /// <param name="startChunkIndex">The starting chunk index (inclusive).</param>
+        /// <param name="endChunkIndex">The ending chunk index (inclusive).</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A collection of download results with refreshed URLs.</returns>
+        Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(long startChunkIndex, long endChunkIndex, CancellationToken cancellationToken);
     }
 
     /// <summary>

--- a/csharp/src/Reader/CloudFetch/ICloudFetchInterfaces.cs
+++ b/csharp/src/Reader/CloudFetch/ICloudFetchInterfaces.cs
@@ -22,6 +22,7 @@
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -202,6 +203,14 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         Exception? Error { get; }
 
         /// <summary>
+        /// Initializes the fetcher with manager-created resources.
+        /// Called by CloudFetchDownloadManager after creating shared resources.
+        /// </summary>
+        /// <param name="memoryManager">The memory buffer manager.</param>
+        /// <param name="downloadQueue">The download queue.</param>
+        void Initialize(ICloudFetchMemoryBufferManager memoryManager, BlockingCollection<IDownloadResult> downloadQueue);
+
+        /// <summary>
         /// Gets a download result for the specified offset, fetching or refreshing as needed.
         /// </summary>
         /// <param name="offset">The row offset for which to get a download result.</param>
@@ -213,11 +222,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// Re-fetches URLs for chunks in the specified range.
         /// Used when URLs expire before download completes.
         /// </summary>
-        /// <param name="startChunkIndex">The starting chunk index (inclusive).</param>
-        /// <param name="endChunkIndex">The ending chunk index (inclusive).</param>
+        /// <param name="startRowOffset">The starting row offset to fetch from (for Thrift protocol).</param>
+        /// <param name="startChunkIndex">The starting chunk index (inclusive, for REST protocol).</param>
+        /// <param name="endChunkIndex">The ending chunk index (inclusive, for REST protocol).</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A collection of download results with refreshed URLs.</returns>
-        Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(long startChunkIndex, long endChunkIndex, CancellationToken cancellationToken);
+        Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(long startRowOffset, long startChunkIndex, long endChunkIndex, CancellationToken cancellationToken);
     }
 
     /// <summary>

--- a/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
@@ -1,0 +1,160 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
+{
+    /// <summary>
+    /// Fetches result chunks from the Statement Execution REST API.
+    /// Supports both manifest-based fetching (all links available upfront) and
+    /// incremental chunk fetching via GetResultChunkAsync().
+    /// </summary>
+    internal class StatementExecutionResultFetcher : BaseResultFetcher
+    {
+        private readonly IStatementExecutionClient _client;
+        private readonly string _statementId;
+        private readonly ResultManifest _manifest;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatementExecutionResultFetcher"/> class.
+        /// </summary>
+        /// <param name="client">The Statement Execution API client.</param>
+        /// <param name="statementId">The statement ID for fetching results.</param>
+        /// <param name="manifest">The result manifest containing chunk information.</param>
+        /// <param name="memoryManager">The memory buffer manager.</param>
+        /// <param name="downloadQueue">The queue to add download tasks to.</param>
+        public StatementExecutionResultFetcher(
+            IStatementExecutionClient client,
+            string statementId,
+            ResultManifest manifest,
+            ICloudFetchMemoryBufferManager memoryManager,
+            BlockingCollection<IDownloadResult> downloadQueue)
+            : base(memoryManager, downloadQueue)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _statementId = statementId ?? throw new ArgumentNullException(nameof(statementId));
+            _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+        }
+
+        /// <inheritdoc />
+        public override Task<IDownloadResult?> GetDownloadResultAsync(long offset, CancellationToken cancellationToken)
+        {
+            // For REST API, presigned URLs are long-lived and don't need refresh.
+            // All URLs are obtained during the initial fetch in FetchAllResultsAsync.
+            // URL refresh is not supported for Statement Execution API.
+            return Task.FromResult<IDownloadResult?>(null);
+        }
+
+        /// <inheritdoc />
+        protected override async Task FetchAllResultsAsync(CancellationToken cancellationToken)
+        {
+            // Yield execution so the download queue doesn't get blocked before downloader is started
+            await Task.Yield();
+
+            if (_manifest.Chunks == null || _manifest.Chunks.Count == 0)
+            {
+                // No chunks to process
+                _hasMoreResults = false;
+                return;
+            }
+
+            // Process all chunks from the manifest
+            foreach (var chunk in _manifest.Chunks)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Check if chunk has external links in the manifest
+                if (chunk.ExternalLinks != null && chunk.ExternalLinks.Any())
+                {
+                    // Manifest-based fetching: all links available upfront
+                    foreach (var link in chunk.ExternalLinks)
+                    {
+                        CreateAndAddDownloadResult(link, cancellationToken);
+                    }
+                }
+                else
+                {
+                    // Incremental chunk fetching: fetch external links for this chunk
+                    // This handles cases where the manifest doesn't contain all links upfront
+                    var resultData = await _client.GetResultChunkAsync(
+                        _statementId,
+                        chunk.ChunkIndex,
+                        cancellationToken).ConfigureAwait(false);
+
+                    if (resultData.ExternalLinks != null && resultData.ExternalLinks.Any())
+                    {
+                        foreach (var link in resultData.ExternalLinks)
+                        {
+                            CreateAndAddDownloadResult(link, cancellationToken);
+                        }
+                    }
+                }
+            }
+
+            // All chunks have been processed
+            _hasMoreResults = false;
+        }
+
+        /// <summary>
+        /// Creates a DownloadResult from an ExternalLink and adds it to the download queue.
+        /// </summary>
+        /// <param name="link">The external link from the REST API.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        private void CreateAndAddDownloadResult(ExternalLink link, CancellationToken cancellationToken)
+        {
+            // Parse the expiration time from ISO 8601 format
+            DateTime expirationTime = DateTime.UtcNow.AddHours(1); // Default to 1 hour if parsing fails
+            if (!string.IsNullOrEmpty(link.Expiration))
+            {
+                try
+                {
+                    expirationTime = DateTime.Parse(link.Expiration, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                }
+                catch (FormatException)
+                {
+                    // Use default expiration time if parsing fails
+                }
+            }
+
+            // Create download result from REST API link
+            var downloadResult = new DownloadResult(
+                fileUrl: link.ExternalLinkUrl,
+                startRowOffset: link.RowOffset,
+                rowCount: link.RowCount,
+                byteCount: link.ByteCount,
+                expirationTime: expirationTime,
+                memoryManager: _memoryManager,
+                httpHeaders: link.HttpHeaders); // Pass custom headers for cloud storage auth
+
+            // Add to download queue
+            AddDownloadResult(downloadResult, cancellationToken);
+        }
+    }
+}

--- a/csharp/src/Reader/DatabricksReader.cs
+++ b/csharp/src/Reader/DatabricksReader.cs
@@ -152,6 +152,39 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader
             this.index++;
         }
 
+        private bool _isClosed;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _ = CloseOperationAsync().Result;
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Closes the Thrift operation.
+        /// </summary>
+        /// <returns>Returns true if the close operation completes successfully, false otherwise.</returns>
+        /// <exception cref="HiveServer2Exception" />
+        private async Task<bool> CloseOperationAsync()
+        {
+            try
+            {
+                if (!_isClosed && this.response != null)
+                {
+                    _ = await HiveServer2Reader.CloseOperationAsync(_statement, this.response);
+                    return true;
+                }
+                return false;
+            }
+            finally
+            {
+                _isClosed = true;
+            }
+        }
+
         sealed class SingleBatch : IArrowReader
         {
             private RecordBatch? _recordBatch;

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache;
 using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Apache.Arrow.Ipc;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
 {
@@ -28,7 +29,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
     /// Connection implementation for Databricks Statement Execution REST API.
     /// Manages SQL sessions and statement creation using the REST protocol.
     /// </summary>
-    internal class StatementExecutionConnection : IDisposable
+    internal class StatementExecutionConnection : AdbcConnection
     {
         private readonly IStatementExecutionClient _client;
         private readonly IReadOnlyDictionary<string, string> _properties;
@@ -105,12 +106,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
         /// </summary>
         /// <returns>A new statement instance.</returns>
         /// <remarks>
-        /// This will be implemented in PECO-2791-B to return StatementExecutionStatement.
-        /// For now, it throws NotImplementedException.
+        /// Returns a StatementExecutionStatement instance. Full query execution
+        /// implementation will be completed in PECO-2791-B.
         /// </remarks>
-        public AdbcStatement CreateStatement()
+        public override AdbcStatement CreateStatement()
         {
-            throw new NotImplementedException("Statement creation will be implemented in PECO-2791-B");
+            return new StatementExecutionStatement(_client, _warehouseId, _sessionId);
         }
 
         /// <summary>
@@ -136,6 +137,51 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
                     _sessionId = null;
                 }
             }
+        }
+
+        /// <summary>
+        /// Get a hierarchical view of all catalogs, database schemas, tables, and columns.
+        /// </summary>
+        /// <remarks>
+        /// Metadata operations via Statement Execution API will be implemented in a future release.
+        /// </remarks>
+        public override IArrowArrayStream GetObjects(
+            GetObjectsDepth depth,
+            string? catalogPattern,
+            string? dbSchemaPattern,
+            string? tableNamePattern,
+            IReadOnlyList<string>? tableTypes,
+            string? columnNamePattern)
+        {
+            throw AdbcException.NotImplemented(
+                "GetObjects not yet implemented for Statement Execution API. " +
+                "Metadata operations will be added in a future release.");
+        }
+
+        /// <summary>
+        /// Get the Arrow schema of a database table.
+        /// </summary>
+        /// <remarks>
+        /// Metadata operations via Statement Execution API will be implemented in a future release.
+        /// </remarks>
+        public override Schema GetTableSchema(string? catalog, string? dbSchema, string tableName)
+        {
+            throw AdbcException.NotImplemented(
+                "GetTableSchema not yet implemented for Statement Execution API. " +
+                "Metadata operations will be added in a future release.");
+        }
+
+        /// <summary>
+        /// Get a list of table types supported by the database.
+        /// </summary>
+        /// <remarks>
+        /// Metadata operations via Statement Execution API will be implemented in a future release.
+        /// </remarks>
+        public override IArrowArrayStream GetTableTypes()
+        {
+            throw AdbcException.NotImplemented(
+                "GetTableTypes not yet implemented for Statement Execution API. " +
+                "Metadata operations will be added in a future release.");
         }
 
         /// <summary>
@@ -183,7 +229,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
         /// <summary>
         /// Disposes the connection and releases resources.
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
         {
             if (!_disposed)
             {
@@ -201,6 +247,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
                     }
                 }
 
+                base.Dispose();
                 _disposed = true;
             }
         }

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -1,0 +1,208 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Apache;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
+{
+    /// <summary>
+    /// Connection implementation for Databricks Statement Execution REST API.
+    /// Manages SQL sessions and statement creation using the REST protocol.
+    /// </summary>
+    internal class StatementExecutionConnection : IDisposable
+    {
+        private readonly IStatementExecutionClient _client;
+        private readonly IReadOnlyDictionary<string, string> _properties;
+        private readonly string _warehouseId;
+        private readonly string? _catalog;
+        private readonly string? _schema;
+        private readonly bool _enableSessionManagement;
+        private string? _sessionId;
+        private bool _disposed;
+
+        /// <summary>
+        /// Gets the session ID if session management is enabled and a session has been created.
+        /// </summary>
+        public string? SessionId => _sessionId;
+
+        /// <summary>
+        /// Gets the warehouse ID extracted from the http_path parameter.
+        /// </summary>
+        public string WarehouseId => _warehouseId;
+
+        /// <summary>
+        /// Initializes a new instance of the StatementExecutionConnection class.
+        /// </summary>
+        /// <param name="client">The Statement Execution API client.</param>
+        /// <param name="properties">Connection properties.</param>
+        /// <exception cref="ArgumentNullException">Thrown if client or properties is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if required properties are missing or invalid.</exception>
+        public StatementExecutionConnection(IStatementExecutionClient client, IReadOnlyDictionary<string, string> properties)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _properties = properties ?? throw new ArgumentNullException(nameof(properties));
+
+            // Extract warehouse ID from http_path
+            _warehouseId = ExtractWarehouseId(properties);
+
+            // Extract optional catalog and schema (using standard ADBC parameters)
+            properties.TryGetValue(AdbcOptions.Connection.CurrentCatalog, out _catalog);
+            properties.TryGetValue(AdbcOptions.Connection.CurrentDbSchema, out _schema);
+
+            // Check if session management is enabled (default: true)
+            _enableSessionManagement = true;
+            if (properties.TryGetValue(DatabricksParameters.EnableSessionManagement, out var enableSessionMgmt))
+            {
+                if (bool.TryParse(enableSessionMgmt, out var enabled))
+                {
+                    _enableSessionManagement = enabled;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Opens the connection and creates a session if session management is enabled.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async Task OpenAsync(CancellationToken cancellationToken = default)
+        {
+            if (_enableSessionManagement && _sessionId == null)
+            {
+                var request = new CreateSessionRequest
+                {
+                    WarehouseId = _warehouseId,
+                    Catalog = _catalog,
+                    Schema = _schema
+                };
+
+                var response = await _client.CreateSessionAsync(request, cancellationToken).ConfigureAwait(false);
+                _sessionId = response.SessionId;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new statement for executing queries.
+        /// </summary>
+        /// <returns>A new statement instance.</returns>
+        /// <remarks>
+        /// This will be implemented in PECO-2791-B to return StatementExecutionStatement.
+        /// For now, it throws NotImplementedException.
+        /// </remarks>
+        public AdbcStatement CreateStatement()
+        {
+            throw new NotImplementedException("Statement creation will be implemented in PECO-2791-B");
+        }
+
+        /// <summary>
+        /// Closes the connection and deletes the session if one was created.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async Task CloseAsync(CancellationToken cancellationToken = default)
+        {
+            if (_enableSessionManagement && _sessionId != null)
+            {
+                try
+                {
+                    await _client.DeleteSessionAsync(_sessionId, _warehouseId, cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Swallow exceptions during session deletion to avoid masking other errors
+                    // TODO: Consider logging this error
+                }
+                finally
+                {
+                    _sessionId = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Extracts the warehouse ID from the http_path property (SparkParameters.Path).
+        /// </summary>
+        /// <param name="properties">Connection properties.</param>
+        /// <returns>The warehouse ID.</returns>
+        /// <exception cref="ArgumentException">Thrown if http_path is missing or invalid.</exception>
+        private static string ExtractWarehouseId(IReadOnlyDictionary<string, string> properties)
+        {
+            // Use the standard SparkParameters.Path (adbc.spark.path) for http_path
+            if (!properties.TryGetValue(SparkParameters.Path, out var httpPath))
+            {
+                throw new ArgumentException(
+                    $"Missing required property: {SparkParameters.Path}");
+            }
+
+            if (string.IsNullOrWhiteSpace(httpPath))
+            {
+                throw new ArgumentException(
+                    $"Property {SparkParameters.Path} cannot be null or empty");
+            }
+
+            // Expected format: /sql/1.0/warehouses/{warehouse_id}
+            // Also support: /sql/1.0/warehouses/{warehouse_id}/
+            var parts = httpPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Look for "warehouses" segment followed by the warehouse ID
+            for (int i = 0; i < parts.Length - 1; i++)
+            {
+                if (parts[i].Equals("warehouses", StringComparison.OrdinalIgnoreCase))
+                {
+                    var warehouseId = parts[i + 1];
+                    if (!string.IsNullOrWhiteSpace(warehouseId))
+                    {
+                        return warehouseId;
+                    }
+                }
+            }
+
+            throw new ArgumentException(
+                $"Invalid http_path format: '{httpPath}'. Expected format: /sql/1.0/warehouses/{{warehouse_id}}");
+        }
+
+        /// <summary>
+        /// Disposes the connection and releases resources.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                // Synchronously close the connection
+                // In a real implementation, we should consider async disposal
+                if (_enableSessionManagement && _sessionId != null)
+                {
+                    try
+                    {
+                        CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    }
+                    catch
+                    {
+                        // Swallow exceptions during disposal
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -368,6 +368,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
 
         /// <summary>
         /// Creates a reader for external links results using the CloudFetch pipeline.
+        /// Follows the protocol-agnostic pattern: Create fetcher → Parse config → Create manager → Start → Create reader.
         /// </summary>
         /// <param name="response">The statement execution response.</param>
         /// <returns>A CloudFetch reader.</returns>

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1,0 +1,782 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks.Reader;
+using Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch;
+using Apache.Arrow.Adbc.Tracing;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
+{
+    /// <summary>
+    /// Statement implementation for Databricks Statement Execution REST API.
+    /// Executes queries via REST endpoints and supports both inline and external links result dispositions.
+    /// </summary>
+    internal class StatementExecutionStatement : AdbcStatement, ITracingStatement
+    {
+        private readonly IStatementExecutionClient _client;
+        private readonly string _warehouseId;
+        private readonly string? _sessionId;
+        private readonly IReadOnlyDictionary<string, string> _properties;
+        private readonly HttpClient _httpClient;
+
+        private string? _statementId;
+        private GetStatementResponse? _response;
+        private bool _disposed;
+        private HttpClient? _cloudFetchHttpClient; // Separate HttpClient for CloudFetch downloads
+
+        // Configuration properties
+        private readonly string _resultDisposition;
+        private readonly string _resultFormat;
+        private readonly string? _resultCompression;
+        private readonly int _pollingIntervalMs;
+        private readonly string? _waitTimeout;
+        private readonly bool _enableDirectResults;
+        private readonly long _byteLimit;
+
+        // Statement properties
+        private string? _catalogName;
+        private string? _schemaName;
+        private long _maxRows;
+        private int _queryTimeoutSeconds;
+
+        // Tracing support
+        private readonly ActivityTrace _trace;
+        private readonly string? _traceParent;
+        private readonly string _assemblyVersion;
+        private readonly string _assemblyName;
+
+        /// <summary>
+        /// Initializes a new instance of the StatementExecutionStatement class.
+        /// </summary>
+        /// <param name="client">The Statement Execution API client.</param>
+        /// <param name="warehouseId">The warehouse ID for query execution.</param>
+        /// <param name="sessionId">Optional session ID for session-scoped execution.</param>
+        /// <param name="properties">Connection properties for configuration.</param>
+        /// <param name="httpClient">HTTP client for CloudFetch downloads.</param>
+        public StatementExecutionStatement(
+            IStatementExecutionClient client,
+            string warehouseId,
+            string? sessionId,
+            IReadOnlyDictionary<string, string> properties,
+            HttpClient httpClient)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _warehouseId = warehouseId ?? throw new ArgumentNullException(nameof(warehouseId));
+            _sessionId = sessionId;
+            _properties = properties ?? throw new ArgumentNullException(nameof(properties));
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+
+            // Parse configuration from properties
+            _resultDisposition = GetPropertyOrDefault(DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
+            _resultFormat = GetPropertyOrDefault(DatabricksParameters.ResultFormat, "ARROW_STREAM");
+            _resultCompression = GetPropertyOrDefault(DatabricksParameters.ResultCompression, null);
+            _pollingIntervalMs = int.Parse(GetPropertyOrDefault(DatabricksParameters.PollingInterval, "1000"));
+            _waitTimeout = GetPropertyOrDefault(DatabricksParameters.WaitTimeout, null);
+            _enableDirectResults = bool.Parse(GetPropertyOrDefault(DatabricksParameters.EnableDirectResults, "true"));
+            _byteLimit = long.Parse(GetPropertyOrDefault("adbc.databricks.rest.byte_limit", "0"));
+
+            // Initialize catalog and schema from connection properties
+            properties.TryGetValue(AdbcOptions.Connection.CurrentCatalog, out _catalogName);
+            properties.TryGetValue(AdbcOptions.Connection.CurrentDbSchema, out _schemaName);
+
+            // Initialize tracing
+            var assembly = Assembly.GetExecutingAssembly();
+            _assemblyName = assembly.GetName().Name ?? "Apache.Arrow.Adbc.Drivers.Databricks";
+            _assemblyVersion = assembly.GetName().Version?.ToString() ?? "1.0.0";
+            _trace = new ActivityTrace(_assemblyName, _assemblyVersion);
+            _traceParent = Activity.Current?.Id;
+        }
+
+        /// <summary>
+        /// Gets or sets the catalog name for query execution.
+        /// </summary>
+        public string? CatalogName
+        {
+            get => _catalogName;
+            set => _catalogName = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the schema name for query execution.
+        /// </summary>
+        public string? SchemaName
+        {
+            get => _schemaName;
+            set => _schemaName = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of rows to return.
+        /// </summary>
+        public long MaxRows
+        {
+            get => _maxRows;
+            set => _maxRows = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the query timeout in seconds.
+        /// </summary>
+        public int QueryTimeoutSeconds
+        {
+            get => _queryTimeoutSeconds;
+            set => _queryTimeoutSeconds = value;
+        }
+
+        /// <summary>
+        /// Gets the activity trace for this statement.
+        /// </summary>
+        public ActivityTrace Trace => _trace;
+
+        /// <summary>
+        /// Gets the trace parent ID.
+        /// </summary>
+        public string? TraceParent => _traceParent;
+
+        /// <summary>
+        /// Gets the assembly version.
+        /// </summary>
+        public string AssemblyVersion => _assemblyVersion;
+
+        /// <summary>
+        /// Gets the assembly name.
+        /// </summary>
+        public string AssemblyName => _assemblyName;
+
+        /// <summary>
+        /// Executes a query and returns the results.
+        /// </summary>
+        /// <returns>Query results with schema and data.</returns>
+        public override QueryResult ExecuteQuery()
+        {
+            return ExecuteQueryAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Executes a query asynchronously and returns the results.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>Query results with schema and data.</returns>
+        private async Task<QueryResult> ExecuteQueryAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            // Build ExecuteStatementRequest
+            var request = new ExecuteStatementRequest
+            {
+                Statement = SqlQuery,
+                Disposition = _resultDisposition,
+                Format = _resultFormat,
+                // Parameters = ConvertParameters() // TODO: Implement parameter conversion
+            };
+
+            // Set warehouse_id (always required) and session_id if available
+            request.WarehouseId = _warehouseId;
+
+            if (_sessionId != null)
+            {
+                request.SessionId = _sessionId;
+            }
+            else
+            {
+                // Only set catalog/schema when not using a session
+                // (sessions have their own catalog/schema)
+                request.Catalog = _catalogName;
+                request.Schema = _schemaName;
+            }
+
+            // Set compression (skip for inline results)
+            if (request.Disposition != "INLINE")
+            {
+                request.ResultCompression = _resultCompression ?? "lz4";
+            }
+
+            // Set wait_timeout (skip if direct results mode is enabled OR using a session)
+            // Sessions don't support wait_timeout parameter
+            if (!_enableDirectResults && _sessionId == null)
+            {
+                request.WaitTimeout = _waitTimeout ?? "10s";  // Default to 10s if not specified
+                request.OnWaitTimeout = "CONTINUE";
+            }
+
+            // Set row/byte limits
+            if (_maxRows > 0)
+            {
+                request.RowLimit = _maxRows;
+            }
+            if (_byteLimit > 0)
+            {
+                request.ByteLimit = _byteLimit;
+            }
+
+            // Execute statement
+            var executeResponse = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);
+            _statementId = executeResponse.StatementId;
+
+            // Poll until completion if async
+            if (executeResponse.Status?.State == "PENDING" || executeResponse.Status?.State == "RUNNING")
+            {
+                _response = await PollUntilCompleteAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _response = new GetStatementResponse
+                {
+                    StatementId = executeResponse.StatementId,
+                    Status = executeResponse.Status,
+                    Manifest = executeResponse.Manifest,
+                    Result = executeResponse.Result
+                };
+            }
+
+            // Handle errors
+            if (_response.Status?.State == "FAILED")
+            {
+                throw new AdbcException(
+                    _response.Status.Error?.Message ?? "Query execution failed",
+                    AdbcStatusCode.UnknownError);
+            }
+
+            // Check if results were truncated
+            if (_response.Manifest?.Truncated == true)
+            {
+                // Log warning (would need logger instance)
+                Debug.WriteLine($"Results truncated by row_limit or byte_limit for statement {_statementId}");
+            }
+
+            // Create reader based on actual disposition in response
+            IArrowArrayStream reader = CreateReader(_response);
+
+            return new QueryResult(
+                _response.Manifest?.TotalRowCount ?? 0,
+                reader);
+        }
+
+        /// <summary>
+        /// Polls the statement until it completes or fails.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The final statement response.</returns>
+        private async Task<GetStatementResponse> PollUntilCompleteAsync(CancellationToken cancellationToken)
+        {
+            int pollCount = 0;
+            var startTime = DateTime.UtcNow;
+
+            while (true)
+            {
+                // First poll happens immediately (no delay)
+                if (pollCount > 0)
+                {
+                    await Task.Delay(_pollingIntervalMs, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Check timeout
+                if (_queryTimeoutSeconds > 0)
+                {
+                    var elapsed = (DateTime.UtcNow - startTime).TotalSeconds;
+                    if (elapsed > _queryTimeoutSeconds)
+                    {
+                        await _client.CancelStatementAsync(_statementId!, cancellationToken).ConfigureAwait(false);
+                        throw new AdbcException(
+                            $"Query timeout exceeded ({_queryTimeoutSeconds}s) for statement {_statementId}",
+                            AdbcStatusCode.Timeout);
+                    }
+                }
+
+                var status = await _client.GetStatementAsync(_statementId!, cancellationToken).ConfigureAwait(false);
+
+                if (status.Status?.State == "SUCCEEDED" ||
+                    status.Status?.State == "FAILED" ||
+                    status.Status?.State == "CANCELED" ||
+                    status.Status?.State == "CLOSED")
+                {
+                    return status;
+                }
+
+                pollCount++;
+            }
+        }
+
+        /// <summary>
+        /// Creates the appropriate reader based on the response disposition.
+        /// </summary>
+        /// <param name="response">The statement execution response.</param>
+        /// <returns>An Arrow array stream reader.</returns>
+        private IArrowArrayStream CreateReader(GetStatementResponse response)
+        {
+            // Check if response is in JSON_ARRAY format (fallback when Arrow not supported)
+            bool isJsonFormat = response.Manifest?.Format?.Equals("JSON_ARRAY", StringComparison.OrdinalIgnoreCase) == true;
+
+            if (isJsonFormat)
+            {
+                // JSON format - convert to Arrow
+                return CreateJsonArrayReader(response);
+            }
+
+            // Determine actual disposition from response
+            // Check Result field first (contains actual data for this response)
+            var hasExternalLinks = (response.Result?.ExternalLinks != null && response.Result.ExternalLinks.Any()) ||
+                (response.Manifest?.Chunks?.Any(c => c.ExternalLinks != null && c.ExternalLinks.Any()) == true);
+
+            // Check for inline data in Result field (INLINE disposition with Arrow bytes)
+            var hasInlineResult = response.Result?.Attachment != null && response.Result.Attachment.Length > 0;
+
+            // Check for inline data in Manifest chunks (INLINE_OR_EXTERNAL_LINKS with Arrow bytes)
+            var hasInlineManifest = response.Manifest?.Chunks?
+                .Any(c => c.Attachment != null && c.Attachment.Length > 0) == true;
+
+            if (hasExternalLinks)
+            {
+                // External links - use CloudFetch pipeline
+                return CreateExternalLinksReader(response);
+            }
+            else if (hasInlineResult || hasInlineManifest)
+            {
+                // Inline Arrow data - parse directly
+                return CreateInlineReader(response);
+            }
+            else
+            {
+                // Empty result set
+                return CreateEmptyReader(response);
+            }
+        }
+
+        /// <summary>
+        /// Creates a reader for external links results using the CloudFetch pipeline.
+        /// </summary>
+        /// <param name="response">The statement execution response.</param>
+        /// <returns>A CloudFetch reader.</returns>
+        private IArrowArrayStream CreateExternalLinksReader(GetStatementResponse response)
+        {
+            if (response.Manifest == null)
+            {
+                throw new InvalidOperationException("Manifest is required for external links disposition");
+            }
+
+            // Convert REST API schema to Arrow schema
+            var schema = ConvertSchema(response.Manifest.Schema);
+
+            // Determine compression
+            bool isLz4Compressed = response.Manifest.ResultCompression?.Equals("lz4", StringComparison.OrdinalIgnoreCase) == true;
+
+            // 1. Create REST-specific result fetcher
+            // Resources (memory manager, download queue) will be initialized by CloudFetchDownloadManager
+            var resultFetcher = new StatementExecutionResultFetcher(
+                _client,
+                response.StatementId,
+                response.Manifest);
+
+            // 2. Parse configuration from REST properties (unified properties work for both Thrift and REST)
+            var config = CloudFetchConfiguration.FromProperties(
+                _properties,
+                schema,
+                isLz4Compressed);
+
+            // 3. Create a separate HttpClient for CloudFetch downloads if not already created
+            // This allows us to set CloudFetch-specific timeout without affecting API calls
+            if (_cloudFetchHttpClient == null)
+            {
+                _cloudFetchHttpClient = new HttpClient();
+            }
+
+            // 4. Create protocol-agnostic download manager
+            // Manager creates shared resources and calls Initialize() on the fetcher
+            var downloadManager = new CloudFetchDownloadManager(
+                resultFetcher,              // Protocol-specific fetcher
+                _cloudFetchHttpClient,      // Dedicated HttpClient for CloudFetch
+                config,
+                this);                      // ITracingStatement for tracing
+
+            // 5. Start the manager
+            downloadManager.StartAsync().GetAwaiter().GetResult();
+
+            // 6. Create protocol-agnostic reader
+            return new CloudFetchReader(
+                this,                 // ITracingStatement (both Thrift and REST implement this)
+                schema,
+                null,                 // IResponse (REST doesn't use IResponse)
+                downloadManager);
+        }
+
+        /// <summary>
+        /// Creates a reader for inline results.
+        /// </summary>
+        /// <param name="response">The statement execution response.</param>
+        /// <returns>An inline reader.</returns>
+        private IArrowArrayStream CreateInlineReader(GetStatementResponse response)
+        {
+            // For INLINE disposition, data is in response.Result
+            if (response.Result != null && response.Result.Attachment != null && response.Result.Attachment.Length > 0)
+            {
+                // Check if data is compressed (manifest contains compression metadata)
+                byte[] attachmentData = response.Result.Attachment;
+                string? compression = response.Manifest?.ResultCompression;
+
+                // Decompress if necessary
+                if (!string.IsNullOrEmpty(compression) && !compression.Equals("none", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (compression.Equals("lz4", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var decompressed = Lz4Utilities.DecompressLz4(attachmentData);
+                        attachmentData = decompressed.ToArray();
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Compression type '{compression}' is not supported for inline results");
+                    }
+                }
+
+                // Convert ResultData to ResultManifest format for InlineReader
+                var manifest = new ResultManifest
+                {
+                    Format = "arrow_stream",
+                    Chunks = new List<ResultChunk>
+                    {
+                        new ResultChunk
+                        {
+                            ChunkIndex = (int)(response.Result.ChunkIndex ?? 0),
+                            RowCount = response.Result.RowCount ?? 0,
+                            RowOffset = response.Result.RowOffset ?? 0,
+                            ByteCount = response.Result.ByteCount ?? 0,
+                            Attachment = attachmentData  // Use decompressed data
+                        }
+                    }
+                };
+
+                return new InlineReader(manifest);
+            }
+
+            // For INLINE_OR_EXTERNAL_LINKS disposition with inline data, data is in response.Manifest
+            // These chunks should already be decompressed by the server or need similar handling
+            if (response.Manifest != null)
+            {
+                // Check if manifest chunks need decompression
+                if (response.Manifest.Chunks != null && response.Manifest.Chunks.Count > 0)
+                {
+                    string? compression = response.Manifest.ResultCompression;
+                    if (!string.IsNullOrEmpty(compression) && !compression.Equals("none", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Decompress each chunk's attachment
+                        foreach (var chunk in response.Manifest.Chunks)
+                        {
+                            if (chunk.Attachment != null && chunk.Attachment.Length > 0)
+                            {
+                                if (compression.Equals("lz4", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    var decompressed = Lz4Utilities.DecompressLz4(chunk.Attachment);
+                                    chunk.Attachment = decompressed.ToArray();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return new InlineReader(response.Manifest);
+            }
+
+            throw new InvalidOperationException("No inline data found in response.Result or response.Manifest");
+        }
+
+        /// <summary>
+        /// Creates a reader for empty result sets.
+        /// </summary>
+        /// <param name="response">The statement execution response.</param>
+        /// <returns>An empty reader.</returns>
+        private IArrowArrayStream CreateEmptyReader(GetStatementResponse response)
+        {
+            // For empty results, create a schema with no columns if manifest doesn't have schema
+            var schema = response.Manifest?.Schema != null
+                ? ConvertSchema(response.Manifest.Schema)
+                : new Schema(new List<Field>(), null);
+
+            return new EmptyArrowArrayStream(schema);
+        }
+
+        /// <summary>
+        /// Creates a reader for JSON_ARRAY format results.
+        /// </summary>
+        /// <param name="response">The statement execution response.</param>
+        /// <returns>A JSON array reader that converts JSON to Arrow format.</returns>
+        private IArrowArrayStream CreateJsonArrayReader(GetStatementResponse response)
+        {
+            if (response.Manifest == null)
+            {
+                throw new InvalidOperationException("Manifest is required for JSON_ARRAY format");
+            }
+
+            // Extract data_array from the response
+            List<List<string>> data;
+
+            if (response.Result?.DataArray != null && response.Result.DataArray.Count > 0)
+            {
+                // Data is in result.data_array - convert List<List<object>> to List<List<string>>
+                data = response.Result.DataArray
+                    .Select(row => row.Select(cell => cell?.ToString() ?? string.Empty).ToList())
+                    .ToList();
+            }
+            else if (response.Manifest.Chunks != null && response.Manifest.Chunks.Count > 0)
+            {
+                // Try to get data from manifest chunks
+                data = new List<List<string>>();
+                foreach (var chunk in response.Manifest.Chunks)
+                {
+                    if (chunk.DataArray != null)
+                    {
+                        // Convert List<List<object>> to List<List<string>>
+                        var chunkData = chunk.DataArray
+                            .Select(row => row.Select(cell => cell?.ToString() ?? string.Empty).ToList())
+                            .ToList();
+                        data.AddRange(chunkData);
+                    }
+                }
+            }
+            else
+            {
+                // Empty result
+                data = new List<List<string>>();
+            }
+
+            return new JsonArrayReader(response.Manifest, data);
+        }
+
+        /// <summary>
+        /// Converts a REST API result schema to an Arrow schema.
+        /// </summary>
+        /// <param name="resultSchema">The REST API result schema.</param>
+        /// <returns>An Arrow schema.</returns>
+        private Schema ConvertSchema(ResultSchema? resultSchema)
+        {
+            if (resultSchema?.Columns == null || resultSchema.Columns.Count == 0)
+            {
+                return new Schema(new List<Field>(), null);
+            }
+
+            var fields = new List<Field>();
+            foreach (var column in resultSchema.Columns)
+            {
+                // TODO: Implement proper type conversion from REST API types to Arrow types
+                // For now, use string type as fallback
+                var arrowType = ConvertType(column.TypeText);
+                var field = new Field(column.Name ?? $"col_{column.Position}", arrowType, nullable: true);
+                fields.Add(field);
+            }
+
+            return new Schema(fields, null);
+        }
+
+        /// <summary>
+        /// Converts a REST API type string to an Arrow type.
+        /// </summary>
+        /// <param name="typeText">The type text from REST API.</param>
+        /// <returns>An Arrow data type.</returns>
+        private IArrowType ConvertType(string? typeText)
+        {
+            // TODO: Implement comprehensive type mapping
+            // This is a simplified implementation
+            if (string.IsNullOrEmpty(typeText))
+            {
+                return StringType.Default;
+            }
+
+            var lowerType = typeText.ToLowerInvariant();
+
+            if (lowerType.Contains("int")) return Int64Type.Default;
+            if (lowerType.Contains("long")) return Int64Type.Default;
+            if (lowerType.Contains("double")) return DoubleType.Default;
+            if (lowerType.Contains("float")) return FloatType.Default;
+            if (lowerType.Contains("bool")) return BooleanType.Default;
+            if (lowerType.Contains("string")) return StringType.Default;
+            if (lowerType.Contains("binary")) return BinaryType.Default;
+            if (lowerType.Contains("date")) return Date64Type.Default;
+            if (lowerType.Contains("timestamp")) return new TimestampType(TimeUnit.Microsecond, timezone: (string?)null);
+
+            // Default to string for unknown types
+            return StringType.Default;
+        }
+
+        /// <summary>
+        /// Gets a property value or returns a default value if not found.
+        /// </summary>
+        /// <param name="key">The property key.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>The property value or default.</returns>
+        private string GetPropertyOrDefault(string key, string? defaultValue)
+        {
+            return _properties.TryGetValue(key, out var value) ? value : defaultValue ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Executes an update statement (INSERT, UPDATE, DELETE, etc.) and returns affected row count.
+        /// </summary>
+        /// <returns>Update results with affected row count.</returns>
+        public override UpdateResult ExecuteUpdate()
+        {
+            // Execute the query to get the results
+            var queryResult = ExecuteQuery();
+
+            // For DML statements, the manifest should contain the row count
+            // If not available, return -1 (unknown)
+            long affectedRows = _response?.Manifest?.TotalRowCount ?? -1;
+
+            // Dispose the reader since we don't need the data
+            queryResult.Stream?.Dispose();
+
+            return new UpdateResult(affectedRows);
+        }
+
+        /// <summary>
+        /// Disposes the statement and releases resources.
+        /// </summary>
+        public override void Dispose()
+        {
+            if (!_disposed)
+            {
+                // Close statement if it was created
+                if (_statementId != null)
+                {
+                    try
+                    {
+                        _client.CloseStatementAsync(_statementId, CancellationToken.None)
+                            .GetAwaiter().GetResult();
+                    }
+                    catch (Exception)
+                    {
+                        // Swallow exceptions during disposal
+                        // TODO: Consider logging this error
+                    }
+                }
+
+                // Dispose CloudFetch HttpClient if it was created
+                _cloudFetchHttpClient?.Dispose();
+
+                base.Dispose();
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Throws if the statement has been disposed.
+        /// </summary>
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(StatementExecutionStatement));
+            }
+        }
+
+        /// <summary>
+        /// Empty Arrow array stream for empty result sets.
+        /// </summary>
+        private class EmptyArrowArrayStream : IArrowArrayStream
+        {
+            private readonly Schema _schema;
+
+            public EmptyArrowArrayStream(Schema schema)
+            {
+                _schema = schema;
+            }
+
+            public Schema Schema => _schema;
+
+            public ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+            {
+                return new ValueTask<RecordBatch?>(Task.FromResult<RecordBatch?>(null));
+            }
+
+            public void Dispose()
+            {
+                // Nothing to dispose
+            }
+        }
+
+        /// <summary>
+        /// Simple reader for CloudFetch results using ICloudFetchDownloadManager.
+        /// </summary>
+        private class SimpleCloudFetchReader : IArrowArrayStream
+        {
+            private readonly ICloudFetchDownloadManager _downloadManager;
+            private readonly string? _compressionCodec;
+            private readonly Schema _schema;
+            private bool _disposed;
+
+            public SimpleCloudFetchReader(ICloudFetchDownloadManager downloadManager, string? compressionCodec, Schema schema)
+            {
+                _downloadManager = downloadManager ?? throw new ArgumentNullException(nameof(downloadManager));
+                _compressionCodec = compressionCodec;
+                _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+            }
+
+            public Schema Schema => _schema;
+
+            public async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(SimpleCloudFetchReader));
+                }
+
+                var downloadResult = await _downloadManager.GetNextDownloadedFileAsync(cancellationToken).ConfigureAwait(false);
+
+                if (downloadResult == null)
+                {
+                    return null; // End of stream
+                }
+
+                var stream = downloadResult.DataStream;
+
+                // Decompress if needed
+                if (!string.IsNullOrEmpty(_compressionCodec) && _compressionCodec.Equals("lz4", StringComparison.OrdinalIgnoreCase))
+                {
+                    stream = DecompressLz4(stream);
+                }
+
+                // Read Arrow IPC format
+                using var reader = new ArrowStreamReader(stream);
+                var batch = await reader.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false);
+                return batch;
+            }
+
+            private System.IO.Stream DecompressLz4(System.IO.Stream compressedStream)
+            {
+                // TODO: Implement LZ4 decompression
+                // For now, assume data is not compressed or already decompressed
+                return compressedStream;
+            }
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    _downloadManager?.Dispose();
+                    _disposed = true;
+                }
+            }
+        }
+    }
+}

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -389,7 +389,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution
             var resultFetcher = new StatementExecutionResultFetcher(
                 _client,
                 response.StatementId,
-                response.Manifest);
+                response);  // Pass full response to use Result field
 
             // 2. Parse configuration from REST properties (unified properties work for both Thrift and REST)
             var config = CloudFetchConfiguration.FromProperties(

--- a/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
+++ b/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
@@ -82,7 +82,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                         BytesNum = 1024,
                         ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds()
                     };
-                    return DownloadResult.FromThriftLink(link, _mockMemoryManager.Object);
+                    return DownloadResult.FromThriftLink(0, link, _mockMemoryManager.Object);
                 });
         }
 
@@ -661,7 +661,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                 BytesNum = 100,
                 ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set new expiry in the future
             };
-            var refreshedResult = DownloadResult.FromThriftLink(refreshedLink, _mockMemoryManager.Object);
+            var refreshedResult = DownloadResult.FromThriftLink(0, refreshedLink, _mockMemoryManager.Object);
             _mockResultFetcher.Setup(f => f.GetDownloadResultAsync(0, It.IsAny<CancellationToken>()))
                 .Callback(() => {
                     getDownloadResultCalled = true;

--- a/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
+++ b/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
@@ -318,7 +318,6 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                 BytesNum = 100,
                 ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
             };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
             var fileUrl = "http://test.com/file1";
             var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
             mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);

--- a/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
+++ b/csharp/test/E2E/CloudFetch/CloudFetchDownloaderTest.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -69,16 +70,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                 .Returns(Task.CompletedTask);
 
             // Set up result fetcher defaults
-            _mockResultFetcher.Setup(f => f.GetUrlAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            _mockResultFetcher.Setup(f => f.GetDownloadResultAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((long offset, CancellationToken token) =>
                 {
-                    // Return a URL with the same offset
-                    return new TSparkArrowResultLink
+                    // Return a download result with the same offset
+                    var link = new TSparkArrowResultLink
                     {
                         StartRowOffset = offset,
                         FileLink = $"http://test.com/file{offset}",
+                        RowCount = 100,
+                        BytesNum = 1024,
                         ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds()
                     };
+                    return DownloadResult.FromThriftLink(link, _mockMemoryManager.Object);
                 });
         }
 
@@ -142,11 +146,13 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            string fileUrl = "http://test.com/file1";
+            DateTime expirationTime = DateTime.UtcNow.AddMinutes(30);
+
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(testContentBytes.Length);
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -230,11 +236,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            var fileUrl = "http://test.com/file1";
+            var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(1000); // Some arbitrary size
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -312,6 +319,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                 ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
             };
             mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            var fileUrl = "http://test.com/file1";
+            var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -420,11 +433,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            var fileUrl = "http://test.com/file1";
+            var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
             mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -511,11 +525,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
             for (int i = 0; i < totalDownloads; i++)
             {
                 var mockDownloadResult = new Mock<IDownloadResult>();
-                var resultLink = new TSparkArrowResultLink {
-                    FileLink = $"http://test.com/file{i}",
-                    ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set expiry 30 minutes in the future
-                };
-                mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+                var fileUrl = $"http://test.com/file{i}";
+                var expirationTime = DateTimeOffset.UtcNow.AddMinutes(30).UtcDateTime;
+                mockDownloadResult.Setup(r => r.FileUrl).Returns(fileUrl);
+                mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+                mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+                mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
                 mockDownloadResult.Setup(r => r.Size).Returns(100);
                 mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
                 mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
@@ -579,7 +594,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
             // Arrange
             // Create a mock HTTP handler that returns a 403 error for the first request and success for the second
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
-            var requestCount = 0;
+            int requestCount = 0;
+            bool httpMockCalled = false;
 
             mockHttpMessageHandler
                 .Protected()
@@ -589,16 +605,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
                     ItExpr.IsAny<CancellationToken>())
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, token) =>
                 {
+                    httpMockCalled = true;
                     await Task.Delay(1, token); // Small delay to simulate network
 
                     // First request fails with 403 Forbidden (expired URL)
                     if (requestCount == 0)
                     {
                         requestCount++;
+                        Console.WriteLine($"HTTP Mock: Returning 403 Forbidden for request #{requestCount-1}");
                         return new HttpResponseMessage(HttpStatusCode.Forbidden);
                     }
 
                     // Second request succeeds with the refreshed URL
+                    Console.WriteLine($"HTTP Mock: Returning 200 OK for request #{requestCount}");
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new StringContent("Test content")
@@ -609,25 +628,47 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink {
-                StartRowOffset = 0,
-                FileLink = "http://test.com/file1",
-                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds() // Set expiry in the past
-            };
-            mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
+            string fileUrl = "http://test.com/file1";
+            DateTime expirationTime = DateTime.UtcNow.AddMinutes(-5); // Set expiry in the past
+
+            // Track refresh attempts
+            int refreshAttempts = 0;
+
+            mockDownloadResult.Setup(r => r.FileUrl).Returns(() => refreshAttempts == 0 ? fileUrl : "http://test.com/file1-refreshed");
+            mockDownloadResult.Setup(r => r.StartRowOffset).Returns(0);
+            mockDownloadResult.Setup(r => r.ExpirationTime).Returns(expirationTime);
+            mockDownloadResult.Setup(r => r.HttpHeaders).Returns((IReadOnlyDictionary<string, string>?)null);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
-            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
+            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(() => refreshAttempts);
             // Important: Set this to false so the initial URL refresh doesn't happen
             mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
 
+            // Setup UpdateWithRefreshedUrl to increment refresh attempts
+            mockDownloadResult.Setup(r => r.UpdateWithRefreshedUrl(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+                .Callback(() => refreshAttempts++);
+
+            // Setup SetCompleted to allow it to be called
+            mockDownloadResult.Setup(r => r.SetCompleted(It.IsAny<Stream>(), It.IsAny<long>()));
+
             // Setup URL refreshing - expect it to be called once during the HTTP 403 error handling
+            bool getDownloadResultCalled = false;
             var refreshedLink = new TSparkArrowResultLink {
                 StartRowOffset = 0,
                 FileLink = "http://test.com/file1-refreshed",
+                RowCount = 100,
+                BytesNum = 100,
                 ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeMilliseconds() // Set new expiry in the future
             };
-            _mockResultFetcher.Setup(f => f.GetUrlAsync(0, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(refreshedLink);
+            var refreshedResult = DownloadResult.FromThriftLink(refreshedLink, _mockMemoryManager.Object);
+            _mockResultFetcher.Setup(f => f.GetDownloadResultAsync(0, It.IsAny<CancellationToken>()))
+                .Callback(() => {
+                    getDownloadResultCalled = true;
+                    Console.WriteLine("GetDownloadResultAsync was called!");
+                })
+                .ReturnsAsync(refreshedResult);
 
             // Create the downloader and add the download to the queue
             var downloader = new CloudFetchDownloader(
@@ -646,18 +687,29 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
             await downloader.StartAsync(CancellationToken.None);
             _downloadQueue.Add(mockDownloadResult.Object);
 
-            // Wait for the download to be processed
-            await Task.Delay(200);
-
             // Add the end of results guard to complete the downloader
             _downloadQueue.Add(EndOfResultsGuard.Instance);
 
-            // Assert
-            // Verify that GetUrlAsync was called exactly once to refresh the URL
-            _mockResultFetcher.Verify(f => f.GetUrlAsync(0, It.IsAny<CancellationToken>()), Times.Once);
+            // Wait for the download to actually complete
+            var result = await downloader.GetNextDownloadedFileAsync(CancellationToken.None);
 
-            // Verify that UpdateWithRefreshedLink was called with the refreshed link
-            mockDownloadResult.Verify(r => r.UpdateWithRefreshedLink(refreshedLink), Times.Once);
+            // Debug output
+            Console.WriteLine($"HTTP Mock Called: {httpMockCalled}");
+            Console.WriteLine($"GetDownloadResultAsync Called: {getDownloadResultCalled}");
+            Console.WriteLine($"Request Count: {requestCount}");
+            Console.WriteLine($"Refresh Attempts: {refreshAttempts}");
+
+            // Assert
+            Assert.Same(mockDownloadResult.Object, result);
+
+            // Verify that GetDownloadResultAsync was called exactly once to refresh the URL
+            _mockResultFetcher.Verify(f => f.GetDownloadResultAsync(0, It.IsAny<CancellationToken>()), Times.Once);
+
+            // Verify that UpdateWithRefreshedUrl was called with the refreshed URL
+            mockDownloadResult.Verify(r => r.UpdateWithRefreshedUrl(
+                refreshedResult.FileUrl,
+                refreshedResult.ExpirationTime,
+                refreshedResult.HttpHeaders), Times.Once);
 
             // Cleanup
             await downloader.StopAsync();

--- a/csharp/test/E2E/DatabricksTestHelpers.cs
+++ b/csharp/test/E2E/DatabricksTestHelpers.cs
@@ -1,0 +1,88 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.E2E
+{
+    /// <summary>
+    /// Helper methods for Databricks E2E tests.
+    /// </summary>
+    public static class DatabricksTestHelpers
+    {
+        /// <summary>
+        /// Extracts the host name from test configuration.
+        /// Supports both explicit HostName and Uri formats.
+        /// </summary>
+        /// <param name="config">The test configuration.</param>
+        /// <returns>The extracted host name.</returns>
+        /// <exception cref="ArgumentException">Thrown if neither HostName nor Uri is set, or if Uri format is invalid.</exception>
+        public static string GetHostFromConfiguration(DatabricksTestConfiguration config)
+        {
+            if (!string.IsNullOrEmpty(config.HostName))
+            {
+                return config.HostName;
+            }
+            else if (!string.IsNullOrEmpty(config.Uri))
+            {
+                if (Uri.TryCreate(config.Uri, UriKind.Absolute, out Uri? parsedUri))
+                {
+                    return parsedUri.Host;
+                }
+                else
+                {
+                    throw new ArgumentException($"Invalid URI format: {config.Uri}");
+                }
+            }
+            else
+            {
+                throw new ArgumentException(
+                    "Either HostName or Uri must be set in the test configuration file");
+            }
+        }
+
+        /// <summary>
+        /// Extracts the path from test configuration.
+        /// Supports both explicit Path and Uri formats.
+        /// </summary>
+        /// <param name="config">The test configuration.</param>
+        /// <returns>The extracted path.</returns>
+        /// <exception cref="ArgumentException">Thrown if neither Path nor Uri is set, or if Uri format is invalid.</exception>
+        public static string GetPathFromConfiguration(DatabricksTestConfiguration config)
+        {
+            if (!string.IsNullOrEmpty(config.Path))
+            {
+                return config.Path;
+            }
+            else if (!string.IsNullOrEmpty(config.Uri))
+            {
+                if (Uri.TryCreate(config.Uri, UriKind.Absolute, out Uri? parsedUri))
+                {
+                    return parsedUri.AbsolutePath;
+                }
+                else
+                {
+                    throw new ArgumentException($"Invalid URI format: {config.Uri}");
+                }
+            }
+            else
+            {
+                throw new ArgumentException(
+                    "Either Path or Uri must be set in the test configuration file");
+            }
+        }
+    }
+}

--- a/csharp/test/E2E/StatementExecution/StatementExecutionConnectionE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/StatementExecutionConnectionE2ETests.cs
@@ -522,16 +522,16 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.E2E.StatementExecution
         }
 
         [Fact]
-        public void CreateStatement_ThrowsNotImplementedException()
+        public void CreateStatement_ReturnsStatement()
         {
             _client = CreateClient();
             var properties = GetConnectionProperties(enableSessionManagement: true);
             var connection = new StatementExecutionConnection(_client, properties);
 
-            var exception = Assert.Throws<NotImplementedException>(() =>
-                connection.CreateStatement());
+            var statement = connection.CreateStatement();
 
-            Assert.Contains("PECO-2791-B", exception.Message);
+            Assert.NotNull(statement);
+            Assert.IsAssignableFrom<AdbcStatement>(statement);
         }
     }
 }

--- a/csharp/test/E2E/StatementExecution/StatementExecutionConnectionE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/StatementExecutionConnectionE2ETests.cs
@@ -1,0 +1,537 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Apache.Arrow.Adbc.Drivers.Databricks;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+using Apache.Arrow.Adbc.Tests.Drivers.Apache.Common;
+using Moq;
+using Moq.Protected;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.E2E.StatementExecution
+{
+    /// <summary>
+    /// E2E tests for StatementExecutionConnection with support for both mock and real environments.
+    /// By default, tests use mock responses for fast, isolated testing.
+    /// To run against a real Databricks endpoint:
+    /// 1. Set DATABRICKS_TEST_CONFIG_FILE environment variable to point to a JSON configuration file
+    /// 2. Set USE_REAL_STATEMENT_EXECUTION_ENDPOINT=true to enable real endpoint testing
+    /// The configuration file should include: hostName, path (with warehouse ID), and token/access_token.
+    /// </summary>
+    public class StatementExecutionConnectionE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
+    {
+        private readonly bool _useRealEndpoint;
+        private HttpClient? _httpClient;
+        private Mock<HttpMessageHandler>? _mockHttpMessageHandler;
+        private StatementExecutionClient? _client;
+
+        public StatementExecutionConnectionE2ETests(ITestOutputHelper? outputHelper)
+            : base(outputHelper, new DatabricksTestEnvironment.Factory())
+        {
+            // Only use real endpoint if explicitly enabled AND config file is available
+            _useRealEndpoint = Environment.GetEnvironmentVariable("USE_REAL_STATEMENT_EXECUTION_ENDPOINT") == "true"
+                            && Utils.CanExecuteTestConfig(TestConfigVariable);
+
+            // Initialize mock infrastructure in constructor for mock mode
+            if (!_useRealEndpoint)
+            {
+                _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            }
+        }
+
+        private StatementExecutionClient CreateClient()
+        {
+            if (_useRealEndpoint)
+            {
+                return CreateRealClient();
+            }
+            else
+            {
+                return CreateMockClient();
+            }
+        }
+
+        private StatementExecutionClient CreateRealClient()
+        {
+            var host = DatabricksTestHelpers.GetHostFromConfiguration(TestConfiguration);
+
+            // Get access token from configuration (supports both direct token and OAuth)
+            var accessToken = TestConfiguration.Token ?? TestConfiguration.AccessToken;
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                throw new InvalidOperationException(
+                    "Token or AccessToken must be set in the test configuration file. " +
+                    "For OAuth, ensure the connection has been established to obtain an access token.");
+            }
+
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+
+            return new StatementExecutionClient(_httpClient, host);
+        }
+
+        private StatementExecutionClient CreateMockClient()
+        {
+            if (_mockHttpMessageHandler == null)
+            {
+                throw new InvalidOperationException("Mock HTTP handler not initialized");
+            }
+
+            _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+            return new StatementExecutionClient(_httpClient, "mock.databricks.com");
+        }
+
+        private void SetupMockResponse(HttpStatusCode statusCode, string responseContent)
+        {
+            if (_useRealEndpoint)
+            {
+                throw new InvalidOperationException("Cannot setup mock responses when using real endpoint");
+            }
+
+            if (_mockHttpMessageHandler == null)
+            {
+                throw new InvalidOperationException("Mock HTTP handler not initialized");
+            }
+
+            var httpResponseMessage = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseContent)
+            };
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(httpResponseMessage);
+        }
+
+        private Dictionary<string, string> GetConnectionProperties(bool enableSessionManagement = true)
+        {
+            var properties = new Dictionary<string, string>();
+
+            if (_useRealEndpoint)
+            {
+                properties[SparkParameters.Path] = DatabricksTestHelpers.GetPathFromConfiguration(TestConfiguration);
+            }
+            else
+            {
+                properties[SparkParameters.Path] = "/sql/1.0/warehouses/mock-warehouse-id";
+            }
+
+            properties[DatabricksParameters.EnableSessionManagement] = enableSessionManagement.ToString().ToLower();
+
+            return properties;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _httpClient?.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        [Fact]
+        public async Task ConnectionLifecycle_OpenAndClose_CreatesAndDeletesSession()
+        {
+            if (!_useRealEndpoint)
+            {
+                // Mock: Setup create session response
+                SetupMockResponse(HttpStatusCode.OK,
+                    JsonSerializer.Serialize(new { session_id = "mock-session-123" }));
+            }
+
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            // Open connection - should create session
+            await connection.OpenAsync();
+            Assert.NotNull(connection.SessionId);
+            Assert.False(string.IsNullOrEmpty(connection.SessionId));
+
+            if (!_useRealEndpoint)
+            {
+                // Mock: Setup delete session response
+                SetupMockResponse(HttpStatusCode.OK, "");
+            }
+
+            // Close connection - should delete session
+            await connection.CloseAsync();
+            Assert.Null(connection.SessionId);
+        }
+
+        [Fact]
+        public async Task ConnectionLifecycle_WithCatalogAndSchema_PassesToSession()
+        {
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK,
+                    JsonSerializer.Serialize(new { session_id = "mock-session-456" }));
+            }
+
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            properties[AdbcOptions.Connection.CurrentCatalog] = "test_catalog";
+            properties[AdbcOptions.Connection.CurrentDbSchema] = "test_schema";
+
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            await connection.OpenAsync();
+            Assert.NotNull(connection.SessionId);
+
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK, "");
+            }
+
+            await connection.CloseAsync();
+        }
+
+        [Fact]
+        public async Task ConnectionLifecycle_SessionManagementDisabled_DoesNotCreateSession()
+        {
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: false);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            // Open connection - should NOT create session
+            await connection.OpenAsync();
+            Assert.Null(connection.SessionId);
+
+            // Close connection - should NOT attempt to delete session
+            await connection.CloseAsync();
+            Assert.Null(connection.SessionId);
+        }
+
+        [Fact]
+        public async Task Dispose_WithActiveSession_ClosesSessionProperly()
+        {
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK,
+                    JsonSerializer.Serialize(new { session_id = "mock-session-dispose" }));
+            }
+
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            await connection.OpenAsync();
+            var sessionId = connection.SessionId;
+            Assert.NotNull(sessionId);
+
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK, "");
+            }
+
+            // Dispose should close the session
+            connection.Dispose();
+
+            // After dispose, we can't check the session ID state, but we've verified it was created
+            // and the dispose method should have cleaned it up
+        }
+
+        [Fact]
+        public async Task OpenTwice_OnlyCreatesOneSession()
+        {
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK,
+                    JsonSerializer.Serialize(new { session_id = "mock-session-once" }));
+            }
+
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            // First open
+            await connection.OpenAsync();
+            var firstSessionId = connection.SessionId;
+            Assert.NotNull(firstSessionId);
+
+            // Second open - should not create a new session
+            await connection.OpenAsync();
+            var secondSessionId = connection.SessionId;
+            Assert.Equal(firstSessionId, secondSessionId);
+
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK, "");
+            }
+
+            await connection.CloseAsync();
+        }
+
+        [Fact]
+        public async Task CloseWithoutOpen_DoesNotThrow()
+        {
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            // Close without opening should not throw
+            await connection.CloseAsync();
+            Assert.Null(connection.SessionId);
+        }
+
+        [Fact]
+        public async Task CloseTwice_DoesNotThrow()
+        {
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK,
+                    JsonSerializer.Serialize(new { session_id = "mock-session-close-twice" }));
+            }
+
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            await connection.OpenAsync();
+            Assert.NotNull(connection.SessionId);
+
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK, "");
+            }
+
+            // First close
+            await connection.CloseAsync();
+            Assert.Null(connection.SessionId);
+
+            // Second close - should not throw
+            await connection.CloseAsync();
+            Assert.Null(connection.SessionId);
+        }
+
+        [Fact]
+        public async Task Close_WhenDeleteSessionFails_SwallowsException()
+        {
+            if (!_useRealEndpoint)
+            {
+                // Setup create session to succeed
+                SetupMockResponse(HttpStatusCode.OK,
+                    JsonSerializer.Serialize(new { session_id = "mock-session-fail-delete" }));
+            }
+
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            await connection.OpenAsync();
+            Assert.NotNull(connection.SessionId);
+
+            if (!_useRealEndpoint)
+            {
+                // Setup delete session to fail
+                SetupMockResponse(HttpStatusCode.InternalServerError,
+                    JsonSerializer.Serialize(new { error_code = "INTERNAL_ERROR", message = "Failed to delete session" }));
+            }
+
+            // Close should not throw even if delete fails
+            await connection.CloseAsync();
+            Assert.Null(connection.SessionId); // Session ID should be cleared regardless
+        }
+
+        [Fact]
+        public void WarehouseIdExtraction_FromStandardPath_Succeeds()
+        {
+            _client = CreateClient();
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123def456" }
+            };
+
+            var connection = new StatementExecutionConnection(_client, properties);
+            Assert.Equal("abc123def456", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void WarehouseIdExtraction_WithTrailingSlash_Succeeds()
+        {
+            _client = CreateClient();
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse/" }
+            };
+
+            var connection = new StatementExecutionConnection(_client, properties);
+            Assert.Equal("test-warehouse", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void WarehouseIdExtraction_CaseInsensitive_Succeeds()
+        {
+            _client = CreateClient();
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/WAREHOUSES/uppercase-id" }
+            };
+
+            var connection = new StatementExecutionConnection(_client, properties);
+            Assert.Equal("uppercase-id", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void Constructor_MissingPath_ThrowsArgumentException()
+        {
+            _client = CreateClient();
+            var properties = new Dictionary<string, string>();
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new StatementExecutionConnection(_client, properties));
+
+            Assert.Contains("Missing required property", exception.Message);
+        }
+
+        [Fact]
+        public void Constructor_InvalidPathFormat_ThrowsArgumentException()
+        {
+            _client = CreateClient();
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/invalid/path/format" }
+            };
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new StatementExecutionConnection(_client, properties));
+
+            Assert.Contains("Invalid http_path format", exception.Message);
+        }
+
+        [Fact]
+        public async Task FullWorkflow_CreateOpenCloseDispose_Succeeds()
+        {
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK,
+                    JsonSerializer.Serialize(new { session_id = "mock-session-workflow" }));
+            }
+
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            properties[AdbcOptions.Connection.CurrentCatalog] = "main";
+            properties[AdbcOptions.Connection.CurrentDbSchema] = "default";
+
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            // Verify warehouse ID extraction
+            Assert.NotNull(connection.WarehouseId);
+            Assert.NotEmpty(connection.WarehouseId);
+
+            // Open connection
+            await connection.OpenAsync();
+            Assert.NotNull(connection.SessionId);
+            Assert.NotEmpty(connection.SessionId);
+
+            if (!_useRealEndpoint)
+            {
+                SetupMockResponse(HttpStatusCode.OK, "");
+            }
+
+            // Close connection
+            await connection.CloseAsync();
+            Assert.Null(connection.SessionId);
+
+            // Dispose (should be safe even after close)
+            connection.Dispose();
+        }
+
+        [Fact]
+        public async Task MultipleConnections_Independent_EachHasOwnSession()
+        {
+            if (!_useRealEndpoint)
+            {
+                // Will be called multiple times, return different session IDs
+                var sessionIdCounter = 0;
+                _mockHttpMessageHandler!.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
+                        ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonSerializer.Serialize(new
+                        {
+                            session_id = $"mock-session-{++sessionIdCounter}"
+                        }))
+                    });
+            }
+
+            _client = CreateClient();
+            var properties1 = GetConnectionProperties(enableSessionManagement: true);
+            var properties2 = GetConnectionProperties(enableSessionManagement: true);
+
+            var connection1 = new StatementExecutionConnection(_client, properties1);
+            var connection2 = new StatementExecutionConnection(_client, properties2);
+
+            // Open both connections
+            await connection1.OpenAsync();
+            await connection2.OpenAsync();
+
+            Assert.NotNull(connection1.SessionId);
+            Assert.NotNull(connection2.SessionId);
+
+            if (!_useRealEndpoint)
+            {
+                // Sessions should be different
+                Assert.NotEqual(connection1.SessionId, connection2.SessionId);
+
+                // Setup delete responses
+                _mockHttpMessageHandler!.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Delete),
+                        ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+
+            // Close both connections
+            await connection1.CloseAsync();
+            await connection2.CloseAsync();
+
+            Assert.Null(connection1.SessionId);
+            Assert.Null(connection2.SessionId);
+        }
+
+        [Fact]
+        public void CreateStatement_ThrowsNotImplementedException()
+        {
+            _client = CreateClient();
+            var properties = GetConnectionProperties(enableSessionManagement: true);
+            var connection = new StatementExecutionConnection(_client, properties);
+
+            var exception = Assert.Throws<NotImplementedException>(() =>
+                connection.CreateStatement());
+
+            Assert.Contains("PECO-2791-B", exception.Message);
+        }
+    }
+}

--- a/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
+++ b/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
@@ -51,9 +51,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Reader.CloudFetch
             var fetcher = new StatementExecutionResultFetcher(
                 _mockClient.Object,
                 TestStatementId,
-                manifest,
-                _mockMemoryManager.Object,
-                _downloadQueue);
+                manifest);
 
             Assert.NotNull(fetcher);
         }
@@ -67,9 +65,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Reader.CloudFetch
                 new StatementExecutionResultFetcher(
                     null!,
                     TestStatementId,
-                    manifest,
-                    _mockMemoryManager.Object,
-                    _downloadQueue));
+                    manifest));
         }
 
         [Fact]
@@ -81,9 +77,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Reader.CloudFetch
                 new StatementExecutionResultFetcher(
                     _mockClient.Object,
                     null!,
-                    manifest,
-                    _mockMemoryManager.Object,
-                    _downloadQueue));
+                    manifest));
         }
 
         [Fact]
@@ -93,36 +87,6 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Reader.CloudFetch
                 new StatementExecutionResultFetcher(
                     _mockClient.Object,
                     TestStatementId,
-                    null!,
-                    _mockMemoryManager.Object,
-                    _downloadQueue));
-        }
-
-        [Fact]
-        public void Constructor_WithNullMemoryManager_ThrowsArgumentNullException()
-        {
-            var manifest = CreateTestManifest(chunkCount: 1);
-
-            Assert.Throws<ArgumentNullException>(() =>
-                new StatementExecutionResultFetcher(
-                    _mockClient.Object,
-                    TestStatementId,
-                    manifest,
-                    null!,
-                    _downloadQueue));
-        }
-
-        [Fact]
-        public void Constructor_WithNullDownloadQueue_ThrowsArgumentNullException()
-        {
-            var manifest = CreateTestManifest(chunkCount: 1);
-
-            Assert.Throws<ArgumentNullException>(() =>
-                new StatementExecutionResultFetcher(
-                    _mockClient.Object,
-                    TestStatementId,
-                    manifest,
-                    _mockMemoryManager.Object,
                     null!));
         }
 
@@ -477,12 +441,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Reader.CloudFetch
 
         private StatementExecutionResultFetcher CreateFetcher(ResultManifest manifest)
         {
-            return new StatementExecutionResultFetcher(
+            var fetcher = new StatementExecutionResultFetcher(
                 _mockClient.Object,
                 TestStatementId,
-                manifest,
-                _mockMemoryManager.Object,
-                _downloadQueue);
+                manifest);
+
+            // Initialize with resources (simulating what CloudFetchDownloadManager does)
+            fetcher.Initialize(_mockMemoryManager.Object, _downloadQueue);
+
+            return fetcher;
         }
 
         private ResultManifest CreateTestManifest(int chunkCount, int linksPerChunk = 1)

--- a/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
+++ b/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
@@ -1,0 +1,577 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+using Moq;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Reader.CloudFetch
+{
+    public class StatementExecutionResultFetcherTests
+    {
+        private readonly Mock<IStatementExecutionClient> _mockClient;
+        private readonly Mock<ICloudFetchMemoryBufferManager> _mockMemoryManager;
+        private readonly BlockingCollection<IDownloadResult> _downloadQueue;
+        private const string TestStatementId = "test-statement-123";
+
+        public StatementExecutionResultFetcherTests()
+        {
+            _mockClient = new Mock<IStatementExecutionClient>();
+            _mockMemoryManager = new Mock<ICloudFetchMemoryBufferManager>();
+            _downloadQueue = new BlockingCollection<IDownloadResult>();
+        }
+
+        #region Constructor Tests
+
+        [Fact]
+        public void Constructor_WithValidParameters_CreatesFetcher()
+        {
+            var manifest = CreateTestManifest(chunkCount: 1);
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                TestStatementId,
+                manifest,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            Assert.NotNull(fetcher);
+        }
+
+        [Fact]
+        public void Constructor_WithNullClient_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(chunkCount: 1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    null!,
+                    TestStatementId,
+                    manifest,
+                    _mockMemoryManager.Object,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullStatementId_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(chunkCount: 1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    null!,
+                    manifest,
+                    _mockMemoryManager.Object,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullManifest_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    TestStatementId,
+                    null!,
+                    _mockMemoryManager.Object,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullMemoryManager_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(chunkCount: 1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    TestStatementId,
+                    manifest,
+                    null!,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullDownloadQueue_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(chunkCount: 1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    TestStatementId,
+                    manifest,
+                    _mockMemoryManager.Object,
+                    null!));
+        }
+
+        #endregion
+
+        #region Manifest-Based Fetching Tests
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithManifestLinks_AddsAllDownloadResults()
+        {
+            // Arrange: Create manifest with 2 chunks, each with 1 external link
+            var manifest = CreateTestManifest(chunkCount: 2, linksPerChunk: 1);
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100); // Give time for background task to complete
+
+            // Assert
+            var results = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result, 0))
+            {
+                results.Add(result);
+            }
+
+            // Should have 2 download results + 1 EndOfResultsGuard
+            Assert.Equal(3, results.Count);
+            Assert.True(results[2] is EndOfResultsGuard);
+            Assert.True(fetcher.IsCompleted);
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithMultipleLinksPerChunk_AddsAllLinks()
+        {
+            // Arrange: Create manifest with 1 chunk containing 3 external links
+            var manifest = CreateTestManifest(chunkCount: 1, linksPerChunk: 3);
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            var results = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result, 0))
+            {
+                results.Add(result);
+            }
+
+            // Should have 3 download results + 1 EndOfResultsGuard
+            Assert.Equal(4, results.Count);
+            Assert.True(results[3] is EndOfResultsGuard);
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithExternalLinks_CreatesCorrectDownloadResults()
+        {
+            // Arrange
+            var externalLink = CreateTestExternalLink(
+                url: "https://s3.amazonaws.com/bucket/file1.arrow",
+                rowOffset: 0,
+                rowCount: 1000,
+                byteCount: 10240,
+                expiration: DateTime.UtcNow.AddHours(1).ToString("o"));
+
+            var manifest = CreateTestManifestWithLinks(new[] { externalLink });
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            _downloadQueue.TryTake(out var result, 0);
+            Assert.NotNull(result);
+            Assert.NotEqual(typeof(EndOfResultsGuard), result.GetType());
+            Assert.Equal("https://s3.amazonaws.com/bucket/file1.arrow", result.FileUrl);
+            Assert.Equal(0, result.StartRowOffset);
+            Assert.Equal(1000, result.RowCount);
+            Assert.Equal(10240, result.ByteCount);
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithHttpHeaders_PassesHeadersToDownloadResult()
+        {
+            // Arrange
+            var headers = new Dictionary<string, string>
+            {
+                { "x-amz-server-side-encryption-customer-algorithm", "AES256" },
+                { "x-amz-server-side-encryption-customer-key", "test-key" }
+            };
+
+            var externalLink = CreateTestExternalLink(
+                url: "https://s3.amazonaws.com/bucket/file1.arrow",
+                rowOffset: 0,
+                rowCount: 1000,
+                byteCount: 10240,
+                httpHeaders: headers);
+
+            var manifest = CreateTestManifestWithLinks(new[] { externalLink });
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            _downloadQueue.TryTake(out var result, 0);
+            Assert.NotNull(result);
+            Assert.NotNull(result.HttpHeaders);
+            Assert.Equal(2, result.HttpHeaders.Count);
+            Assert.Equal("AES256", result.HttpHeaders["x-amz-server-side-encryption-customer-algorithm"]);
+            Assert.Equal("test-key", result.HttpHeaders["x-amz-server-side-encryption-customer-key"]);
+        }
+
+        #endregion
+
+        #region Incremental Chunk Fetching Tests
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithoutManifestLinks_CallsGetResultChunkAsync()
+        {
+            // Arrange: Create manifest with chunks but no external links
+            var manifest = CreateTestManifest(chunkCount: 2, linksPerChunk: 0);
+
+            var resultData1 = CreateTestResultData(1, new[]
+            {
+                CreateTestExternalLink("https://s3.amazonaws.com/file1.arrow", 0, 500, 5120)
+            });
+
+            var resultData2 = CreateTestResultData(2, new[]
+            {
+                CreateTestExternalLink("https://s3.amazonaws.com/file2.arrow", 500, 500, 5120)
+            });
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(TestStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(resultData1);
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(TestStatementId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(resultData2);
+
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            _mockClient.Verify(c => c.GetResultChunkAsync(TestStatementId, 0, It.IsAny<CancellationToken>()), Times.Once);
+            _mockClient.Verify(c => c.GetResultChunkAsync(TestStatementId, 1, It.IsAny<CancellationToken>()), Times.Once);
+
+            var results = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result, 0))
+            {
+                results.Add(result);
+            }
+
+            // Should have 2 download results + 1 EndOfResultsGuard
+            Assert.Equal(3, results.Count);
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_IncrementalFetching_CreatesCorrectDownloadResults()
+        {
+            // Arrange
+            var manifest = CreateTestManifest(chunkCount: 1, linksPerChunk: 0);
+
+            var resultData = CreateTestResultData(0, new[]
+            {
+                CreateTestExternalLink("https://s3.amazonaws.com/file1.arrow", 0, 1000, 10240)
+            });
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(TestStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(resultData);
+
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            _downloadQueue.TryTake(out var result, 0);
+            Assert.NotNull(result);
+            Assert.Equal("https://s3.amazonaws.com/file1.arrow", result.FileUrl);
+            Assert.Equal(0, result.StartRowOffset);
+            Assert.Equal(1000, result.RowCount);
+            Assert.Equal(10240, result.ByteCount);
+        }
+
+        #endregion
+
+        #region GetDownloadResultAsync Tests
+
+        [Fact]
+        public async Task GetDownloadResultAsync_ReturnsNull()
+        {
+            // Arrange
+            var manifest = CreateTestManifest(chunkCount: 1);
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            var result = await fetcher.GetDownloadResultAsync(0, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region Error Handling Tests
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithEmptyManifest_CompletesSuccessfully()
+        {
+            // Arrange
+            var manifest = CreateTestManifest(chunkCount: 0);
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            Assert.True(fetcher.IsCompleted);
+            Assert.False(fetcher.HasError);
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithCancellation_StopsGracefully()
+        {
+            // Arrange
+            var manifest = CreateTestManifest(chunkCount: 10, linksPerChunk: 1);
+            var cts = new CancellationTokenSource();
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(cts.Token);
+            cts.Cancel();
+            await Task.Delay(100);
+
+            // Assert
+            Assert.True(fetcher.IsCompleted);
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WhenGetResultChunkThrows_SetsError()
+        {
+            // Arrange
+            var manifest = CreateTestManifest(chunkCount: 1, linksPerChunk: 0);
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(TestStatementId, It.IsAny<long>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Network error"));
+
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            Assert.True(fetcher.HasError);
+            Assert.NotNull(fetcher.Error);
+            Assert.Contains("Network error", fetcher.Error.Message);
+        }
+
+        #endregion
+
+        #region Expiration Time Parsing Tests
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithValidISO8601Expiration_ParsesCorrectly()
+        {
+            // Arrange
+            var expectedExpiration = DateTime.UtcNow.AddHours(2);
+            var externalLink = CreateTestExternalLink(
+                url: "https://s3.amazonaws.com/file1.arrow",
+                rowOffset: 0,
+                rowCount: 1000,
+                byteCount: 10240,
+                expiration: expectedExpiration.ToString("o"));
+
+            var manifest = CreateTestManifestWithLinks(new[] { externalLink });
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            _downloadQueue.TryTake(out var result, 0);
+            Assert.NotNull(result);
+            // Allow small time difference due to parsing
+            Assert.True(Math.Abs((result.ExpirationTime - expectedExpiration).TotalSeconds) < 1);
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithInvalidExpiration_UsesDefaultExpiration()
+        {
+            // Arrange
+            var externalLink = CreateTestExternalLink(
+                url: "https://s3.amazonaws.com/file1.arrow",
+                rowOffset: 0,
+                rowCount: 1000,
+                byteCount: 10240,
+                expiration: "invalid-date");
+
+            var manifest = CreateTestManifestWithLinks(new[] { externalLink });
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            _downloadQueue.TryTake(out var result, 0);
+            Assert.NotNull(result);
+            // Should default to ~1 hour from now
+            var timeDiff = (result.ExpirationTime - DateTime.UtcNow).TotalMinutes;
+            Assert.InRange(timeDiff, 50, 70); // Allow some variance
+        }
+
+        [Fact]
+        public async Task FetchAllResultsAsync_WithNullExpiration_UsesDefaultExpiration()
+        {
+            // Arrange
+            var externalLink = CreateTestExternalLink(
+                url: "https://s3.amazonaws.com/file1.arrow",
+                rowOffset: 0,
+                rowCount: 1000,
+                byteCount: 10240,
+                expiration: null);
+
+            var manifest = CreateTestManifestWithLinks(new[] { externalLink });
+            var fetcher = CreateFetcher(manifest);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            _downloadQueue.TryTake(out var result, 0);
+            Assert.NotNull(result);
+            // Should default to ~1 hour from now
+            var timeDiff = (result.ExpirationTime - DateTime.UtcNow).TotalMinutes;
+            Assert.InRange(timeDiff, 50, 70);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private StatementExecutionResultFetcher CreateFetcher(ResultManifest manifest)
+        {
+            return new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                TestStatementId,
+                manifest,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+        }
+
+        private ResultManifest CreateTestManifest(int chunkCount, int linksPerChunk = 1)
+        {
+            var chunks = new List<ResultChunk>();
+            for (int i = 0; i < chunkCount; i++)
+            {
+                var chunk = new ResultChunk
+                {
+                    ChunkIndex = i,
+                    RowCount = 1000,
+                    RowOffset = i * 1000,
+                    ByteCount = 10240
+                };
+
+                if (linksPerChunk > 0)
+                {
+                    chunk.ExternalLinks = new List<ExternalLink>();
+                    for (int j = 0; j < linksPerChunk; j++)
+                    {
+                        chunk.ExternalLinks.Add(CreateTestExternalLink(
+                            $"https://s3.amazonaws.com/file{i}_{j}.arrow",
+                            i * 1000 + j * 100,
+                            100,
+                            1024));
+                    }
+                }
+
+                chunks.Add(chunk);
+            }
+
+            return new ResultManifest
+            {
+                TotalChunkCount = chunkCount,
+                Chunks = chunks,
+                TotalRowCount = chunkCount * 1000,
+                TotalByteCount = chunkCount * 10240
+            };
+        }
+
+        private ResultManifest CreateTestManifestWithLinks(ExternalLink[] links)
+        {
+            return new ResultManifest
+            {
+                TotalChunkCount = 1,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk
+                    {
+                        ChunkIndex = 0,
+                        RowCount = links.Sum(l => l.RowCount),
+                        RowOffset = 0,
+                        ByteCount = links.Sum(l => l.ByteCount),
+                        ExternalLinks = links.ToList()
+                    }
+                },
+                TotalRowCount = links.Sum(l => l.RowCount),
+                TotalByteCount = links.Sum(l => l.ByteCount)
+            };
+        }
+
+        private ExternalLink CreateTestExternalLink(
+            string url,
+            long rowOffset,
+            long rowCount,
+            long byteCount,
+            string? expiration = null,
+            Dictionary<string, string>? httpHeaders = null)
+        {
+            return new ExternalLink
+            {
+                ExternalLinkUrl = url,
+                RowOffset = rowOffset,
+                RowCount = rowCount,
+                ByteCount = byteCount,
+                Expiration = expiration ?? DateTime.UtcNow.AddHours(1).ToString("o"),
+                HttpHeaders = httpHeaders
+            };
+        }
+
+        private ResultData CreateTestResultData(long chunkIndex, ExternalLink[] links)
+        {
+            return new ResultData
+            {
+                ChunkIndex = chunkIndex,
+                ExternalLinks = links.ToList()
+            };
+        }
+
+        #endregion
+    }
+}

--- a/csharp/test/Unit/StatementExecution/StatementExecutionConnectionTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionConnectionTests.cs
@@ -1,0 +1,403 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Moq;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.StatementExecution
+{
+    public class StatementExecutionConnectionTests
+    {
+        private readonly Mock<IStatementExecutionClient> _mockClient;
+
+        public StatementExecutionConnectionTests()
+        {
+            _mockClient = new Mock<IStatementExecutionClient>();
+        }
+
+        #region Constructor Tests
+
+        [Fact]
+        public void Constructor_WithValidParameters_CreatesConnection()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse-id" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            Assert.NotNull(connection);
+            Assert.Equal("test-warehouse-id", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void Constructor_WithNullClient_ThrowsArgumentNullException()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse-id" }
+            };
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionConnection(null!, properties));
+        }
+
+        [Fact]
+        public void Constructor_WithNullProperties_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionConnection(_mockClient.Object, null!));
+        }
+
+        [Fact]
+        public void Constructor_WithMissingHttpPath_ThrowsArgumentException()
+        {
+            var properties = new Dictionary<string, string>();
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new StatementExecutionConnection(_mockClient.Object, properties));
+
+            Assert.Contains("Missing required property", exception.Message);
+        }
+
+        [Fact]
+        public void Constructor_WithEmptyHttpPath_ThrowsArgumentException()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "" }
+            };
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new StatementExecutionConnection(_mockClient.Object, properties));
+
+            Assert.Contains("cannot be null or empty", exception.Message);
+        }
+
+        [Fact]
+        public void Constructor_WithCatalogAndSchema_ExtractsValues()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse-id" },
+                { AdbcOptions.Connection.CurrentCatalog, "my_catalog" },
+                { AdbcOptions.Connection.CurrentDbSchema, "my_schema" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            Assert.NotNull(connection);
+            // Catalog and Schema are not exposed as public properties, but they should be used in OpenAsync
+        }
+
+        #endregion
+
+        #region Warehouse ID Extraction Tests
+
+        [Fact]
+        public void Constructor_WithStandardHttpPath_ExtractsWarehouseId()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123def456" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            Assert.Equal("abc123def456", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void Constructor_WithTrailingSlash_ExtractsWarehouseId()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123def456/" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            Assert.Equal("abc123def456", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void Constructor_WithSparkParametersPath_ExtractsWarehouseId()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/fallback-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            Assert.Equal("fallback-warehouse", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void Constructor_WithUppercaseWarehouses_ExtractsWarehouseId()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/WAREHOUSES/uppercase-id" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            Assert.Equal("uppercase-id", connection.WarehouseId);
+        }
+
+        [Fact]
+        public void Constructor_WithInvalidHttpPath_ThrowsArgumentException()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/invalid/path" }
+            };
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new StatementExecutionConnection(_mockClient.Object, properties));
+
+            Assert.Contains("Invalid http_path format", exception.Message);
+        }
+
+        [Fact]
+        public void Constructor_WithMissingWarehouseId_ThrowsArgumentException()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/" }
+            };
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new StatementExecutionConnection(_mockClient.Object, properties));
+
+            Assert.Contains("Invalid http_path format", exception.Message);
+        }
+
+        #endregion
+
+        #region Session Management Tests
+
+        [Fact]
+        public async Task OpenAsync_WithSessionManagementEnabled_CreatesSession()
+        {
+            var expectedSessionId = "test-session-123";
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" },
+                { AdbcOptions.Connection.CurrentCatalog, "main" },
+                { AdbcOptions.Connection.CurrentDbSchema, "default" }
+            };
+
+            _mockClient
+                .Setup(c => c.CreateSessionAsync(
+                    It.IsAny<CreateSessionRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateSessionResponse { SessionId = expectedSessionId });
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            await connection.OpenAsync();
+
+            Assert.Equal(expectedSessionId, connection.SessionId);
+
+            _mockClient.Verify(c => c.CreateSessionAsync(
+                It.Is<CreateSessionRequest>(req =>
+                    req.WarehouseId == "test-warehouse" &&
+                    req.Catalog == "main" &&
+                    req.Schema == "default"),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task OpenAsync_WithSessionManagementDisabled_DoesNotCreateSession()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" },
+                { DatabricksParameters.EnableSessionManagement, "false" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            await connection.OpenAsync();
+
+            Assert.Null(connection.SessionId);
+
+            _mockClient.Verify(c => c.CreateSessionAsync(
+                It.IsAny<CreateSessionRequest>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task OpenAsync_WithoutCatalogAndSchema_CreatesSessionWithoutThem()
+        {
+            var expectedSessionId = "test-session-456";
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            _mockClient
+                .Setup(c => c.CreateSessionAsync(
+                    It.IsAny<CreateSessionRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateSessionResponse { SessionId = expectedSessionId });
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            await connection.OpenAsync();
+
+            Assert.Equal(expectedSessionId, connection.SessionId);
+
+            _mockClient.Verify(c => c.CreateSessionAsync(
+                It.Is<CreateSessionRequest>(req =>
+                    req.WarehouseId == "test-warehouse" &&
+                    req.Catalog == null &&
+                    req.Schema == null),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CloseAsync_WithActiveSession_DeletesSession()
+        {
+            var sessionId = "test-session-789";
+            var warehouseId = "test-warehouse";
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, $"/sql/1.0/warehouses/{warehouseId}" }
+            };
+
+            _mockClient
+                .Setup(c => c.CreateSessionAsync(
+                    It.IsAny<CreateSessionRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateSessionResponse { SessionId = sessionId });
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            await connection.OpenAsync();
+            await connection.CloseAsync();
+
+            Assert.Null(connection.SessionId);
+
+            _mockClient.Verify(c => c.DeleteSessionAsync(
+                sessionId,
+                warehouseId,
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CloseAsync_WithSessionManagementDisabled_DoesNotDeleteSession()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" },
+                { DatabricksParameters.EnableSessionManagement, "false" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            await connection.OpenAsync();
+            await connection.CloseAsync();
+
+            _mockClient.Verify(c => c.DeleteSessionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CloseAsync_WhenDeleteSessionFails_SwallowsException()
+        {
+            var sessionId = "test-session-999";
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            _mockClient
+                .Setup(c => c.CreateSessionAsync(
+                    It.IsAny<CreateSessionRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateSessionResponse { SessionId = sessionId });
+
+            _mockClient
+                .Setup(c => c.DeleteSessionAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Session deletion failed"));
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            await connection.OpenAsync();
+
+            // Should not throw
+            await connection.CloseAsync();
+
+            Assert.Null(connection.SessionId);
+        }
+
+        [Fact]
+        public async Task Dispose_WithActiveSession_ClosesSession()
+        {
+            var sessionId = "test-session-dispose";
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            _mockClient
+                .Setup(c => c.CreateSessionAsync(
+                    It.IsAny<CreateSessionRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateSessionResponse { SessionId = sessionId });
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            await connection.OpenAsync();
+
+            connection.Dispose();
+
+            _mockClient.Verify(c => c.DeleteSessionAsync(
+                sessionId,
+                "test-warehouse",
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+
+        #region CreateStatement Tests
+
+        [Fact]
+        public void CreateStatement_ThrowsNotImplementedException()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            var exception = Assert.Throws<NotImplementedException>(() => connection.CreateStatement());
+            Assert.Contains("PECO-2791-B", exception.Message);
+        }
+
+        #endregion
+    }
+}

--- a/csharp/test/Unit/StatementExecution/StatementExecutionConnectionTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionConnectionTests.cs
@@ -382,10 +382,10 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.StatementExecution
 
         #endregion
 
-        #region CreateStatement Tests
+        #region AdbcConnection Implementation Tests
 
         [Fact]
-        public void CreateStatement_ThrowsNotImplementedException()
+        public void Connection_InheritsFromAdbcConnection()
         {
             var properties = new Dictionary<string, string>
             {
@@ -394,7 +394,107 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.StatementExecution
 
             var connection = new StatementExecutionConnection(_mockClient.Object, properties);
 
-            var exception = Assert.Throws<NotImplementedException>(() => connection.CreateStatement());
+            Assert.IsAssignableFrom<AdbcConnection>(connection);
+        }
+
+        [Fact]
+        public void CreateStatement_ReturnsStatementExecutionStatement()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            var statement = connection.CreateStatement();
+
+            Assert.NotNull(statement);
+            Assert.IsType<StatementExecutionStatement>(statement);
+        }
+
+        [Fact]
+        public void GetObjects_ThrowsNotImplemented()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            var exception = Assert.Throws<AdbcException>(() =>
+                connection.GetObjects(
+                    AdbcConnection.GetObjectsDepth.All,
+                    null, null, null, null, null));
+
+            Assert.Contains("not yet implemented", exception.Message);
+        }
+
+        [Fact]
+        public void GetTableSchema_ThrowsNotImplemented()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            var exception = Assert.Throws<AdbcException>(() =>
+                connection.GetTableSchema(null, null, "test_table"));
+
+            Assert.Contains("not yet implemented", exception.Message);
+        }
+
+        [Fact]
+        public void GetTableTypes_ThrowsNotImplemented()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+
+            var exception = Assert.Throws<AdbcException>(() =>
+                connection.GetTableTypes());
+
+            Assert.Contains("not yet implemented", exception.Message);
+        }
+
+        [Fact]
+        public void Statement_ExecuteQuery_ThrowsNotImplementedException()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            var statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 1";
+
+            var exception = Assert.Throws<NotImplementedException>(() =>
+                statement.ExecuteQuery());
+
+            Assert.Contains("PECO-2791-B", exception.Message);
+        }
+
+        [Fact]
+        public void Statement_ExecuteUpdate_ThrowsNotImplementedException()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/test-warehouse" }
+            };
+
+            var connection = new StatementExecutionConnection(_mockClient.Object, properties);
+            var statement = connection.CreateStatement();
+            statement.SqlQuery = "INSERT INTO test VALUES (1)";
+
+            var exception = Assert.Throws<NotImplementedException>(() =>
+                statement.ExecuteUpdate());
+
             Assert.Contains("PECO-2791-B", exception.Message);
         }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/17/files/66f7736845877b85df769ce53c93b8960c9eb3c4..d9ba98053d914f6f8d2195f4a4d37342d905f458) to review incremental changes.
- [stack/PECO-2788-cloudfetch-protocol-agnostic](https://github.com/adbc-drivers/databricks/pull/14) [[Files changed](https://github.com/adbc-drivers/databricks/pull/14/files)]
  - [stack/PECO-2790-statement-execution-result-fetcher](https://github.com/adbc-drivers/databricks/pull/15) [[Files changed](https://github.com/adbc-drivers/databricks/pull/15/files/2d7d1aecaa6ec5e3c101322fde7ce186ea6d02b8..318277c04119a86d4f3642f56eb60c0ab48ee0dc)]
    - [stack/PECO-2791-connection-statement-rest-execution](https://github.com/adbc-drivers/databricks/pull/16) [[Files changed](https://github.com/adbc-drivers/databricks/pull/16/files/318277c04119a86d4f3642f56eb60c0ab48ee0dc..66f7736845877b85df769ce53c93b8960c9eb3c4)]
      - [**stack/PECO-2837-session-management**](https://github.com/adbc-drivers/databricks/pull/17) [[Files changed](https://github.com/adbc-drivers/databricks/pull/17/files/66f7736845877b85df769ce53c93b8960c9eb3c4..d9ba98053d914f6f8d2195f4a4d37342d905f458)]
        - [stack/PECO-2839-inline-reader](https://github.com/adbc-drivers/databricks/pull/18) [[Files changed](https://github.com/adbc-drivers/databricks/pull/18/files/d9ba98053d914f6f8d2195f4a4d37342d905f458..f1edfb7e0ba46a8cb6793c8811a0834313cd7516)]
          - [stack/PECO-2840-protocol-selection](https://github.com/adbc-drivers/databricks/pull/19) [[Files changed](https://github.com/adbc-drivers/databricks/pull/19/files/f1edfb7e0ba46a8cb6793c8811a0834313cd7516..641f3ac3371d2fc4e16da5a6a0e6209aa41086be)]
            - [stack/PECO-2838-statement-execution](https://github.com/adbc-drivers/databricks/pull/20) [[Files changed](https://github.com/adbc-drivers/databricks/pull/20/files/641f3ac3371d2fc4e16da5a6a0e6209aa41086be..356693f61bbe940717a4debf352e61f59018473c)]
              - [stack/PECO-2792-feature-parity](https://github.com/adbc-drivers/databricks/pull/21) [[Files changed](https://github.com/adbc-drivers/databricks/pull/21/files/356693f61bbe940717a4debf352e61f59018473c..3cd98321863e76149c43b216a5822a8dcaf43eec)]
                - [stack/PECO-2849-extend-cloudfetch-e2e-tests](https://github.com/adbc-drivers/databricks/pull/22) [[Files changed](https://github.com/adbc-drivers/databricks/pull/22/files/3cd98321863e76149c43b216a5822a8dcaf43eec..815b17a5cb9438b4b8f0d6b4727bf37a4cceffa2)]

---------
## What's Changed

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
