### PR TITLE
feat(csharp): added connection params of rateLimitRetry and rateLimitRetryTimeout 

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -79,7 +79,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private const long DefaultMaxBytesPerFetchRequest = 400 * 1024 * 1024; // 400MB
         private long _maxBytesPerFetchRequest = DefaultMaxBytesPerFetchRequest;
         private const bool DefaultRetryOnUnavailable = true;
+        private const bool DefaultRateLimitRetry = true;
         private const int DefaultTemporarilyUnavailableRetryTimeout = 900;
+        private const int DefaultRateLimitRetryTimeout = 120;
         private bool _useDescTableExtended = false;
 
         // Trace propagation configuration
@@ -546,14 +548,24 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         public bool RunAsyncInThrift => _runAsyncInThrift;
 
         /// <summary>
-        /// Gets a value indicating whether to retry requests that receive a 503 response with a Retry-After header.
+        /// Gets a value indicating whether to retry requests that receive retryable responses (408, 502, 503, 504) .
         /// </summary>
         protected bool TemporarilyUnavailableRetry { get; private set; } = DefaultRetryOnUnavailable;
 
         /// <summary>
-        /// Gets the maximum total time in seconds to retry 503 responses before failing.
+        /// Gets the maximum total time in seconds to retry retryable responses (408, 502, 503, 504) before failing.
         /// </summary>
         protected int TemporarilyUnavailableRetryTimeout { get; private set; } = DefaultTemporarilyUnavailableRetryTimeout;
+
+        /// <summary>
+        /// Gets a value indicating whether to retry requests that receive HTTP 429 responses.
+        /// </summary>
+        protected bool RateLimitRetry { get; private set; } = DefaultRateLimitRetry;
+
+        /// <summary>
+        /// Gets the number of seconds to wait before stopping an attempt to retry HTTP 429 responses.
+        /// </summary>
+        protected int RateLimitRetryTimeout { get; private set; } = DefaultRateLimitRetryTimeout;
 
         protected override HttpMessageHandler CreateHttpHandler()
         {
@@ -571,7 +583,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             // Current chain order (outermost to innermost):
             // 1. OAuth handlers (OAuthDelegatingHandler, etc.) - only on baseHandler for API requests
             // 2. ThriftErrorMessageHandler - extracts x-thriftserver-error-message and throws descriptive exceptions
-            // 3. RetryHttpHandler - retries 408, 502, 503, 504 with Retry-After support
+            // 3. RetryHttpHandler - retries 408, 429, 502, 503, 504 with Retry-After support
             // 4. TracingDelegatingHandler - propagates W3C trace context
             // 5. Base HTTP handler - actual network communication
             //
@@ -592,16 +604,16 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 baseAuthHandler = new TracingDelegatingHandler(baseAuthHandler, this, _traceParentHeaderName, _traceStateEnabled);
             }
 
-            if (TemporarilyUnavailableRetry)
+            if (TemporarilyUnavailableRetry || RateLimitRetry)
             {
-                // Add retry handler for 408, 502, 503, 504 responses with Retry-After support
+                // Add retry handler for 408, 429, 502, 503, 504 responses with Retry-After support
                 // This must be INSIDE ThriftErrorMessageHandler so retries happen before exceptions are thrown
-                baseHandler = new RetryHttpHandler(baseHandler, TemporarilyUnavailableRetryTimeout);
-                baseAuthHandler = new RetryHttpHandler(baseAuthHandler, TemporarilyUnavailableRetryTimeout);
+                baseHandler = new RetryHttpHandler(baseHandler, TemporarilyUnavailableRetryTimeout, RateLimitRetryTimeout, TemporarilyUnavailableRetry, RateLimitRetry);
+                baseAuthHandler = new RetryHttpHandler(baseAuthHandler, TemporarilyUnavailableRetryTimeout, RateLimitRetryTimeout, TemporarilyUnavailableRetry, RateLimitRetry);
             }
 
             // Add Thrift error message handler AFTER retry handler (OUTSIDE in the chain)
