### PR TITLE
fix(ci): add pull-requests write permission for PR comments

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,7 +39,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write  # Required to push benchmark results to gh-pages branch
+  contents: write       # Required to push benchmark results to gh-pages branch
+  pull-requests: write  # Required to post comparison comments on PRs
 
 jobs:
   benchmark-net8:


### PR DESCRIPTION
## Summary

Fixes the missing PR comments issue by adding `pull-requests: write` permission to the benchmark workflow.

## Problem

Benchmark comparison comments were not being posted on PRs even though `comment-always: true` was configured. The workflow runs successfully but silently fails to post comments because it lacks the necessary permission.

**Error (not visible in logs):**
- The `benchmark-action/github-action-benchmark` action requires `pull-requests: write` permission to post comments
- The workflow only had `contents: write` permission

## Solution

Added `pull-requests: write` permission to the workflow permissions block:

```yaml
permissions:
  contents: write       # Required to push benchmark results to gh-pages branch
  pull-requests: write  # Required to post comparison comments on PRs
```

## Impact

**Before:**
- ❌ Comparison step runs successfully but silently fails to post comments
- ❌ No visible feedback on PRs about performance impact
- ❌ Users have to download artifacts to see results

**After:**
- ✅ Comparison comments will be posted on PRs with benchmark label
- ✅ Shows baseline vs PR comparison for all 4 metrics
- ✅ Visual indicators for improvements (🟢) and regressions (⚠️)
- ✅ Automatic alerts for >10% regressions

## Testing

This can be tested by:
1. Merging this PR
2. Adding the `benchmark` label to PR #59
3. Verifying that comparison comments are posted by both jobs (.NET 8.0 and .NET 4.7.2)

## References

- Issue: No comments on PR #59 despite `comment-always: true`
- Related: [benchmark-action documentation](https://github.com/benchmark-action/github-action-benchmark#permissions)

Closes #59

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>