### PR TITLE
feat(csharp): add CloudFetch support for Statement Execution API

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -81,8 +81,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private long _maxBytesPerFetchRequest = DefaultMaxBytesPerFetchRequest;
         private const bool DefaultRetryOnUnavailable = true;
         private const bool DefaultRateLimitRetry = true;
-        private const int DefaultTemporarilyUnavailableRetryTimeout = 900;
-        private const int DefaultRateLimitRetryTimeout = 120;
         private bool _useDescTableExtended = false;
 
         // Trace propagation configuration
@@ -439,7 +437,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// <summary>
         /// Gets the maximum total time in seconds to retry retryable responses (408, 502, 503, 504) before failing.
         /// </summary>
-        protected int TemporarilyUnavailableRetryTimeout { get; private set; } = DefaultTemporarilyUnavailableRetryTimeout;
+        protected int TemporarilyUnavailableRetryTimeout { get; private set; } = DatabricksConstants.DefaultTemporarilyUnavailableRetryTimeout;
 
         /// <summary>
         /// Gets a value indicating whether to retry requests that receive HTTP 429 responses.
@@ -449,7 +447,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// <summary>
         /// Gets the number of seconds to wait before stopping an attempt to retry HTTP 429 responses.
         /// </summary>
-        protected int RateLimitRetryTimeout { get; private set; } = DefaultRateLimitRetryTimeout;
+        protected int RateLimitRetryTimeout { get; private set; } = DatabricksConstants.DefaultRateLimitRetryTimeout;
 
         protected override HttpMessageHandler CreateHttpHandler()
         {

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -375,6 +375,21 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         public const int DefaultAsyncExecPollIntervalMs = 100;
 
         /// <summary>
+        /// Default timeout in seconds for retrying temporarily unavailable responses (408, 502, 503, 504).
+        /// </summary>
+        public const int DefaultTemporarilyUnavailableRetryTimeout = 900; // 15 minutes
+
+        /// <summary>
+        /// Default timeout in seconds for retrying rate-limited responses (429).
+        /// </summary>
+        public const int DefaultRateLimitRetryTimeout = 120; // 2 minutes
+
+        /// <summary>
+        /// Default timeout in minutes for CloudFetch HTTP operations.
+        /// </summary>
+        public const int DefaultCloudFetchTimeoutMinutes = 5;
+
+        /// <summary>
         /// OAuth grant type constants
         /// </summary>
         public static class OAuthGrantTypes

--- a/csharp/src/Reader/BaseDatabricksReader.cs
+++ b/csharp/src/Reader/BaseDatabricksReader.cs
@@ -42,15 +42,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader
         private bool isDisposed;
 
         /// <summary>
-        /// Gets the statement for this reader. Subclasses can decide how to provide it.
-        /// Used for Thrift operations in DatabricksReader. Not used in CloudFetchReader.
-        /// </summary>
-        protected abstract ITracingStatement Statement { get; }
-
-        /// <summary>
         /// Protocol-agnostic constructor.
         /// </summary>
-        /// <param name="statement">The tracing statement (both Thrift and REST implement ITracingStatement).</param>
+        /// <param name="statement">The tracing statement (both Thrift and REST statements implement ITracingStatement).</param>
         /// <param name="schema">The Arrow schema.</param>
         /// <param name="response">The query response (nullable for REST API).</param>
         /// <param name="isLz4Compressed">Whether results are LZ4 compressed.</param>

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs
@@ -75,8 +75,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 
             if (config == null) throw new ArgumentNullException(nameof(config));
 
-            // Set HTTP client timeout
-            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
+            // Note: Don't set _httpClient.Timeout here - it should already be configured
+            // when the HttpClient was created, and modifying it after requests have started
+            // throws InvalidOperationException.
         }
 
         /// <inheritdoc />

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -37,10 +37,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 {
     /// <summary>
     /// Downloads files from URLs.
+    /// Uses dependency injection to receive IActivityTracer for tracing support.
     /// </summary>
-    internal sealed class CloudFetchDownloader : ICloudFetchDownloader, IActivityTracer
+    internal sealed class CloudFetchDownloader : ICloudFetchDownloader
     {
-        private readonly ITracingStatement? _statement;
+        private readonly IActivityTracer _activityTracer;
         private readonly BlockingCollection<IDownloadResult> _downloadQueue;
         private readonly BlockingCollection<IDownloadResult> _resultQueue;
         private readonly ICloudFetchMemoryBufferManager _memoryManager;
@@ -53,7 +54,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         private readonly int _maxUrlRefreshAttempts;
         private readonly int _urlExpirationBufferSeconds;
         private readonly SemaphoreSlim _downloadSemaphore;
-        private readonly Lazy<ActivityTrace> _fallbackTrace;
         private readonly RecyclableMemoryStreamManager? _memoryStreamManager;
         private readonly ArrayPool<byte>? _lz4BufferPool;
         private Task? _downloadTask;
@@ -65,7 +65,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchDownloader"/> class.
         /// </summary>
-        /// <param name="statement">The tracing statement for Activity context and connection access (nullable for protocol-agnostic usage).</param>
+        /// <param name="activityTracer">The activity tracer for tracing support (dependency injection).</param>
         /// <param name="downloadQueue">The queue of downloads to process.</param>
         /// <param name="resultQueue">The queue to add completed downloads to.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
@@ -73,7 +73,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <param name="resultFetcher">The result fetcher that manages URLs.</param>
         /// <param name="config">The CloudFetch configuration.</param>
         public CloudFetchDownloader(
-            ITracingStatement? statement,
+            IActivityTracer activityTracer,
             BlockingCollection<IDownloadResult> downloadQueue,
             BlockingCollection<IDownloadResult> resultQueue,
             ICloudFetchMemoryBufferManager memoryManager,
@@ -81,7 +81,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             ICloudFetchResultFetcher resultFetcher,
             CloudFetchConfiguration config)
         {
-            _statement = statement;
+            _activityTracer = activityTracer ?? throw new ArgumentNullException(nameof(activityTracer));
             _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
             _resultQueue = resultQueue ?? throw new ArgumentNullException(nameof(resultQueue));
             _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
@@ -99,14 +99,13 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             _memoryStreamManager = config.MemoryStreamManager;
             _lz4BufferPool = config.Lz4BufferPool;
             _downloadSemaphore = new SemaphoreSlim(_maxParallelDownloads, _maxParallelDownloads);
-            _fallbackTrace = new Lazy<ActivityTrace>(() => new ActivityTrace("CloudFetchDownloader", "1.0.0"));
             _isCompleted = false;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchDownloader"/> class for testing.
         /// </summary>
-        /// <param name="statement">The tracing statement for Activity context (nullable for testing).</param>
+        /// <param name="activityTracer">The activity tracer for tracing support (dependency injection).</param>
         /// <param name="downloadQueue">The queue of downloads to process.</param>
         /// <param name="resultQueue">The queue to add completed downloads to.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
@@ -117,7 +116,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
         /// <param name="maxRetries">Maximum retry attempts (optional, default 3).</param>
         /// <param name="retryDelayMs">Delay between retries in ms (optional, default 1000).</param>
         internal CloudFetchDownloader(
-            ITracingStatement? statement,
+            IActivityTracer activityTracer,
             BlockingCollection<IDownloadResult> downloadQueue,
             BlockingCollection<IDownloadResult> resultQueue,
             ICloudFetchMemoryBufferManager memoryManager,
@@ -128,7 +127,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             int maxRetries = 3,
             int retryDelayMs = 1000)
         {
-            _statement = statement;
+            _activityTracer = activityTracer ?? throw new ArgumentNullException(nameof(activityTracer));
             _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
             _resultQueue = resultQueue ?? throw new ArgumentNullException(nameof(resultQueue));
             _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
@@ -144,7 +143,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
             _memoryStreamManager = null;
             _lz4BufferPool = null;
             _downloadSemaphore = new SemaphoreSlim(_maxParallelDownloads, _maxParallelDownloads);
-            _fallbackTrace = new Lazy<ActivityTrace>(() => new ActivityTrace("CloudFetchDownloader", "1.0.0"));
             _isCompleted = false;
         }
 
@@ -219,6 +217,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 // Try to take the next result from the queue
                 IDownloadResult result = await Task.Run(() => _resultQueue.Take(cancellationToken), cancellationToken);
 
+                Activity.Current?.AddEvent("cloudfetch.result_dequeued", [
+                    new("chunk_index", result?.ChunkIndex ?? -1),
+                    new("is_end_guard", result == EndOfResultsGuard.Instance)
+                ]);
+
                 // Check if this is the end of results guard
                 if (result == EndOfResultsGuard.Instance)
                 {
@@ -254,7 +257,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 
         private async Task DownloadFilesAsync(CancellationToken cancellationToken)
         {
-            await this.TraceActivityAsync(async activity =>
+            await _activityTracer.TraceActivityAsync(async activity =>
             {
                 await Task.Yield();
 
@@ -271,11 +274,21 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                     var downloadTaskCompletionSource = new TaskCompletionSource<bool>();
 
                     // Process items from the download queue until it's completed
+                    activity?.AddEvent("cloudfetch.download_loop_start", [
+                        new("download_queue_count", _downloadQueue.Count)
+                    ]);
+
                     foreach (var downloadResult in _downloadQueue.GetConsumingEnumerable(cancellationToken))
                     {
+                        activity?.AddEvent("cloudfetch.download_item_dequeued", [
+                            new("chunk_index", downloadResult?.ChunkIndex ?? -1),
+                            new("is_end_guard", downloadResult == EndOfResultsGuard.Instance)
+                        ]);
+
                         // Check if there's an error before processing more downloads
                         if (HasError)
                         {
+                            activity?.AddEvent("cloudfetch.download_loop_error_break");
                             // Add the failed download result to the queue to signal the error
                             // This will be caught by GetNextDownloadedFileAsync
                             break;
@@ -284,6 +297,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Check if this is the end of results guard
                         if (downloadResult == EndOfResultsGuard.Instance)
                         {
+                            activity?.AddEvent("cloudfetch.end_of_results_guard_received");
                             // Wait for all active downloads to complete
                             if (downloadTasks.Count > 0)
                             {
@@ -314,6 +328,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Check if the URL is expired or about to expire
                         if (downloadResult.IsExpiredOrExpiringSoon(_urlExpirationBufferSeconds))
                         {
+                            activity?.AddEvent("cloudfetch.url_expired_refreshing", [
+                                new("chunk_index", downloadResult.ChunkIndex),
+                                new("start_row_offset", downloadResult.StartRowOffset)
+                            ]);
                             // Get refreshed URLs starting from this offset
                             var refreshedResults = await _resultFetcher.RefreshUrlsAsync(downloadResult.StartRowOffset, cancellationToken);
                             var refreshedResult = refreshedResults.FirstOrDefault(r => r.StartRowOffset == downloadResult.StartRowOffset);
@@ -329,6 +347,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 
                         // Acquire a download slot
                         await _downloadSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                        activity?.AddEvent("cloudfetch.download_slot_acquired", [
+                            new("chunk_index", downloadResult.ChunkIndex)
+                        ]);
 
                         // Start the download task
                         Task downloadTask = DownloadFileAsync(downloadResult, cancellationToken)
@@ -374,6 +396,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Add the result to the result queue add the result here to assure the download sequence.
                         _resultQueue.Add(downloadResult, cancellationToken);
 
+                        activity?.AddEvent("cloudfetch.result_enqueued", [
+                            new("chunk_index", downloadResult.ChunkIndex),
+                            new("result_queue_count", _resultQueue.Count)
+                        ]);
+
                         // If there's an error, stop processing more downloads
                         if (HasError)
                         {
@@ -416,7 +443,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
 
         private async Task DownloadFileAsync(IDownloadResult downloadResult, CancellationToken cancellationToken)
         {
-            await this.TraceActivityAsync(async activity =>
+            await _activityTracer.TraceActivityAsync(async activity =>
             {
                 string url = downloadResult.FileUrl;
                 string sanitizedUrl = SanitizeUrl(downloadResult.FileUrl);
@@ -670,18 +697,5 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                 return "cloud-storage-url";
             }
         }
-
-        // IActivityTracer implementation - delegates to statement (or returns lazy-initialized fallback if null)
-        // TODO(PECO-2838): Verify ActivityTrace propagation works correctly for Statement Execution API (REST).
-        // The fallback trace is used when statement is null (shouldn't happen in practice).
-        // For REST API, we need to ensure the StatementExecutionStatement implements ITracingStatement
-        // and properly propagates trace context through the CloudFetch pipeline.
-        ActivityTrace IActivityTracer.Trace => _statement?.Trace ?? _fallbackTrace.Value;
-
-        string? IActivityTracer.TraceParent => _statement?.TraceParent;
-
-        public string AssemblyVersion => _statement?.AssemblyVersion ?? string.Empty;
-
-        public string AssemblyName => _statement?.AssemblyName ?? string.Empty;
     }
 }

--- a/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
@@ -1,0 +1,326 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+using Apache.Arrow.Adbc.Tracing;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
+{
+    /// <summary>
+    /// Statement Execution API-specific implementation that fetches result chunks
+    /// from the REST API. The initial response includes external links for chunk 0,
+    /// and subsequent chunks are fetched via GetResultChunkAsync.
+    /// </summary>
+    internal class StatementExecutionResultFetcher : CloudFetchResultFetcher, IDisposable
+    {
+        private readonly IStatementExecutionClient _client;
+        private readonly string _statementId;
+        private readonly ResultManifest _manifest;
+        private readonly List<ExternalLink>? _initialExternalLinks;
+        private readonly SemaphoreSlim _fetchLock = new SemaphoreSlim(1, 1);
+        private int _currentChunkIndex;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatementExecutionResultFetcher"/> class.
+        /// </summary>
+        /// <param name="client">The Statement Execution API client.</param>
+        /// <param name="statementId">The statement ID for fetching results.</param>
+        /// <param name="manifest">The result manifest containing chunk metadata.</param>
+        /// <param name="initialExternalLinks">External links for chunk 0 from the initial response (may be null).</param>
+        /// <param name="memoryManager">The memory buffer manager.</param>
+        /// <param name="downloadQueue">The queue to add download tasks to.</param>
+        public StatementExecutionResultFetcher(
+            IStatementExecutionClient client,
+            string statementId,
+            ResultManifest manifest,
+            List<ExternalLink>? initialExternalLinks,
+            ICloudFetchMemoryBufferManager memoryManager,
+            BlockingCollection<IDownloadResult> downloadQueue)
+            : base(memoryManager, downloadQueue)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _statementId = statementId ?? throw new ArgumentNullException(nameof(statementId));
+            _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+            _initialExternalLinks = initialExternalLinks;
+        }
+
+        /// <inheritdoc />
+        protected override void ResetState()
+        {
+            _currentChunkIndex = 0;
+        }
+
+        /// <inheritdoc />
+        protected override Task<bool> HasInitialResultsAsync(CancellationToken cancellationToken)
+        {
+            // Check if we have initial external links from the response
+            bool hasResults = _initialExternalLinks != null && _initialExternalLinks.Count > 0;
+            return Task.FromResult(hasResults);
+        }
+
+        /// <inheritdoc />
+        protected override void ProcessInitialResultsAsync(CancellationToken cancellationToken)
+        {
+            if (_initialExternalLinks == null || _initialExternalLinks.Count == 0)
+            {
+                // No initial links - will fetch chunk 0 via API
+                return;
+            }
+
+            // Process the initial external links (chunk 0)
+            ProcessExternalLinks(_initialExternalLinks, cancellationToken);
+            _currentChunkIndex = 1; // Start fetching from chunk 1
+
+            // Check if there are more chunks to fetch
+            _hasMoreResults = _currentChunkIndex < _manifest.TotalChunkCount;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Note: This method does NOT use a lock because it's called sequentially by a single
+        /// fetcher background task (same pattern as ThriftResultFetcher). The _fetchLock is only
+        /// used in RefreshUrlsAsync to serialize concurrent URL refresh requests from the downloader.
+        /// </remarks>
+        protected override async Task FetchNextBatchAsync(CancellationToken cancellationToken)
+        {
+            if (_currentChunkIndex >= _manifest.TotalChunkCount)
+            {
+                _hasMoreResults = false;
+                return;
+            }
+
+            int chunkToFetch = _currentChunkIndex;
+
+            Activity.Current?.AddEvent("cloudfetch.fetch_chunk_start", [
+                new("chunk_index", chunkToFetch),
+                new("total_chunks", _manifest.TotalChunkCount)
+            ]);
+
+            try
+            {
+                var resultData = await _client.GetResultChunkAsync(
+                    _statementId,
+                    chunkToFetch,
+                    cancellationToken).ConfigureAwait(false);
+
+                Activity.Current?.AddEvent("cloudfetch.fetch_chunk_complete", [
+                    new("chunk_index", chunkToFetch),
+                    new("external_links_count", resultData.ExternalLinks?.Count ?? 0)
+                ]);
+
+                if (resultData.ExternalLinks != null && resultData.ExternalLinks.Count > 0)
+                {
+                    ProcessExternalLinks(resultData.ExternalLinks, cancellationToken);
+                }
+
+                _currentChunkIndex++;
+                _hasMoreResults = _currentChunkIndex < _manifest.TotalChunkCount;
+            }
+            catch (Exception ex)
+            {
+                Activity.Current?.AddEvent("cloudfetch.fetch_chunk_error", [
+                    new("error_message", ex.Message),
+                    new("error_type", ex.GetType().Name),
+                    new("chunk_index", chunkToFetch)
+                ]);
+                _hasMoreResults = false;
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Processes a collection of external links by creating download results and adding them to the queue.
+        /// </summary>
+        /// <param name="externalLinks">The collection of external links to process.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        private void ProcessExternalLinks(List<ExternalLink> externalLinks, CancellationToken cancellationToken)
+        {
+            foreach (var link in externalLinks)
+            {
+                var downloadResult = CreateDownloadResultFromLink(link);
+                _downloadQueue.Add(downloadResult, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Creates a DownloadResult from an ExternalLink.
+        /// </summary>
+        /// <param name="link">The external link.</param>
+        /// <returns>A new DownloadResult instance.</returns>
+        private DownloadResult CreateDownloadResultFromLink(ExternalLink link)
+        {
+            // Parse expiration time from ISO 8601 string
+            DateTime expirationTime = DateTime.UtcNow.AddHours(1); // Default to 1 hour
+            if (!string.IsNullOrEmpty(link.Expiration))
+            {
+                if (DateTime.TryParse(link.Expiration, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsedTime))
+                {
+                    expirationTime = parsedTime.ToUniversalTime();
+                }
+                else
+                {
+                    Activity.Current?.AddEvent("cloudfetch.expiration_parse_failed", [
+                        new("chunk_index", link.ChunkIndex),
+                        new("expiration_string", link.Expiration),
+                        new("default_expiration_minutes", 60)
+                    ]);
+                }
+            }
+            else
+            {
+                Activity.Current?.AddEvent("cloudfetch.expiration_missing", [
+                    new("chunk_index", link.ChunkIndex),
+                    new("default_expiration_minutes", 60)
+                ]);
+            }
+
+            return new DownloadResult(
+                chunkIndex: link.ChunkIndex,
+                fileUrl: link.ExternalLinkUrl,
+                startRowOffset: link.RowOffset,
+                rowCount: link.RowCount,
+                byteCount: link.ByteCount,
+                expirationTime: expirationTime,
+                memoryManager: _memoryManager,
+                httpHeaders: link.HttpHeaders);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This method uses _fetchLock to serialize concurrent URL refresh requests from the downloader.
+        /// This matches the pattern used in ThriftResultFetcher.RefreshUrlsAsync. The lock is held during
+        /// the entire operation including the HTTP call to prevent multiple concurrent refresh requests
+        /// for the same or nearby chunks.
+        /// </remarks>
+        public override async Task<IEnumerable<IDownloadResult>> RefreshUrlsAsync(
+            long startRowOffset,
+            CancellationToken cancellationToken)
+        {
+            await _fetchLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Find the chunk index that contains or follows the given row offset
+                long targetChunkIndex = FindChunkIndexForRowOffset(startRowOffset);
+
+                if (targetChunkIndex < 0 || targetChunkIndex >= _manifest.TotalChunkCount)
+                {
+                    return new List<IDownloadResult>();
+                }
+
+                Activity.Current?.AddEvent("cloudfetch.refresh_urls_start", [
+                    new("start_row_offset", startRowOffset),
+                    new("target_chunk_index", targetChunkIndex)
+                ]);
+
+                var resultData = await _client.GetResultChunkAsync(
+                    _statementId,
+                    targetChunkIndex,
+                    cancellationToken).ConfigureAwait(false);
+
+                var refreshedResults = new List<IDownloadResult>();
+
+                if (resultData.ExternalLinks != null && resultData.ExternalLinks.Count > 0)
+                {
+                    foreach (var link in resultData.ExternalLinks)
+                    {
+                        var downloadResult = CreateDownloadResultFromLink(link);
+                        refreshedResults.Add(downloadResult);
+                    }
+
+                    Activity.Current?.AddEvent("cloudfetch.urls_refreshed", [
+                        new("count", refreshedResults.Count),
+                        new("start_offset", startRowOffset),
+                        new("chunk_index", targetChunkIndex)
+                    ]);
+                }
+
+                return refreshedResults;
+            }
+            finally
+            {
+                _fetchLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Finds the chunk index that contains or follows the given row offset.
+        /// </summary>
+        /// <param name="rowOffset">The row offset to find.</param>
+        /// <returns>The chunk index, or -1 if not found.</returns>
+        private long FindChunkIndexForRowOffset(long rowOffset)
+        {
+            if (_manifest.Chunks == null || _manifest.Chunks.Count == 0)
+            {
+                Activity.Current?.AddEvent("cloudfetch.find_chunk_failed", [
+                    new("reason", "manifest_chunks_empty"),
+                    new("row_offset", rowOffset)
+                ]);
+                return -1;
+            }
+
+            // Look for the chunk that contains this row offset
+            foreach (var chunk in _manifest.Chunks)
+            {
+                if (rowOffset >= chunk.RowOffset && rowOffset < chunk.RowOffset + chunk.RowCount)
+                {
+                    return chunk.ChunkIndex;
+                }
+            }
+
+            // Chunk not found in manifest - log and return failure
+            Activity.Current?.AddEvent("cloudfetch.find_chunk_failed", [
+                new("reason", "chunk_not_in_manifest"),
+                new("row_offset", rowOffset),
+                new("manifest_chunk_count", _manifest.Chunks.Count),
+                new("total_chunk_count", _manifest.TotalChunkCount)
+            ]);
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Disposes the fetcher and releases the semaphore.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes managed resources.
+        /// </summary>
+        /// <param name="disposing">True if disposing managed resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _fetchLock?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/csharp/src/Reader/DatabricksReader.cs
+++ b/csharp/src/Reader/DatabricksReader.cs
@@ -40,10 +40,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader
         int index;
         IArrowReader? reader;
 
-        protected override ITracingStatement Statement => _statement;
-
         public DatabricksReader(IHiveServer2Statement statement, Schema schema, IResponse response, TFetchResultsResp? initialResults, bool isLz4Compressed)
-            : base(statement, schema, response, isLz4Compressed)
+            : base(statement, schema, response, isLz4Compressed) // IHiveServer2Statement implements IActivityTracer
         {
             _statement = statement;
 

--- a/csharp/test/E2E/CloudFetch/StatementExecutionResultFetcherTest.cs
+++ b/csharp/test/E2E/CloudFetch/StatementExecutionResultFetcherTest.cs
@@ -1,0 +1,613 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks;
+using Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+using Moq;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
+{
+    /// <summary>
+    /// Tests for StatementExecutionResultFetcher
+    /// </summary>
+    public class StatementExecutionResultFetcherTest : IDisposable
+    {
+        private readonly Mock<IStatementExecutionClient> _mockClient;
+        private readonly Mock<ICloudFetchMemoryBufferManager> _mockMemoryManager;
+        private readonly BlockingCollection<IDownloadResult> _downloadQueue;
+        private readonly string _testStatementId = "test-statement-123";
+
+        public StatementExecutionResultFetcherTest()
+        {
+            _mockClient = new Mock<IStatementExecutionClient>();
+            _mockMemoryManager = new Mock<ICloudFetchMemoryBufferManager>();
+            _downloadQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), 10);
+        }
+
+        #region Manifest-Based Fetching Tests
+
+        [Fact]
+        public async Task FetchResultsAsync_WithManifestExternalLinks_SuccessfullyFetchesResults()
+        {
+            // Arrange
+            var (manifest, initialExternalLinks) = CreateTestManifestWithExternalLinks(3);
+
+            // Setup mock to return external links for chunks 1 and 2 (chunk 0 is provided as initialExternalLinks)
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 1,
+                    RowOffset = 100,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 1,
+                            ExternalLinkUrl = "https://storage.example.com/result1.arrow",
+                            RowOffset = 100,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 2, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 2,
+                    RowOffset = 200,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 2,
+                            ExternalLinkUrl = "https://storage.example.com/result2.arrow",
+                            RowOffset = 200,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+
+            // Wait for the fetcher to process the results
+            await Task.Delay(200);
+
+            // Assert
+            // The download queue should contain our result links
+            var downloadResults = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result))
+            {
+                if (result == EndOfResultsGuard.Instance)
+                {
+                    continue;
+                }
+                downloadResults.Add(result);
+            }
+
+            Assert.Equal(3, downloadResults.Count);
+
+            // Verify each download result has the correct link
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.Equal($"https://storage.example.com/result{i}.arrow", downloadResults[i].FileUrl);
+                Assert.Equal(i * 100, downloadResults[i].StartRowOffset);
+                Assert.Equal(100, downloadResults[i].RowCount);
+            }
+
+            // Verify the fetcher state
+            Assert.False(fetcher.HasMoreResults);
+            Assert.True(fetcher.IsCompleted);
+            Assert.False(fetcher.HasError);
+            Assert.Null(fetcher.Error);
+
+            // Cleanup
+            await fetcher.StopAsync();
+        }
+
+        [Fact]
+        public async Task FetchResultsAsync_WithHttpHeaders_PassesHeadersCorrectly()
+        {
+            // Arrange
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 1,
+                TotalRowCount = 100,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk
+                    {
+                        ChunkIndex = 0,
+                        RowOffset = 0,
+                        RowCount = 100,
+                        ByteCount = 1024
+                    }
+                }
+            };
+
+            var initialExternalLinks = new List<ExternalLink>
+            {
+                new ExternalLink
+                {
+                    ChunkIndex = 0,
+                    ExternalLinkUrl = "https://storage.example.com/result.arrow",
+                    RowOffset = 0,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                    HttpHeaders = new Dictionary<string, string>
+                    {
+                        { "x-amz-server-side-encryption-customer-algorithm", "AES256" },
+                        { "x-amz-server-side-encryption-customer-key", "test-key" }
+                    }
+                }
+            };
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            // Assert
+            var downloadResults = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result))
+            {
+                if (result != EndOfResultsGuard.Instance)
+                {
+                    downloadResults.Add(result);
+                }
+            }
+
+            Assert.Single(downloadResults);
+            var downloadResult = downloadResults[0] as DownloadResult;
+            Assert.NotNull(downloadResult);
+            Assert.NotNull(downloadResult.HttpHeaders);
+            Assert.Equal(2, downloadResult.HttpHeaders.Count);
+            Assert.Equal("AES256", downloadResult.HttpHeaders["x-amz-server-side-encryption-customer-algorithm"]);
+
+            await fetcher.StopAsync();
+        }
+
+        #endregion
+
+        #region Incremental Chunk Fetching Tests
+
+        [Fact]
+        public async Task FetchResultsAsync_WithChunksWithoutLinks_FetchesFromApi()
+        {
+            // Arrange - Manifest has chunks without external links (need incremental fetching)
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 2,
+                TotalRowCount = 200,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 },
+                    new ResultChunk { ChunkIndex = 1, RowOffset = 100, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            // Setup mock to return external links when GetResultChunkAsync is called
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 0,
+                    RowOffset = 0,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 0,
+                            ExternalLinkUrl = "https://storage.example.com/chunk0.arrow",
+                            RowOffset = 0,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 1,
+                    RowOffset = 100,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 1,
+                            ExternalLinkUrl = "https://storage.example.com/chunk1.arrow",
+                            RowOffset = 100,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(300);
+
+            // Assert
+            // Verify GetResultChunkAsync was called for both chunks
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()), Times.Once);
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()), Times.Once);
+
+            var downloadResults = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result))
+            {
+                if (result != EndOfResultsGuard.Instance)
+                {
+                    downloadResults.Add(result);
+                }
+            }
+
+            Assert.Equal(2, downloadResults.Count);
+            Assert.True(fetcher.IsCompleted);
+            Assert.False(fetcher.HasError);
+
+            await fetcher.StopAsync();
+        }
+
+        #endregion
+
+        #region URL Refresh Tests
+
+        [Fact]
+        public async Task RefreshUrlsAsync_FetchesFreshUrls()
+        {
+            // Arrange
+            var (manifest, _) = CreateTestManifestWithExternalLinks(2);
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 0,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 0,
+                            ExternalLinkUrl = "https://storage.example.com/refreshed.arrow",
+                            RowOffset = 0,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act
+            var results = await fetcher.RefreshUrlsAsync(0, CancellationToken.None);
+
+            // Assert
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()), Times.Once);
+            Assert.NotNull(results);
+            var resultList = results.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("https://storage.example.com/refreshed.arrow", resultList[0].FileUrl);
+        }
+
+        [Fact]
+        public async Task RefreshUrlsAsync_WithRowOffsetInMiddleOfChunk_FindsCorrectChunk()
+        {
+            // Arrange
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 2,
+                TotalRowCount = 200,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 },
+                    new ResultChunk { ChunkIndex = 1, RowOffset = 100, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 1,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 1,
+                            ExternalLinkUrl = "https://storage.example.com/chunk1.arrow",
+                            RowOffset = 100,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act - Refresh with row offset 150, which is in the middle of chunk 1
+            var results = await fetcher.RefreshUrlsAsync(150, CancellationToken.None);
+
+            // Assert
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()), Times.Once);
+            Assert.NotNull(results);
+            Assert.Single(results);
+        }
+
+        #endregion
+
+        #region Error Handling Tests
+
+        [Fact]
+        public async Task FetchResultsAsync_WithApiError_SetsErrorState()
+        {
+            // Arrange - Manifest without external links to trigger API fetch
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 1,
+                TotalRowCount = 100,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new DatabricksException("API Error"));
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(200);
+
+            // Assert
+            Assert.False(fetcher.HasMoreResults);
+            Assert.True(fetcher.IsCompleted);
+            Assert.True(fetcher.HasError);
+            Assert.NotNull(fetcher.Error);
+            Assert.IsType<DatabricksException>(fetcher.Error);
+
+            await fetcher.StopAsync();
+        }
+
+        [Fact]
+        public async Task FetchResultsAsync_WithEmptyResults_CompletesGracefully()
+        {
+            // Arrange
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 0,
+                TotalRowCount = 0,
+                Chunks = new List<ResultChunk>()
+            };
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            // Assert
+            var nonGuardItems = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result))
+            {
+                if (result != EndOfResultsGuard.Instance)
+                {
+                    nonGuardItems.Add(result);
+                }
+            }
+            Assert.Empty(nonGuardItems);
+
+            Assert.False(fetcher.HasMoreResults);
+            Assert.True(fetcher.IsCompleted);
+            Assert.False(fetcher.HasError);
+
+            await fetcher.StopAsync();
+        }
+
+        #endregion
+
+        #region Cancellation Tests
+
+        [Fact]
+        public async Task StopAsync_CancelsFetching()
+        {
+            // Arrange
+            var fetchStarted = new TaskCompletionSource<bool>();
+            var fetchCancelled = new TaskCompletionSource<bool>();
+
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 10, // Many chunks to ensure fetching continues
+                TotalRowCount = 1000,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, It.IsAny<long>(), It.IsAny<CancellationToken>()))
+                .Returns(async (string statementId, long chunkIndex, CancellationToken token) =>
+                {
+                    fetchStarted.TrySetResult(true);
+
+                    try
+                    {
+                        // Wait for a long time or until cancellation
+                        await Task.Delay(10000, token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        fetchCancelled.TrySetResult(true);
+                        throw;
+                    }
+
+                    return new ResultData
+                    {
+                        ChunkIndex = chunkIndex,
+                        ExternalLinks = new List<ExternalLink>()
+                    };
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            // Act
+            await fetcher.StartAsync(CancellationToken.None);
+
+            // Wait for fetch to start
+            await fetchStarted.Task;
+
+            // Stop the fetcher
+            await fetcher.StopAsync();
+
+            // Assert
+            var cancelled = await Task.WhenAny(fetchCancelled.Task, Task.Delay(1000)) == fetchCancelled.Task;
+            Assert.True(cancelled, "Fetch operation should have been cancelled");
+            Assert.True(fetcher.IsCompleted);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Creates a test manifest and returns the initial external links for chunk 0.
+        /// The manifest contains chunk metadata without external links (as the server returns),
+        /// and the initial external links are returned separately (as they come from result.external_links).
+        /// </summary>
+        private (ResultManifest manifest, List<ExternalLink> initialExternalLinks) CreateTestManifestWithExternalLinks(int chunkCount)
+        {
+            var chunks = new List<ResultChunk>();
+            for (int i = 0; i < chunkCount; i++)
+            {
+                chunks.Add(new ResultChunk
+                {
+                    ChunkIndex = i,
+                    RowOffset = i * 100,
+                    RowCount = 100,
+                    ByteCount = 1024
+                });
+            }
+
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = chunkCount,
+                TotalRowCount = chunkCount * 100,
+                Chunks = chunks
+            };
+
+            // Initial external links for chunk 0 (from result.external_links)
+            var initialExternalLinks = new List<ExternalLink>
+            {
+                new ExternalLink
+                {
+                    ChunkIndex = 0,
+                    ExternalLinkUrl = "https://storage.example.com/result0.arrow",
+                    RowOffset = 0,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                }
+            };
+
+            return (manifest, initialExternalLinks);
+        }
+
+        public void Dispose()
+        {
+            _downloadQueue?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}

--- a/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
+++ b/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
@@ -1,0 +1,639 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks;
+using Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.StatementExecution;
+using Moq;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Reader.CloudFetch
+{
+    public class StatementExecutionResultFetcherTests : IDisposable
+    {
+        private readonly Mock<IStatementExecutionClient> _mockClient;
+        private readonly Mock<ICloudFetchMemoryBufferManager> _mockMemoryManager;
+        private readonly BlockingCollection<IDownloadResult> _downloadQueue;
+        private readonly string _testStatementId = "test-statement-123";
+
+        public StatementExecutionResultFetcherTests()
+        {
+            _mockClient = new Mock<IStatementExecutionClient>();
+            _mockMemoryManager = new Mock<ICloudFetchMemoryBufferManager>();
+            _downloadQueue = new BlockingCollection<IDownloadResult>();
+        }
+
+        #region Constructor Tests
+
+        [Fact]
+        public void Constructor_WithValidParameters_CreatesFetcher()
+        {
+            var manifest = CreateTestManifest(1);
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            Assert.NotNull(fetcher);
+        }
+
+        [Fact]
+        public void Constructor_WithNullClient_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    null!,
+                    _testStatementId,
+                    manifest,
+                    initialExternalLinks: null,
+                    _mockMemoryManager.Object,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullStatementId_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    null!,
+                    manifest,
+                    initialExternalLinks: null,
+                    _mockMemoryManager.Object,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullManifest_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    _testStatementId,
+                    null!,
+                    initialExternalLinks: null,
+                    _mockMemoryManager.Object,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullMemoryManager_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    _testStatementId,
+                    manifest,
+                    initialExternalLinks: null,
+                    null!,
+                    _downloadQueue));
+        }
+
+        [Fact]
+        public void Constructor_WithNullDownloadQueue_ThrowsArgumentNullException()
+        {
+            var manifest = CreateTestManifest(1);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new StatementExecutionResultFetcher(
+                    _mockClient.Object,
+                    _testStatementId,
+                    manifest,
+                    initialExternalLinks: null,
+                    _mockMemoryManager.Object,
+                    null!));
+        }
+
+        #endregion
+
+        #region Manifest-Based Fetching Tests
+
+        [Fact]
+        public async Task StartAsync_WithManifestExternalLinks_AddsDownloadResultsToQueue()
+        {
+            var (manifest, initialExternalLinks) = CreateTestManifestWithExternalLinks(2);
+
+            // Setup mock to return external links for chunk 1 (chunk 0 is provided as initialExternalLinks)
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 1,
+                    RowOffset = 100,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 1,
+                            ExternalLinkUrl = "https://storage.example.com/result1.arrow",
+                            RowOffset = 100,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+
+            // Wait for the fetcher to complete
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            // Should have 2 download results + end guard
+            var results = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result, TimeSpan.FromMilliseconds(100)))
+            {
+                results.Add(result);
+            }
+
+            // 2 external links (one per chunk) + end guard
+            Assert.Equal(3, results.Count);
+            Assert.IsType<EndOfResultsGuard>(results.Last());
+
+            var downloadResults = results.Take(2).ToList();
+            Assert.All(downloadResults, r => Assert.IsType<DownloadResult>(r));
+        }
+
+        [Fact]
+        public async Task StartAsync_WithManifestExternalLinks_SetsCorrectProperties()
+        {
+            var (manifest, initialExternalLinks) = CreateTestManifestWithExternalLinks(1);
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            Assert.True(_downloadQueue.TryTake(out var result));
+            var downloadResult = Assert.IsType<DownloadResult>(result);
+
+            Assert.Equal("https://storage.example.com/result0.arrow", downloadResult.FileUrl);
+            Assert.Equal(0, downloadResult.ChunkIndex);
+            Assert.Equal(0, downloadResult.StartRowOffset);
+            Assert.Equal(100, downloadResult.RowCount);
+            Assert.Equal(1024, downloadResult.ByteCount);
+        }
+
+        [Fact]
+        public async Task StartAsync_WithHttpHeaders_PassesHeadersToDownloadResult()
+        {
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 1,
+                TotalRowCount = 100,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk
+                    {
+                        ChunkIndex = 0,
+                        RowOffset = 0,
+                        RowCount = 100,
+                        ByteCount = 1024
+                    }
+                }
+            };
+
+            var initialExternalLinks = new List<ExternalLink>
+            {
+                new ExternalLink
+                {
+                    ChunkIndex = 0,
+                    ExternalLinkUrl = "https://storage.example.com/result.arrow",
+                    RowOffset = 0,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                    HttpHeaders = new Dictionary<string, string>
+                    {
+                        { "x-amz-server-side-encryption-customer-algorithm", "AES256" },
+                        { "x-amz-server-side-encryption-customer-key", "test-key" }
+                    }
+                }
+            };
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            Assert.True(_downloadQueue.TryTake(out var result));
+            var downloadResult = Assert.IsType<DownloadResult>(result);
+
+            Assert.NotNull(downloadResult.HttpHeaders);
+            Assert.Equal(2, downloadResult.HttpHeaders.Count);
+            Assert.Equal("AES256", downloadResult.HttpHeaders["x-amz-server-side-encryption-customer-algorithm"]);
+        }
+
+        #endregion
+
+        #region Incremental Chunk Fetching Tests
+
+        [Fact]
+        public async Task StartAsync_WithChunksWithoutExternalLinks_FetchesFromApi()
+        {
+            // Manifest has chunks without external links (need incremental fetching)
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 2,
+                TotalRowCount = 200,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 },
+                    new ResultChunk { ChunkIndex = 1, RowOffset = 100, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            // Setup mock to return external links when GetResultChunkAsync is called
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 0,
+                    RowOffset = 0,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 0,
+                            ExternalLinkUrl = "https://storage.example.com/chunk0.arrow",
+                            RowOffset = 0,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 1,
+                    RowOffset = 100,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 1,
+                            ExternalLinkUrl = "https://storage.example.com/chunk1.arrow",
+                            RowOffset = 100,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            // Verify GetResultChunkAsync was called for both chunks
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()), Times.Once);
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()), Times.Once);
+
+            // Collect results
+            var results = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result, TimeSpan.FromMilliseconds(100)))
+            {
+                results.Add(result);
+            }
+
+            // 2 download results + end guard
+            Assert.Equal(3, results.Count);
+        }
+
+        #endregion
+
+        #region URL Refresh Tests
+
+        [Fact]
+        public async Task RefreshUrlsAsync_CallsGetResultChunkAsync()
+        {
+            var (manifest, _) = CreateTestManifestWithExternalLinks(2);
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 0,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 0,
+                            ExternalLinkUrl = "https://storage.example.com/refreshed.arrow",
+                            RowOffset = 0,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            var refreshedResults = await fetcher.RefreshUrlsAsync(0, CancellationToken.None);
+
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()), Times.Once);
+            Assert.Single(refreshedResults);
+            var downloadResult = Assert.IsType<DownloadResult>(refreshedResults.First());
+            Assert.Equal("https://storage.example.com/refreshed.arrow", downloadResult.FileUrl);
+        }
+
+        [Fact]
+        public async Task RefreshUrlsAsync_WithRowOffsetInMiddleOfChunk_FindsCorrectChunk()
+        {
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 2,
+                TotalRowCount = 200,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 },
+                    new ResultChunk { ChunkIndex = 1, RowOffset = 100, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ChunkIndex = 1,
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink
+                        {
+                            ChunkIndex = 1,
+                            ExternalLinkUrl = "https://storage.example.com/chunk1.arrow",
+                            RowOffset = 100,
+                            RowCount = 100,
+                            ByteCount = 1024,
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                        }
+                    }
+                });
+
+            // Refresh with row offset 150, which is in the middle of chunk 1
+            var refreshedResults = await fetcher.RefreshUrlsAsync(150, CancellationToken.None);
+
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()), Times.Once);
+            Assert.Single(refreshedResults);
+        }
+
+        #endregion
+
+        #region Error Handling Tests
+
+        [Fact]
+        public async Task StartAsync_WithApiError_SetsErrorState()
+        {
+            // Manifest has chunks without external links (need incremental fetching)
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 1,
+                TotalRowCount = 100,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new DatabricksException("API Error"));
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            Assert.True(fetcher.IsCompleted);
+            Assert.True(fetcher.HasError);
+            Assert.NotNull(fetcher.Error);
+            Assert.IsType<DatabricksException>(fetcher.Error);
+        }
+
+        [Fact]
+        public async Task StartAsync_WithEmptyManifest_CompletesWithNoResults()
+        {
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 0,
+                TotalRowCount = 0,
+                Chunks = new List<ResultChunk>()
+            };
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks: null,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            Assert.True(fetcher.IsCompleted);
+            Assert.False(fetcher.HasError);
+            Assert.False(fetcher.HasMoreResults);
+
+            // Only end guard should be in queue
+            Assert.True(_downloadQueue.TryTake(out var result));
+            Assert.IsType<EndOfResultsGuard>(result);
+        }
+
+        #endregion
+
+        #region Cancellation Tests
+
+        [Fact]
+        public async Task StopAsync_StopsFetching()
+        {
+            var (manifest, initialExternalLinks) = CreateTestManifestWithExternalLinks(10);
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object,
+                _testStatementId,
+                manifest,
+                initialExternalLinks,
+                _mockMemoryManager.Object,
+                _downloadQueue);
+
+            using var cts = new CancellationTokenSource();
+            await fetcher.StartAsync(cts.Token);
+
+            // Stop immediately
+            await fetcher.StopAsync();
+
+            Assert.True(fetcher.IsCompleted);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private ResultManifest CreateTestManifest(int chunkCount)
+        {
+            var chunks = new List<ResultChunk>();
+            for (int i = 0; i < chunkCount; i++)
+            {
+                chunks.Add(new ResultChunk
+                {
+                    ChunkIndex = i,
+                    RowOffset = i * 100,
+                    RowCount = 100,
+                    ByteCount = 1024
+                });
+            }
+
+            return new ResultManifest
+            {
+                TotalChunkCount = chunkCount,
+                TotalRowCount = chunkCount * 100,
+                Chunks = chunks
+            };
+        }
+
+        /// <summary>
+        /// Creates a test manifest and returns the initial external links for chunk 0.
+        /// The manifest contains chunk metadata without external links (as the server returns),
+        /// and the initial external links are returned separately (as they come from result.external_links).
+        /// </summary>
+        private (ResultManifest manifest, List<ExternalLink> initialExternalLinks) CreateTestManifestWithExternalLinks(int chunkCount)
+        {
+            var chunks = new List<ResultChunk>();
+            for (int i = 0; i < chunkCount; i++)
+            {
+                chunks.Add(new ResultChunk
+                {
+                    ChunkIndex = i,
+                    RowOffset = i * 100,
+                    RowCount = 100,
+                    ByteCount = 1024
+                });
+            }
+
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = chunkCount,
+                TotalRowCount = chunkCount * 100,
+                Chunks = chunks
+            };
+
+            // Initial external links for chunk 0 (from result.external_links)
+            var initialExternalLinks = new List<ExternalLink>
+            {
+                new ExternalLink
+                {
+                    ChunkIndex = 0,
+                    ExternalLinkUrl = "https://storage.example.com/result0.arrow",
+                    RowOffset = 0,
+                    RowCount = 100,
+                    ByteCount = 1024,
+                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                }
+            };
+
+            return (manifest, initialExternalLinks);
+        }
+
+        private async Task WaitForFetcherCompletionAsync(StatementExecutionResultFetcher fetcher, CancellationToken cancellationToken)
+        {
+            var timeout = TimeSpan.FromSeconds(5);
+            var startTime = DateTime.UtcNow;
+
+            while (!fetcher.IsCompleted && DateTime.UtcNow - startTime < timeout)
+            {
+                await Task.Delay(50, cancellationToken);
+            }
+        }
+
+        public void Dispose()
+        {
+            _downloadQueue?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/64/files) to review incremental changes.
- [**stack/PECO-2790-result-fetcher**](https://github.com/adbc-drivers/databricks/pull/64) [[Files changed](https://github.com/adbc-drivers/databricks/pull/64/files)]

---------
## Summary

  Adds CloudFetch support for the Statement Execution REST API, enabling high-performance result
  retrieval via pre-signed cloud storage URLs.

  ### Changes

  - **StatementExecutionResultFetcher**: New CloudFetch result fetcher that supports:
    - Manifest-based fetching (all external links available upfront)
    - Incremental chunk fetching (links fetched per-chunk via `GetResultChunkAsync`)
    - URL refresh for expired pre-signed URLs
  - **CloudFetchReaderFactory**: Extended with `CreateStatementExecutionReader()` factory method and
  adapter classes (`StatementExecutionStatementAdapter`, `StatementExecutionResponseAdapter`)
  - **StatementExecutionStatement**: Added `CreateCloudFetchReader()` for external link results with
  Arrow schema extraction from manifest
  - **Tracing**: Added detailed activity events throughout the CloudFetch pipeline for debugging
  - **Bug fix**: Removed `HttpClient.Timeout` assignment in `CloudFetchDownloadManager` that could
  throw after requests started

  ## Test Plan

  - [x] Unit tests: `StatementExecutionResultFetcherTests` (14 tests)
  - [x] E2E tests: `StatementExecutionResultFetcherTest` (10 tests)
  - [x] Extended `CloudFetchE2ETest` with Statement Execution API scenarios