-            // This ensures retryable status codes (408, 502, 503, 504) are retried by RetryHttpHandler
+            // This ensures retryable status codes (408, 429, 502, 503, 504) are retried by RetryHttpHandler
             // before ThriftErrorMessageHandler throws exceptions with Thrift error messages
             baseHandler = new ThriftErrorMessageHandler(baseHandler);
             baseAuthHandler = new ThriftErrorMessageHandler(baseAuthHandler);
@@ -906,6 +918,16 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 TemporarilyUnavailableRetry = tempUnavailableRetryValue;
             }
 
+            if (Properties.TryGetValue(DatabricksParameters.RateLimitRetry, out string? rateLimitRetryStr))
+            {
+                if (!bool.TryParse(rateLimitRetryStr, out bool rateLimitRetryValue))
+                {
+                    throw new ArgumentOutOfRangeException(DatabricksParameters.RateLimitRetry, rateLimitRetryStr,
+                        $"must be a value of false (disabled) or true (enabled). Default is true.");
+                }
+
+                RateLimitRetry = rateLimitRetryValue;
+            }
 
             if (Properties.TryGetValue(DatabricksParameters.TemporarilyUnavailableRetryTimeout, out string? tempUnavailableRetryTimeoutStr))
             {
@@ -916,6 +938,17 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                         $"must be a value of 0 (retry indefinitely) or a positive integer representing seconds. Default is 900 seconds (15 minutes).");
                 }
                 TemporarilyUnavailableRetryTimeout = tempUnavailableRetryTimeoutValue;
+            }
+
+            if (Properties.TryGetValue(DatabricksParameters.RateLimitRetryTimeout, out string? rateLimitRetryTimeoutStr))
+            {
+                if (!int.TryParse(rateLimitRetryTimeoutStr, out int rateLimitRetryTimeoutValue) ||
+                    rateLimitRetryTimeoutValue < 0)
+                {
+                    throw new ArgumentOutOfRangeException(DatabricksParameters.RateLimitRetryTimeout, rateLimitRetryTimeoutStr,
+                        $"must be a value of 0 (retry indefinitely) or a positive integer representing seconds. Default is 120 seconds (2 minutes).");
+                }
+                RateLimitRetryTimeout = rateLimitRetryTimeoutValue;
             }
 
             // When TemporarilyUnavailableRetry is enabled, we need to make sure connection timeout (which is used to cancel the HttpConnection) is equal

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -105,16 +105,30 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// </summary>
         public const string ServerSidePropertyPrefix = "adbc.databricks.ssp_";
 
-        /// Controls whether to retry requests that receive a 503 response with a Retry-After header.
+        /// <summary>
+        /// Controls whether to retry requests that receive retryable responses (408, 502, 503, 504).
         /// Default value is true (enabled). Set to false to disable retry behavior.
         /// </summary>
         public const string TemporarilyUnavailableRetry = "adbc.spark.temporarily_unavailable_retry";
 
         /// <summary>
-        /// Maximum total time in seconds to retry 503 responses before failing.
+        /// Maximum total time in seconds to retry retryable responses (408, 502, 503, 504) before failing.
         /// Default value is 900 seconds (15 minutes). Set to 0 to retry indefinitely.
         /// </summary>
         public const string TemporarilyUnavailableRetryTimeout = "adbc.spark.temporarily_unavailable_retry_timeout";
+
+        /// <summary>
+        /// Controls whether to retry requests that receive HTTP 429 (TooManyRequests) response.
+        /// Default value is true. Set to false to disable rate limit retry behavior.
+        /// </summary>
+        public const string RateLimitRetry = "adbc.databricks.rate_limit_retry";
+
+        /// <summary>
+        /// The number of seconds that the connector waits before stopping an attempt to retry an operation
+        /// when the operation receives an HTTP 429 response.
+        /// Default value is 120 seconds. Set to 0 to retry indefinitely.
+        /// </summary>
+        public const string RateLimitRetryTimeout = "adbc.databricks.rate_limit_retry_timeout";
 
         /// <summary>
         /// Maximum number of parallel downloads for CloudFetch operations.

