### PR TITLE
feat(csharp): add Activity-based logging to RetryHttpHandler

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -608,8 +608,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             {
                 // Add retry handler for 408, 429, 502, 503, 504 responses with Retry-After support
                 // This must be INSIDE ThriftErrorMessageHandler so retries happen before exceptions are thrown
-                baseHandler = new RetryHttpHandler(baseHandler, TemporarilyUnavailableRetryTimeout, RateLimitRetryTimeout, TemporarilyUnavailableRetry, RateLimitRetry);
-                baseAuthHandler = new RetryHttpHandler(baseAuthHandler, TemporarilyUnavailableRetryTimeout, RateLimitRetryTimeout, TemporarilyUnavailableRetry, RateLimitRetry);
+                baseHandler = new RetryHttpHandler(baseHandler, this, TemporarilyUnavailableRetryTimeout, RateLimitRetryTimeout, TemporarilyUnavailableRetry, RateLimitRetry);
+                baseAuthHandler = new RetryHttpHandler(baseAuthHandler, this, TemporarilyUnavailableRetryTimeout, RateLimitRetryTimeout, TemporarilyUnavailableRetry, RateLimitRetry);
             }
 
             // Add Thrift error message handler AFTER retry handler (OUTSIDE in the chain)


### PR DESCRIPTION
## Summary

Adds Activity-based logging to `RetryHttpHandler` to track HTTP retry attempts for better observability and debugging of retry scenarios.

## Changes

### Core Implementation
- **RetryHttpHandler.cs**: Wrapped entire `SendAsync` method in `TraceActivityAsync` to create Activities for retry operations
- **DatabricksConnection.cs**: Updated `RetryHttpHandler` instantiation to pass `IActivityTracer` for trace context propagation
- **RetryHttpHandlerTest.cs**: Added test to verify `IActivityTracer` interface implementation and retry behavior

### Key Features
1. **Single Activity Per Request**: All retry attempts for a single request are logged to the same Activity
2. **PowerBI Compatible**: Implements `IActivityTracer` interface for proper trace context propagation
3. **Comprehensive Tags**: Logs retry attempt number, HTTP status codes, outcomes, and total attempts
4. **Consistent Pattern**: Uses `TraceActivityAsync` extension method following established codebase patterns

### Logged Activity Tags
- `http.retry.attempt`: Current retry attempt number (1, 2, 3, ...)
- `http.response.status_code`: HTTP status code (408, 429, 502, 503, 504)
- `http.retry.outcome`: Final outcome on failure
  - `"timeout_exceeded"` - Service unavailable timeout reached
  - `"rate_limit_timeout_exceeded"` - Rate limit timeout reached
  - `"cancelled"` - Request was cancelled
- `http.retry.total_attempts`: Total number of attempts made

## Implementation Pattern

```csharp
return await this.TraceActivityAsync(async activity =>
{
    // Entire retry logic wrapped in single Activity
    do
    {
        response = await base.SendAsync(request, cancellationToken);
        
        if (!IsRetryableStatusCode(response.StatusCode))
        {
            return response;
        }
        
        attemptCount++;
        activity?.SetTag("http.retry.attempt", attemptCount);
        activity?.SetTag("http.response.status_code", (int)response.StatusCode);
        
        // Calculate backoff, wait, and retry...
    } while (!cancellationToken.IsCancellationRequested);
});
```

## Testing

All 17 existing tests pass:
- ✅ Retry behavior preserved (408, 429, 502, 503, 504 status codes)
- ✅ Exponential backoff with jitter working correctly
- ✅ Retry-After header handling intact
- ✅ Timeout checking for both rate limit and service unavailable errors
- ✅ IActivityTracer interface implementation verified

Test command:
```bash
cd csharp/test
dotnet test --filter "FullyQualifiedName~RetryHttpHandlerTest"
```

Result: **17/17 tests passed** (27.7 seconds)

## Tracing Output Example

When retries occur, Activities are logged to trace files (default: `~/Library/Application Support/Apache.Arrow.Adbc/Traces/`):

```json
{
  "Name": "SendAsync",
  "OperationName": "SendAsync",
  "Tags": {
    "http.retry.attempt": 2,
    "http.response.status_code": 503,
    "http.retry.outcome": "timeout_exceeded",
    "http.retry.total_attempts": 3
  },
  "Status": "Error",
  "Duration": "00:00:03.2145678"
}
```

## Original Control Flow Preserved

- All `break` statements work identically
- Exceptions thrown at the same points
- Content restoration logic unchanged
- Timeout calculations and backoff logic preserved exactly
- Zero regressions in existing functionality