### PR TITLE
ci(csharp): updated the workflow to use macos-15-intel. 

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -52,7 +52,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-2022
-          - macos-13  # Intel
+          - macos-15-intel  # Intel
           - macos-latest  # ARM
         dotnet:
           - '8.0.x'


### PR DESCRIPTION
## What's Changed
The workflow github/workflows/csharp.yml used macos-13 , which is deprecated by GitHub Actions.
GitHub is deprecating macOS-13 runners and recommends switching to macOS-15.