--- a/csharp/src/RetryHttpHandler.cs
+++ b/csharp/src/RetryHttpHandler.cs
@@ -31,12 +31,15 @@ using System.IO;
 namespace Apache.Arrow.Adbc.Drivers.Databricks
 {
     /// <summary>
-    /// HTTP handler that implements retry behavior for 408, 502, 503, and 504 responses.
+    /// HTTP handler that implements retry behavior for 408, 429, 502, 503, and 504 responses.
     /// Uses Retry-After header if present, otherwise uses exponential backoff.
     /// </summary>
     internal class RetryHttpHandler : DelegatingHandler
     {
         private readonly int _retryTimeoutSeconds;
+        private readonly int _rateLimitRetryTimeoutSeconds;
+        private readonly bool _retryTemporarilyUnavailableEnabled;
+        private readonly bool _rateLimitRetryEnabled;
         private readonly int _initialBackoffSeconds = 1;
         private readonly int _maxBackoffSeconds = 32;
 
@@ -44,11 +47,28 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Initializes a new instance of the <see cref="RetryHttpHandler"/> class.
         /// </summary>
         /// <param name="innerHandler">The inner handler to delegate to.</param>
-        /// <param name="retryTimeoutSeconds">Maximum total time in seconds to retry before failing.</param>
-        public RetryHttpHandler(HttpMessageHandler innerHandler, int retryTimeoutSeconds)
+        /// <param name="retryTimeoutSeconds">Maximum total time in seconds to retry retryable responses (408, 502, 503, 504) before failing.</param>
+        /// <param name="rateLimitRetryTimeoutSeconds">Maximum total time in seconds to retry HTTP 429 responses before failing.</param>
+        public RetryHttpHandler(HttpMessageHandler innerHandler, int retryTimeoutSeconds, int rateLimitRetryTimeoutSeconds)
+            : this(innerHandler, retryTimeoutSeconds, rateLimitRetryTimeoutSeconds, true, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryHttpHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to delegate to.</param>
+        /// <param name="retryTimeoutSeconds">Maximum total time in seconds to retry retryable responses (408, 502, 503, 504) before failing.</param>
+        /// <param name="rateLimitRetryTimeoutSeconds">Maximum total time in seconds to retry 429 (rate limit) responses before failing.</param>
+        /// <param name="retryTemporarilyUnavailableEnabled">Whether to retry temporarily unavailable (408, 502, 503, 504) responses.</param>
+        /// <param name="rateLimitRetryEnabled">Whether to retry HTTP 429 responses.</param>
+        public RetryHttpHandler(HttpMessageHandler innerHandler, int retryTimeoutSeconds, int rateLimitRetryTimeoutSeconds, bool retryTemporarilyUnavailableEnabled, bool rateLimitRetryEnabled)
             : base(innerHandler)
         {
             _retryTimeoutSeconds = retryTimeoutSeconds;
+            _rateLimitRetryTimeoutSeconds = rateLimitRetryTimeoutSeconds;
+            _retryTemporarilyUnavailableEnabled = retryTemporarilyUnavailableEnabled;
+            _rateLimitRetryEnabled = rateLimitRetryEnabled;
         }
 
         /// <summary>
@@ -65,10 +85,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
             HttpResponseMessage response;
             string? lastErrorMessage = null;
-            DateTime startTime = DateTime.UtcNow;
             int attemptCount = 0;
             int currentBackoffSeconds = _initialBackoffSeconds;
-            int totalRetrySeconds = 0;
+            int totalServiceUnavailableRetrySeconds = 0;
+            int totalTooManyRequestsRetrySeconds = 0;
 
             do
             {
@@ -87,14 +107,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 }
 
                 attemptCount++;
-
-                // Check if we've exceeded the timeout
-                TimeSpan elapsedTime = DateTime.UtcNow - startTime;
-                if (_retryTimeoutSeconds > 0 && elapsedTime.TotalSeconds > _retryTimeoutSeconds)
-                {
-                    // We've exceeded the timeout, so break out of the loop
-                    break;
-                }
 
                 int waitSeconds;
 
@@ -129,12 +141,27 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 // Reset the request content for the next attempt
                 request.Content = null;
 
-                // Update total retry time
-                totalRetrySeconds += waitSeconds;
-                if (_retryTimeoutSeconds > 0 && totalRetrySeconds > _retryTimeoutSeconds)
+                // Check if we would exceed the timeout after waiting, based on error type
+                bool isTooManyRequests = response.StatusCode == (HttpStatusCode)429;
+                if (isTooManyRequests)
                 {
-                    // We've exceeded the timeout, so break out of the loop
-                    break;
+                    // Check 429 rate limit timeout
+                    if (_rateLimitRetryTimeoutSeconds > 0 && totalTooManyRequestsRetrySeconds + waitSeconds > _rateLimitRetryTimeoutSeconds)
+                    {
+                        // We've exceeded the rate limit retry timeout, so break out of the loop
+                        break;
+                    }
+                    totalTooManyRequestsRetrySeconds += waitSeconds;
+                }
+                else
+                {
+                    // Check service unavailable timeout for other retryable errors (408, 502, 503, 504)
+                    if (_retryTimeoutSeconds > 0 && totalServiceUnavailableRetrySeconds + waitSeconds > _retryTimeoutSeconds)
+                    {
+                        // We've exceeded the retry timeout, so break out of the loop
+                        break;
+                    }
+                    totalServiceUnavailableRetrySeconds += waitSeconds;
                 }
 
                 // Wait for the calculated time
@@ -159,10 +186,18 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// </summary>
         private bool IsRetryableStatusCode(HttpStatusCode statusCode)
         {
-            return statusCode == HttpStatusCode.RequestTimeout ||      // 408
-                   statusCode == HttpStatusCode.BadGateway ||          // 502
-                   statusCode == HttpStatusCode.ServiceUnavailable ||  // 503
-                   statusCode == HttpStatusCode.GatewayTimeout;        // 504
+            // Check too many requests separately
+            if (statusCode == (HttpStatusCode)429)         // 429 Too Many Requests
+                return _rateLimitRetryEnabled;
+
+            // Check other retryable codes
+            if (statusCode == HttpStatusCode.RequestTimeout ||        // 408
+                statusCode == HttpStatusCode.BadGateway ||            // 502
+                statusCode == HttpStatusCode.ServiceUnavailable ||    // 503
+                statusCode == HttpStatusCode.GatewayTimeout)          // 504
+                return _retryTemporarilyUnavailableEnabled;
+
+            return false;
         }
 
         /// <summary>

--- a/csharp/test/Unit/RetryHttpHandlerTest.cs
+++ b/csharp/test/Unit/RetryHttpHandlerTest.cs
@@ -55,7 +55,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
                 });
 
             // Create the RetryHttpHandler with retry enabled and a 5-second timeout
-            var retryHandler = new RetryHttpHandler(mockHandler, 5);
+            var retryHandler = new RetryHttpHandler(mockHandler, 5, 5, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -90,7 +90,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
                 });
 
             // Create the RetryHttpHandler with retry enabled and a 1-second timeout
