### PR TITLE
feat(csharp): add OAuth authentication to Statement Execution API (PECO-2857)

### DIFF
--- a/csharp/src/Auth/StaticBearerTokenHandler.cs
+++ b/csharp/src/Auth/StaticBearerTokenHandler.cs
@@ -1,0 +1,56 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
+{
+    /// <summary>
+    /// HTTP message handler that sets a static Bearer token on all requests.
+    /// Used when OAuth is configured with an access token but without token refresh.
+    /// </summary>
+    internal class StaticBearerTokenHandler : DelegatingHandler
+    {
+        private readonly string _accessToken;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticBearerTokenHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to delegate to.</param>
+        /// <param name="accessToken">The access token to use for authentication.</param>
+        public StaticBearerTokenHandler(HttpMessageHandler innerHandler, string accessToken)
+            : base(innerHandler)
+        {
+            _accessToken = accessToken ?? throw new ArgumentNullException(nameof(accessToken));
+        }
+
+        /// <summary>
+        /// Sends an HTTP request with the Bearer token.
+        /// </summary>
+        /// <param name="request">The HTTP request message to send.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The HTTP response message.</returns>
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/csharp/src/DatabricksDatabase.cs
+++ b/csharp/src/DatabricksDatabase.cs
@@ -80,8 +80,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 {
                     // Use Statement Execution REST API
                     // The connection creates its own HTTP client with proper handler chain
-                    // including TracingDelegatingHandler and RetryHttpHandler
-                    // TODO (PECO-2790): Add OAuth authentication handlers (OAuth, token refresh, token exchange)
+                    // including TracingDelegatingHandler, RetryHttpHandler, and OAuth authentication
+                    // handlers (OAuthDelegatingHandler, TokenRefreshDelegatingHandler,
+                    // MandatoryTokenExchangeDelegatingHandler) when OAuth auth is configured
                     connection = new StatementExecutionConnection(
                         mergedProperties,
                         this.RecyclableMemoryStreamManager,

--- a/csharp/src/Http/HttpHandlerFactory.cs
+++ b/csharp/src/Http/HttpHandlerFactory.cs
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Apache.Arrow.Adbc.Drivers.Apache.Thrift;
+using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
+using Apache.Arrow.Adbc.Tracing;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Http
+{
+    /// <summary>
+    /// Factory for creating HTTP handlers with OAuth and other delegating handlers.
+    /// This provides a common implementation for both Thrift and Statement Execution API connections.
+    /// </summary>
+    internal static class HttpHandlerFactory
+    {
+        /// <summary>
+        /// Configuration for creating HTTP handlers.
+        /// </summary>
+        internal class HandlerConfig
+        {
+            /// <summary>
+            /// Base HTTP handler to wrap with delegating handlers.
+            /// </summary>
+            public HttpMessageHandler BaseHandler { get; set; } = null!;
+
+            /// <summary>
+            /// Base HTTP handler for OAuth token operations (separate client).
+            /// </summary>
+            public HttpMessageHandler BaseAuthHandler { get; set; } = null!;
+
+            /// <summary>
+            /// Connection properties containing configuration.
+            /// </summary>
+            public IReadOnlyDictionary<string, string> Properties { get; set; } = null!;
+
+            /// <summary>
+            /// Host URL for OAuth operations.
+            /// </summary>
+            public string Host { get; set; } = null!;
+
+            /// <summary>
+            /// Activity tracer for retry operations.
+            /// </summary>
+            public IActivityTracer ActivityTracer { get; set; } = null!;
+
+            /// <summary>
+            /// Whether trace propagation is enabled.
+            /// </summary>
+            public bool TracePropagationEnabled { get; set; }
+
+            /// <summary>
+            /// Name of the trace parent header.
+            /// </summary>
+            public string TraceParentHeaderName { get; set; } = "traceparent";
+
+            /// <summary>
+            /// Whether trace state is enabled.
+            /// </summary>
+            public bool TraceStateEnabled { get; set; }
+
+            /// <summary>
+            /// Identity federation client ID (optional).
+            /// </summary>
+            public string? IdentityFederationClientId { get; set; }
+
+            /// <summary>
+            /// Whether to enable temporarily unavailable retry.
+            /// </summary>
+            public bool TemporarilyUnavailableRetry { get; set; } = true;
+
+            /// <summary>
+            /// Timeout for temporarily unavailable retry in seconds.
+            /// </summary>
+            public int TemporarilyUnavailableRetryTimeout { get; set; }
+
+            /// <summary>
+            /// Whether to enable rate limit retry.
+            /// </summary>
+            public bool RateLimitRetry { get; set; } = true;
+
+            /// <summary>
+            /// Timeout for rate limit retry in seconds.
+            /// </summary>
+            public int RateLimitRetryTimeout { get; set; }
+
+            /// <summary>
+            /// Timeout in minutes for HTTP operations.
+            /// </summary>
+            public int TimeoutMinutes { get; set; }
+
+            /// <summary>
+            /// Whether to add Thrift error handler.
+            /// </summary>
+            public bool AddThriftErrorHandler { get; set; }
+        }
+
+        /// <summary>
+        /// Result of creating HTTP handlers.
+        /// </summary>
+        internal class HandlerResult
+        {
+            /// <summary>
+            /// HTTP handler chain for API requests.
+            /// </summary>
+            public HttpMessageHandler Handler { get; set; } = null!;
+
+            /// <summary>
+            /// HTTP client for OAuth token operations (may be null if OAuth not configured).
+            /// </summary>
+            public HttpClient? AuthHttpClient { get; set; }
+        }
+
+        /// <summary>
+        /// Creates HTTP handlers with OAuth and other delegating handlers.
+        ///
+        /// Handler chain order (outermost to innermost):
+        /// 1. OAuth handlers (OAuthDelegatingHandler or TokenRefreshDelegatingHandler) - token management
+        /// 2. MandatoryTokenExchangeDelegatingHandler (if OAuth) - workload identity federation
+        /// 3. ThriftErrorMessageHandler (optional, for Thrift only) - extracts Thrift error messages
+        /// 4. RetryHttpHandler - retries 408, 429, 502, 503, 504 with Retry-After support
+        /// 5. TracingDelegatingHandler - propagates W3C trace context (closest to network)
+        /// 6. Base HTTP handler - actual network communication
+        /// </summary>
+        public static HandlerResult CreateHandlers(HandlerConfig config)
+        {
+            HttpMessageHandler handler = config.BaseHandler;
+            HttpMessageHandler authHandler = config.BaseAuthHandler;
+
+            // Add tracing handler (INNERMOST - closest to network) if enabled
+            if (config.TracePropagationEnabled)
+            {
+                handler = new TracingDelegatingHandler(handler, config.ActivityTracer, config.TraceParentHeaderName, config.TraceStateEnabled);
+                authHandler = new TracingDelegatingHandler(authHandler, config.ActivityTracer, config.TraceParentHeaderName, config.TraceStateEnabled);
+            }
+
+            // Add retry handler (OUTSIDE tracing)
+            if (config.TemporarilyUnavailableRetry || config.RateLimitRetry)
+            {
+                handler = new RetryHttpHandler(
+                    handler,
+                    config.ActivityTracer,
+                    config.TemporarilyUnavailableRetryTimeout,
+                    config.RateLimitRetryTimeout,
+                    config.TemporarilyUnavailableRetry,
+                    config.RateLimitRetry);
+                authHandler = new RetryHttpHandler(
+                    authHandler,
+                    config.ActivityTracer,
+                    config.TemporarilyUnavailableRetryTimeout,
+                    config.RateLimitRetryTimeout,
+                    config.TemporarilyUnavailableRetry,
+                    config.RateLimitRetry);
+            }
+
+            // Add Thrift error handler if requested (for Thrift connections only)
+            if (config.AddThriftErrorHandler)
+            {
+                handler = new ThriftErrorMessageHandler(handler);
+                authHandler = new ThriftErrorMessageHandler(authHandler);
+            }
+
+            HttpClient? authHttpClient = null;
+
+            // Check if OAuth authentication is configured
+            bool useOAuth = config.Properties.TryGetValue(SparkParameters.AuthType, out string? authType) &&
+                SparkAuthTypeParser.TryParse(authType, out SparkAuthType authTypeValue) &&
+                authTypeValue == SparkAuthType.OAuth;
+
+            if (useOAuth)
+            {
+                // Create auth HTTP client for token operations
+                authHttpClient = new HttpClient(authHandler)
+                {
+                    Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes)
+                };
+
+                ITokenExchangeClient tokenExchangeClient = new TokenExchangeClient(authHttpClient, config.Host);
+
+                // Mandatory token exchange should be the inner handler so that it happens
+                // AFTER the OAuth handlers (e.g. after M2M sets the access token)
+                handler = new MandatoryTokenExchangeDelegatingHandler(
+                    handler,
+                    tokenExchangeClient,
+                    config.IdentityFederationClientId);
+
+                // Determine grant type (defaults to AccessToken if not specified)
+                config.Properties.TryGetValue(DatabricksParameters.OAuthGrantType, out string? grantTypeStr);
+                DatabricksOAuthGrantTypeParser.TryParse(grantTypeStr, out DatabricksOAuthGrantType grantType);
+
+                // Add OAuth client credentials handler if OAuth M2M authentication is being used
+                if (grantType == DatabricksOAuthGrantType.ClientCredentials)
+                {
+                    config.Properties.TryGetValue(DatabricksParameters.OAuthClientId, out string? clientId);
+                    config.Properties.TryGetValue(DatabricksParameters.OAuthClientSecret, out string? clientSecret);
+                    config.Properties.TryGetValue(DatabricksParameters.OAuthScope, out string? scope);
+
+                    var tokenProvider = new OAuthClientCredentialsProvider(
+                        authHttpClient,
+                        clientId!,
+                        clientSecret!,
+                        config.Host,
+                        scope: scope ?? "sql",
+                        timeoutMinutes: 1
+                    );
+
+                    handler = new OAuthDelegatingHandler(handler, tokenProvider);
+                }
+                // For access_token grant type, get the access token from properties
+                else if (grantType == DatabricksOAuthGrantType.AccessToken)
+                {
+                    // Get the access token from properties
+                    string accessToken = string.Empty;
+                    if (config.Properties.TryGetValue(SparkParameters.AccessToken, out string? token))
+                    {
+                        accessToken = token ?? string.Empty;
+                    }
+                    else if (config.Properties.TryGetValue(SparkParameters.Token, out string? fallbackToken))
+                    {
+                        accessToken = fallbackToken ?? string.Empty;
+                    }
+
+                    if (!string.IsNullOrEmpty(accessToken))
+                    {
+                        // Check if token renewal is configured and token is JWT
+                        if (config.Properties.TryGetValue(DatabricksParameters.TokenRenewLimit, out string? tokenRenewLimitStr) &&
+                            int.TryParse(tokenRenewLimitStr, out int tokenRenewLimit) &&
+                            tokenRenewLimit > 0 &&
+                            JwtTokenDecoder.TryGetExpirationTime(accessToken, out DateTime expiryTime))
+                        {
+                            // Use TokenRefreshDelegatingHandler for JWT tokens with renewal configured
+                            handler = new TokenRefreshDelegatingHandler(
+                                handler,
+                                tokenExchangeClient,
+                                accessToken,
+                                expiryTime,
+                                tokenRenewLimit);
+                        }
+                        else
+                        {
+                            // Use StaticBearerTokenHandler for tokens without renewal
+                            handler = new StaticBearerTokenHandler(handler, accessToken);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // Non-OAuth authentication: use static Bearer token if provided
+                // Try access_token first, then fall back to token
+                string accessToken = string.Empty;
+                if (config.Properties.TryGetValue(SparkParameters.AccessToken, out string? token))
+                {
+                    accessToken = token ?? string.Empty;
+                }
+                else if (config.Properties.TryGetValue(SparkParameters.Token, out string? fallbackToken))
+                {
+                    accessToken = fallbackToken ?? string.Empty;
+                }
+
+                if (!string.IsNullOrEmpty(accessToken))
+                {
+                    handler = new StaticBearerTokenHandler(handler, accessToken);
+                }
+            }
+
+            return new HandlerResult
+            {
+                Handler = handler,
+                AuthHttpClient = authHttpClient
+            };
+        }
+    }
+}

--- a/csharp/test/E2E/StatementExecution/StatementExecutionDriverE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/StatementExecutionDriverE2ETests.cs
@@ -39,16 +39,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.E2E.StatementExecution
         {
             Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable), "Test configuration not available");
 
-            // REST API currently only supports direct token authentication (PAT or OAuth access token).
-            // OAuth M2M (client_credentials) flow is not yet supported (PECO-2790).
-            // Skip tests if OAuth is configured but no direct token is available.
-            bool hasDirectToken = !string.IsNullOrEmpty(TestConfiguration.Token) ||
-                                  !string.IsNullOrEmpty(TestConfiguration.AccessToken);
-            bool hasOAuthM2M = !string.IsNullOrEmpty(TestConfiguration.OAuthGrantType) &&
-                               TestConfiguration.OAuthGrantType.Equals("client_credentials", StringComparison.OrdinalIgnoreCase);
-
-            Skip.If(!hasDirectToken && hasOAuthM2M,
-                "REST API does not yet support OAuth M2M (client_credentials). Use a direct token or wait for PECO-2790.");
+            // REST API supports both direct token authentication (PAT or OAuth access token)
+            // and OAuth M2M (client_credentials) flow (implemented in PECO-2857).
         }
 
         private AdbcConnection CreateRestConnection()

--- a/csharp/test/Unit/StatementExecution/StatementExecutionConnectionAuthTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionConnectionAuthTests.cs
@@ -1,0 +1,317 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Apache.Arrow.Adbc.Drivers.Databricks;
+using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.StatementExecution
+{
+    /// <summary>
+    /// Unit tests for StatementExecutionConnection OAuth and token authentication.
+    /// </summary>
+    public class StatementExecutionConnectionAuthTests : IDisposable
+    {
+        private readonly Mock<HttpMessageHandler> _mockHttpHandler;
+
+        public StatementExecutionConnectionAuthTests()
+        {
+            _mockHttpHandler = new Mock<HttpMessageHandler>();
+        }
+
+        /// <summary>
+        /// Creates a basic set of properties required for StatementExecutionConnection.
+        /// </summary>
+        private static Dictionary<string, string> CreateBaseProperties()
+        {
+            return new Dictionary<string, string>
+            {
+                { SparkParameters.HostName, "test-workspace.cloud.databricks.com" },
+                { DatabricksParameters.WarehouseId, "test-warehouse-id" }
+            };
+        }
+
+        [Fact]
+        public void Constructor_WithStaticToken_CreatesConnectionWithBearerAuth()
+        {
+            // Arrange
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AccessToken] = "test-access-token";
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert - verify connection was created successfully
+            Assert.NotNull(connection);
+        }
+
+        [Fact]
+        public void Constructor_WithOAuthClientCredentials_CreatesConnectionWithOAuthHandler()
+        {
+            // Arrange
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AuthType] = "oauth";
+            properties[DatabricksParameters.OAuthGrantType] = "client_credentials";
+            properties[DatabricksParameters.OAuthClientId] = "test-client-id";
+            properties[DatabricksParameters.OAuthClientSecret] = "test-client-secret";
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert - verify connection was created successfully with OAuth
+            Assert.NotNull(connection);
+
+            // Verify _authHttpClient was created
+            var authHttpClientField = typeof(StatementExecutionConnection).GetField(
+                "_authHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(authHttpClientField);
+            var authHttpClient = authHttpClientField!.GetValue(connection);
+            Assert.NotNull(authHttpClient);
+        }
+
+        [Fact]
+        public void Constructor_WithOAuthTokenRefresh_CreatesConnectionWithTokenRefreshHandler()
+        {
+            // Arrange
+            // Create a valid JWT token with expiration claim for testing
+            // JWT format: header.payload.signature
+            // This is a test token with exp claim set to future time
+            var header = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("{\"alg\":\"HS256\",\"typ\":\"JWT\"}")).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            var expTime = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds();
+            var payload = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{{\"exp\":{expTime}}}")).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            var signature = "test-signature";
+            var jwtToken = $"{header}.{payload}.{signature}";
+
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AuthType] = "oauth";
+            properties[SparkParameters.AccessToken] = jwtToken;
+            properties[DatabricksParameters.TokenRenewLimit] = "10"; // 10 minutes before expiry
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert - verify connection was created successfully
+            Assert.NotNull(connection);
+
+            // Verify _authHttpClient was created for token operations
+            var authHttpClientField = typeof(StatementExecutionConnection).GetField(
+                "_authHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(authHttpClientField);
+            var authHttpClient = authHttpClientField!.GetValue(connection);
+            Assert.NotNull(authHttpClient);
+        }
+
+        [Fact]
+        public void Constructor_WithOAuthAccessToken_CreatesConnectionWithStaticBearerToken()
+        {
+            // Arrange - OAuth enabled with access_token grant type (default), but no token refresh
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AuthType] = "oauth";
+            properties[SparkParameters.AccessToken] = "test-access-token";
+            // Note: No TokenRenewLimit set, so StaticBearerTokenHandler should be used
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert - verify connection was created successfully with OAuth handlers
+            Assert.NotNull(connection);
+
+            // Verify _authHttpClient was created for OAuth (needed for MandatoryTokenExchangeDelegatingHandler)
+            var authHttpClientField = typeof(StatementExecutionConnection).GetField(
+                "_authHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(authHttpClientField);
+            var authHttpClient = authHttpClientField!.GetValue(connection);
+            Assert.NotNull(authHttpClient);
+        }
+
+        [Fact]
+        public void Constructor_WithOAuthAccessTokenExplicitGrantType_CreatesConnectionCorrectly()
+        {
+            // Arrange - OAuth enabled with explicit access_token grant type
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AuthType] = "oauth";
+            properties[DatabricksParameters.OAuthGrantType] = "access_token";
+            properties[SparkParameters.AccessToken] = "test-access-token";
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert - verify connection was created successfully
+            Assert.NotNull(connection);
+
+            // Verify _authHttpClient was created for OAuth operations
+            var authHttpClientField = typeof(StatementExecutionConnection).GetField(
+                "_authHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(authHttpClientField);
+            var authHttpClient = authHttpClientField!.GetValue(connection);
+            Assert.NotNull(authHttpClient);
+        }
+
+        [Fact]
+        public void Constructor_WithIdentityFederationClientId_StoresConfigCorrectly()
+        {
+            // Arrange
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AccessToken] = "test-access-token";
+            properties[DatabricksParameters.IdentityFederationClientId] = "test-federation-client-id";
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert
+            Assert.NotNull(connection);
+
+            // Verify identity federation client ID was stored
+            var identityFederationField = typeof(StatementExecutionConnection).GetField(
+                "_identityFederationClientId",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(identityFederationField);
+            var identityFederationClientId = identityFederationField!.GetValue(connection) as string;
+            Assert.Equal("test-federation-client-id", identityFederationClientId);
+        }
+
+        [Fact]
+        public void Constructor_WithoutOAuth_DoesNotCreateAuthHttpClient()
+        {
+            // Arrange
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AccessToken] = "test-access-token";
+            // Note: No AuthType = "oauth" set
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert
+            var authHttpClientField = typeof(StatementExecutionConnection).GetField(
+                "_authHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(authHttpClientField);
+            var authHttpClient = authHttpClientField!.GetValue(connection);
+            Assert.Null(authHttpClient); // Should be null when OAuth is not used
+        }
+
+        [Fact]
+        public void Constructor_WithOAuthAndScope_UsesProvidedScope()
+        {
+            // Arrange
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AuthType] = "oauth";
+            properties[DatabricksParameters.OAuthGrantType] = "client_credentials";
+            properties[DatabricksParameters.OAuthClientId] = "test-client-id";
+            properties[DatabricksParameters.OAuthClientSecret] = "test-client-secret";
+            properties[DatabricksParameters.OAuthScope] = "all-apis";
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert - connection should be created without error
+            Assert.NotNull(connection);
+        }
+
+        [Fact]
+        public void Constructor_WithUriInsteadOfHostName_ExtractsHostCorrectly()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                { AdbcOptions.Uri, "https://test-workspace.cloud.databricks.com/sql/1.0/warehouses/test-warehouse" },
+                { SparkParameters.AccessToken, "test-access-token" }
+            };
+
+            // Act
+            using var connection = new StatementExecutionConnection(properties);
+
+            // Assert - connection should be created successfully, extracting host and warehouse from URI
+            Assert.NotNull(connection);
+        }
+
+        [Fact]
+        public void Dispose_WithOAuthEnabled_DisposesAuthHttpClient()
+        {
+            // Arrange
+            var properties = CreateBaseProperties();
+            properties[SparkParameters.AuthType] = "oauth";
+            properties[DatabricksParameters.OAuthGrantType] = "client_credentials";
+            properties[DatabricksParameters.OAuthClientId] = "test-client-id";
+            properties[DatabricksParameters.OAuthClientSecret] = "test-client-secret";
+
+            var connection = new StatementExecutionConnection(properties);
+
+            // Get reference to auth HTTP client before disposal
+            var authHttpClientField = typeof(StatementExecutionConnection).GetField(
+                "_authHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var authHttpClient = authHttpClientField!.GetValue(connection) as HttpClient;
+            Assert.NotNull(authHttpClient);
+
+            // Act
+            connection.Dispose();
+
+            // Assert - after disposal, attempting to use the client should fail
+            // We can't directly test disposal, but we verify no exceptions during dispose
+            // Multiple dispose calls should be safe
+            connection.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_MissingHostName_ThrowsArgumentException()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                { DatabricksParameters.WarehouseId, "test-warehouse-id" },
+                { SparkParameters.AccessToken, "test-access-token" }
+            };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => new StatementExecutionConnection(properties));
+        }
+
+        [Fact]
+        public void Constructor_MissingWarehouseId_ThrowsArgumentException()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.HostName, "test-workspace.cloud.databricks.com" },
+                { SparkParameters.AccessToken, "test-access-token" }
+            };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => new StatementExecutionConnection(properties));
+        }
+
+        public void Dispose()
+        {
+            _mockHttpHandler?.Object?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/62/files) to review incremental changes.
- [**stack/PECO-2857-oauth-auth-statement-execution**](https://github.com/adbc-drivers/databricks/pull/62) [[Files changed](https://github.com/adbc-drivers/databricks/pull/62/files)]
  - [stack/PECO-2790-result-fetcher](https://github.com/adbc-drivers/databricks/pull/64) [[Files changed](https://github.com/adbc-drivers/databricks/pull/64/files/49d09a4125d79d4870b699e23fb4cbb8d327be1f..44389141c57c8b5b7de84c1c5515a7e38e0c98f5)]

---------
## Summary

This PR adds comprehensive OAuth authentication support to the Statement Execution REST API connection, bringing feature parity with the Thrift-based connection implementation.

### Key Changes

**1. OAuth Client Credentials (M2M) Support**
- Added `OAuthDelegatingHandler` for machine-to-machine authentication
- Uses `OAuthClientCredentialsProvider` to obtain and manage tokens
- Configurable via `oauth.grant_type`, `oauth.client_id`, `oauth.client_secret`, `oauth.scope`

**2. JWT Token Refresh Support**
- Added `TokenRefreshDelegatingHandler` for automatic token renewal
- Non-blocking background refresh before token expiration
- Configurable via `token_renew_limit` parameter (minutes before expiry)

**3. Workload Identity Federation**
- Added `MandatoryTokenExchangeDelegatingHandler` for token exchange
- Supports `identity_federation_client_id` configuration
- Exchanges non-Databricks tokens for Databricks tokens

**4. Handler Chain Architecture**
```
OAuth handlers (outermost)
    ↓
MandatoryTokenExchangeDelegatingHandler
    ↓
RetryHttpHandler
    ↓
TracingDelegatingHandler (innermost)
    ↓
HttpClientHandler (network)
```

### Files Changed (Incremental)

| File | Change |
|------|--------|
| `StatementExecutionConnection.cs` | Added OAuth handler chain to `CreateHttpClient()` |
| `DatabricksDatabase.cs` | Updated comments to reflect implemented auth support |
| `StatementExecutionDriverE2ETests.cs` | Removed OAuth M2M skip condition (now supported) |
| `StatementExecutionConnectionAuthTests.cs` | Added 10 unit tests for auth scenarios |

### Configuration Parameters

| Parameter | Description |
|
--|
----|
| `adbc.spark.auth_type` | Set to `oauth` to enable OAuth authentication |
| `adbc.databricks.oauth.grant_type` | `client_credentials` for M2M flow |
| `adbc.databricks.oauth.client_id` | OAuth client ID |
| `adbc.databricks.oauth.client_secret` | OAuth client secret |
| `adbc.databricks.oauth.scope` | OAuth scope (default: `sql`) |
| `adbc.databricks.token_renew_limit` | Minutes before expiry to refresh token |
| `adbc.databricks.identity_federation_client_id` | For workload identity federation |

## Test Plan

- [x] 10 new unit tests for OAuth authentication configuration
- [x] All existing unit tests pass
- [x] Pre-commit checks pass
- [x] Build succeeds for all target frameworks (net472, netstandard2.0, net8.0)
- [x] E2E tests with OAuth M2M credentials (previously skipped, now enabled)

Closes PECO-2857
