### PR TITLE
feat(csharp): add FileDownloadMetrics for tracking download performance

### DIFF
--- a/csharp/src/Reader/CloudFetch/FileDownloadMetrics.cs
+++ b/csharp/src/Reader/CloudFetch/FileDownloadMetrics.cs
@@ -1,0 +1,144 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
+{
+    /// <summary>
+    /// Tracks timing and throughput metrics for individual file downloads.
+    /// Thread-safe for concurrent access.
+    /// </summary>
+    internal class FileDownloadMetrics
+    {
+        private readonly object _lock = new object();
+        private DateTime? _downloadEndTime;
+        private bool _wasCancelledAsStragler;
+
+        // Minimum elapsed time to avoid unrealistic throughput calculations
+        private const double MinimumElapsedSecondsForThroughput = 0.001;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileDownloadMetrics"/> class.
+        /// </summary>
+        /// <param name="fileOffset">The file offset in the download batch.</param>
+        /// <param name="fileSizeBytes">The size of the file in bytes.</param>
+        public FileDownloadMetrics(long fileOffset, long fileSizeBytes)
+        {
+            if (fileSizeBytes <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(fileSizeBytes),
+                    fileSizeBytes,
+                    "File size must be positive");
+            }
+
+            FileOffset = fileOffset;
+            FileSizeBytes = fileSizeBytes;
+            DownloadStartTime = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Gets the file offset in the download batch.
+        /// </summary>
+        public long FileOffset { get; }
+
+        /// <summary>
+        /// Gets the size of the file in bytes.
+        /// </summary>
+        public long FileSizeBytes { get; }
+
+        /// <summary>
+        /// Gets the time when the download started.
+        /// </summary>
+        public DateTime DownloadStartTime { get; }
+
+        /// <summary>
+        /// Gets the time when the download completed, or null if still in progress.
+        /// </summary>
+        public DateTime? DownloadEndTime => _downloadEndTime;
+
+        /// <summary>
+        /// Gets a value indicating whether the download has completed.
+        /// </summary>
+        public bool IsDownloadCompleted => _downloadEndTime.HasValue;
+
+        /// <summary>
+        /// Gets a value indicating whether this download was cancelled as a straggler.
+        /// </summary>
+        public bool WasCancelledAsStragler => _wasCancelledAsStragler;
+
+        /// <summary>
+        /// Calculates the download throughput in bytes per second.
+        /// Returns null if the download has not completed.
+        /// Thread-safe.
+        /// </summary>
+        /// <returns>The throughput in bytes per second, or null if not completed.</returns>
+        public double? CalculateThroughputBytesPerSecond()
+        {
+            lock (_lock)
+            {
+                if (!_downloadEndTime.HasValue)
+                {
+                    return null;
+                }
+
+                TimeSpan elapsed = _downloadEndTime.Value - DownloadStartTime;
+                double elapsedSeconds = elapsed.TotalSeconds;
+
+                // Avoid division by zero for very fast downloads
+                if (elapsedSeconds < MinimumElapsedSecondsForThroughput)
+                {
+                    elapsedSeconds = MinimumElapsedSecondsForThroughput;
+                }
+
+                return FileSizeBytes / elapsedSeconds;
+            }
+        }
+
+        /// <summary>
+        /// Marks the download as completed and records the end time.
+        /// Thread-safe - idempotent (can be called multiple times safely).
+        /// </summary>
+        public void MarkDownloadCompleted()
+        {
+            lock (_lock)
+            {
+                if (_downloadEndTime.HasValue) return; // Already marked
+                _downloadEndTime = DateTime.UtcNow;
+            }
+        }
+
+        /// <summary>
+        /// Marks this download as having been cancelled due to being identified as a straggler.
+        /// Thread-safe - idempotent.
+        /// </summary>
+        public void MarkCancelledAsStragler()
+        {
+            lock (_lock)
+            {
+                _wasCancelledAsStragler = true;
+            }
+        }
+    }
+}

--- a/csharp/test/Unit/CloudFetchStragglerUnitTests.cs
+++ b/csharp/test/Unit/CloudFetchStragglerUnitTests.cs
@@ -1,0 +1,82 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit
+{
+    /// <summary>
+    /// Unit tests for FileDownloadMetrics functionality.
+    /// Tests cover throughput calculation and straggler flag management.
+    /// </summary>
+    public class CloudFetchStragglerUnitTests
+    {
+        #region FileDownloadMetrics Tests
+
+        [Fact]
+        public void FileDownloadMetrics_CalculateThroughput_BeforeCompletion_ReturnsNull()
+        {
+            // Arrange
+            var metrics = new FileDownloadMetrics(fileOffset: 0, fileSizeBytes: 1024);
+
+            // Act
+            var throughput = metrics.CalculateThroughputBytesPerSecond();
+
+            // Assert
+            Assert.Null(throughput);
+        }
+
+        [Fact]
+        public void FileDownloadMetrics_CalculateThroughput_AfterCompletion_ReturnsValue()
+        {
+            // Arrange
+            var metrics = new FileDownloadMetrics(fileOffset: 0, fileSizeBytes: 10 * 1024 * 1024);
+            System.Threading.Thread.Sleep(100); // Simulate download time
+
+            // Act
+            metrics.MarkDownloadCompleted();
+            var throughput = metrics.CalculateThroughputBytesPerSecond();
+
+            // Assert
+            Assert.NotNull(throughput);
+            Assert.True(throughput.Value > 0);
+        }
+
+        [Fact]
+        public void FileDownloadMetrics_MarkCancelledAsStragler_SetsFlag()
+        {
+            // Arrange
+            var metrics = new FileDownloadMetrics(fileOffset: 0, fileSizeBytes: 1024);
+
+            // Act
+            metrics.MarkCancelledAsStragler();
+
+            // Assert
+            Assert.True(metrics.WasCancelledAsStragler);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/38/files) to review incremental changes.

- [stack/straggler-config-foundation](https://github.com/adbc-drivers/databricks/pull/37) [[Files changed](https://github.com/adbc-drivers/databricks/pull/37/files)]
  - [**stack/straggler-metrics**](https://github.com/adbc-drivers/databricks/pull/38) [[Files changed](https://github.com/adbc-drivers/databricks/pull/38/files)]
    - [stack/straggler-detector](https://github.com/adbc-drivers/databricks/pull/39) [[Files changed](https://github.com/adbc-drivers/databricks/pull/39/files)]
      - [stack/straggler-downloader-impl](https://github.com/adbc-drivers/databricks/pull/42) [[Files changed](https://github.com/adbc-drivers/databricks/pull/42/files)]
        - [stack/straggler-tests](https://github.com/adbc-drivers/databricks/pull/44) [[Files changed](https://github.com/adbc-drivers/databricks/pull/44/files)]
          - [stack/straggler-docs](https://github.com/adbc-drivers/databricks/pull/43) [[Files changed](https://github.com/adbc-drivers/databricks/pull/43/files)]

---------

## Summary

Adds `FileDownloadMetrics` class for tracking per-file download performance metrics. Foundation for identifying slow downloads (stragglers).

**Key Changes:**
- ✅ `FileDownloadMetrics` class implementation
  - Tracks file offset, size, start/completion time
  - Calculates throughput in bytes/second
  - Manages straggler cancellation flag
  - Thread-safe state management
- ✅ Unit tests for throughput calculation and flag management
  - Verify null throughput for in-progress downloads
  - Verify positive throughput for completed downloads
  - Test straggler flag setting