-            var retryHandler = new RetryHttpHandler(mockHandler, 1);
+            var retryHandler = new RetryHttpHandler(mockHandler, 1, 1, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -121,7 +121,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
                 });
 
             // Create the RetryHttpHandler with retry enabled
-            var retryHandler = new RetryHttpHandler(mockHandler, 5);
+            var retryHandler = new RetryHttpHandler(mockHandler, 5, 5, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -149,7 +149,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
                 });
 
             // Create the RetryHttpHandler with retry enabled
-            var retryHandler = new RetryHttpHandler(mockHandler, 5);
+            var retryHandler = new RetryHttpHandler(mockHandler, 5, 5, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -197,7 +197,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
             });
 
             // Create the RetryHttpHandler with retry enabled
-            var retryHandler = new RetryHttpHandler(mockHandler, 5);
+            var retryHandler = new RetryHttpHandler(mockHandler, 5, 5, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -229,7 +229,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
                 });
 
             // Create the RetryHttpHandler with retry enabled
-            var retryHandler = new RetryHttpHandler(mockHandler, 5);
+            var retryHandler = new RetryHttpHandler(mockHandler, 5, 5, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -263,7 +263,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
                 });
 
             // Create the RetryHttpHandler with retry enabled and a generous timeout
-            var retryHandler = new RetryHttpHandler(mockHandler, 10);
+            var retryHandler = new RetryHttpHandler(mockHandler, 10, 10, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -302,7 +302,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
                 });
 
             // Create the RetryHttpHandler with a short timeout to make the test run faster
-            var retryHandler = new RetryHttpHandler(mockHandler, 3);
+            var retryHandler = new RetryHttpHandler(mockHandler, 3, 3, true, true);
 
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
@@ -317,6 +317,73 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
 
             // Verify we tried multiple times before giving up
             Assert.True(mockHandler.RequestCount > 1, $"Expected multiple requests, but got {mockHandler.RequestCount}");
+        }
+
+        /// <summary>
+        /// Tests that the RetryHttpHandler properly handles HTTP TooManyRequests (429) responses with separate timeout.
+        /// </summary>
+        [Fact]
+        public async Task RetryHandlerHandlesRateLimitWithSeparateTimeout()
+        {
+            // Create a mock handler that returns a TooManyRequests (429) response with a Retry-After header
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage((HttpStatusCode)429)
+                {
+                    Headers = { { "Retry-After", "1" } },
+                    Content = new StringContent("Too Many Requests")
+                });
+
+            // Create the RetryHttpHandler with different timeouts: 900s for ServiceUnavailable, 2s for TooManyRequests
+            var retryHandler = new RetryHttpHandler(mockHandler, 900, 2, true, true);
+
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+
+            // Set the mock handler to return a success response after the first retry
+            mockHandler.SetResponseAfterRetryCount(1, new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("Success")
+            });
+
+            // Send a request
+            var response = await httpClient.GetAsync("http://test.com");
+
+            // Verify the response is OK
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Success", await response.Content.ReadAsStringAsync());
+            Assert.Equal(2, mockHandler.RequestCount); // Initial request + 1 retry
+        }
+
+        /// <summary>
+        /// Tests that the RetryHttpHandler respects the rate limit timeout for TooManyRequests (429) responses.
+        /// </summary>
+        [Fact]
+        public async Task RetryHandlerRespectsRateLimitTimeout()
+        {
+            // Create a mock handler that always returns a TooManyRequests (429) response with a Retry-After header
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage((HttpStatusCode)429)
+                {
+                    Headers = { { "Retry-After", "2" } },
+                    Content = new StringContent("Too Many Requests")
+                });
+
+            // Create the RetryHttpHandler with different timeouts: 900s for ServiceUnavailable, 1s for TooManyRequests
+            var retryHandler = new RetryHttpHandler(mockHandler, 900, 1, true, true);
+
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+
+            // Send a request and expect a DatabricksException
+            var exception = await Assert.ThrowsAsync<DatabricksException>(async () =>
+                await httpClient.GetAsync("http://test.com"));
+
+            // Verify the exception has the correct SQL state
+            Assert.Contains("08001", exception.SqlState);
+            Assert.Equal(AdbcStatusCode.IOError, exception.Status);
+
+            // Verify we only tried once (since the Retry-After value of 2 exceeds our TooManyRequests timeout of 1)
+            Assert.Equal(1, mockHandler.RequestCount);
         }
 
         /// <summary>


### PR DESCRIPTION
### **Summary**
Adds support for separate retry configuration for HTTP 429 (Too Many Requests) responses, allowing independent control of rate limit retry behavior from other retryable errors (408, 502, 503, 504).

### **What's Changed**

- **New Connection Parameters:** 
1. `adbc.databricks.rate_limit_retry` (boolean, default: true): Controls whether to retry HTTP 429 (TooManyRequests) responses. Can be disabled independently from other retry types
Example: `"adbc.databricks.rate_limit_retry": "false"`
2. `adbc.databricks.rate_limit_retry_timeout` (integer, default: 120 seconds): Maximum total time in seconds to retry HTTP 429 responses before failing. Set to 0 to retry indefinitely
Separate from the `TemporarilyUnavailableRetryTimeout` (900 seconds for 408/502/503/504)
Example: `"adbc.databricks.rate_limit_retry_timeout": "60"`