### PR TITLE
fix(csharp): improve server-side property name validation

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -578,7 +578,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 // If not using queries to set server-side properties, include them in Configuration
                 if (!_applySSPWithQueries)
                 {
-                    var serverSideProperties = GetServerSideProperties();
+                    var serverSideProperties = GetServerSideProperties(activity);
                     foreach (var property in serverSideProperties)
                     {
                         req.Configuration[property.Key] = property.Value;
@@ -677,16 +677,32 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
         /// <summary>
         /// Gets a dictionary of server-side properties extracted from connection properties.
+        /// Only includes properties with valid property names (letters, numbers, dots, and underscores).
+        /// Invalid property names are logged to the activity trace and filtered out.
         /// </summary>
-        /// <returns>Dictionary of server-side properties with prefix removed from keys.</returns>
-        private Dictionary<string, string> GetServerSideProperties()
+        /// <param name="activity">Optional activity for tracing filtered properties.</param>
+        /// <returns>Dictionary of server-side properties with prefix removed from keys and invalid names filtered out.</returns>
+        private Dictionary<string, string> GetServerSideProperties(Activity? activity = null)
         {
-            return Properties
-                .Where(p => p.Key.ToLowerInvariant().StartsWith(DatabricksParameters.ServerSidePropertyPrefix))
-                .ToDictionary(
-                    p => p.Key.Substring(DatabricksParameters.ServerSidePropertyPrefix.Length),
-                    p => p.Value
-                );
+            var result = new Dictionary<string, string>();
+
+            foreach (var property in Properties.Where(p => p.Key.ToLowerInvariant().StartsWith(DatabricksParameters.ServerSidePropertyPrefix)))
+            {
+                string propertyName = property.Key.Substring(DatabricksParameters.ServerSidePropertyPrefix.Length);
+
+                if (!IsValidPropertyName(propertyName))
+                {
+                    activity?.AddEvent("connection.server_side_property.filtered", [
+                        new("property_name", propertyName),
+                        new("reason", "Invalid property name format")
+                    ]);
+                    continue;
+                }
+
+                result[propertyName] = property.Value;
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -695,49 +711,52 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// <returns>A task representing the asynchronous operation.</returns>
         public async Task ApplyServerSidePropertiesAsync()
         {
-            if (!_applySSPWithQueries)
+            await this.TraceActivityAsync(async activity =>
             {
-                return;
-            }
-
-            var serverSideProperties = GetServerSideProperties();
-
-            if (serverSideProperties.Count == 0)
-            {
-                return;
-            }
-
-            using var statement = new DatabricksStatement(this);
-
-            foreach (var property in serverSideProperties)
-            {
-                if (!IsValidPropertyName(property.Key))
+                if (!_applySSPWithQueries)
                 {
-                    Debug.WriteLine($"Skipping invalid property name: {property.Key}");
-                    continue;
+                    return;
                 }
 
-                string escapedValue = EscapeSqlString(property.Value);
-                string query = $"SET {property.Key}={escapedValue}";
-                statement.SqlQuery = query;
+                var serverSideProperties = GetServerSideProperties(activity);
 
-                try
+                if (serverSideProperties.Count == 0)
                 {
-                    await statement.ExecuteUpdateAsync();
+                    return;
                 }
-                catch (Exception ex)
+
+                activity?.SetTag("connection.server_side_properties.count", serverSideProperties.Count);
+
+                using var statement = new DatabricksStatement(this);
+
+                foreach (var property in serverSideProperties)
                 {
-                    Debug.WriteLine($"Error setting server-side property '{property.Key}': {ex.Message}");
+                    string escapedValue = EscapeSqlString(property.Value);
+                    string query = $"SET {property.Key}={escapedValue}";
+                    statement.SqlQuery = query;
+
+                    try
+                    {
+                        await statement.ExecuteUpdateAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        activity?.AddEvent("connection.server_side_property.set_failed", [
+                            new("property_name", property.Key),
+                            new("error_message", ex.Message)
+                        ]);
+                    }
                 }
-            }
+            });
         }
 
-        private bool IsValidPropertyName(string propertyName)
+        internal bool IsValidPropertyName(string propertyName)
         {
-            // Allow only letters and underscores in property names
+            // Allow property names with letters, numbers, dots, and underscores
+            // Examples: spark.sql.adaptive.enabled, spark.executor.instances, my_property123
             return System.Text.RegularExpressions.Regex.IsMatch(
                 propertyName,
-                @"^[a-zA-Z_]+$");
+                @"^[a-zA-Z0-9_.]+$");
         }
 
         private string EscapeSqlString(string value)

--- a/csharp/test/Unit/DatabricksConnectionUnitTests.cs
+++ b/csharp/test/Unit/DatabricksConnectionUnitTests.cs
@@ -1,0 +1,174 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Apache.Arrow.Adbc.Drivers.Databricks;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
+{
+    /// <summary>
+    /// Unit tests for DatabricksConnection class methods.
+    /// </summary>
+    public class DatabricksConnectionUnitTests
+    {
+        /// <summary>
+        /// Creates a minimal DatabricksConnection for testing internal methods.
+        /// </summary>
+        private DatabricksConnection CreateMinimalConnection()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "test.databricks.com",
+                [SparkParameters.Token] = "test-token"
+            };
+            return new DatabricksConnection(properties);
+        }
+
+        /// <summary>
+        /// Tests that valid property names with standard Spark patterns are accepted.
+        /// </summary>
+        [Theory]
+        [InlineData("spark.sql.adaptive.enabled")]
+        [InlineData("spark.executor.instances")]
+        [InlineData("spark.databricks.delta.optimizeWrite.enabled")]
+        [InlineData("my_custom_property")]
+        [InlineData("property123")]
+        [InlineData("UPPERCASE_PROPERTY")]
+        [InlineData("mixedCase.property_123")]
+        [InlineData("a")]
+        [InlineData("_underscore")]
+        [InlineData("spark.sql.shuffle.partitions")]
+        public void IsValidPropertyName_ValidNames_ReturnsTrue(string propertyName)
+        {
+            // Arrange
+            using var connection = CreateMinimalConnection();
+
+            // Act
+            var result = connection.IsValidPropertyName(propertyName);
+
+            // Assert
+            Assert.True(result, $"Property name '{propertyName}' should be valid");
+        }
+
+        /// <summary>
+        /// Tests that property names with invalid characters are rejected.
+        /// </summary>
+        [Theory]
+        [InlineData("property-with-hyphen")]
+        [InlineData("property with space")]
+        [InlineData("property;with;semicolon")]
+        [InlineData("property'with'quote")]
+        [InlineData("property\"with\"doublequote")]
+        [InlineData("property=with=equals")]
+        [InlineData("property(with)parens")]
+        [InlineData("property[with]brackets")]
+        [InlineData("property{with}braces")]
+        [InlineData("property/with/slash")]
+        [InlineData("property\\with\\backslash")]
+        [InlineData("property@with@at")]
+        [InlineData("property#with#hash")]
+        [InlineData("property$with$dollar")]
+        [InlineData("property%with%percent")]
+        [InlineData("property&with&ampersand")]
+        [InlineData("property*with*asterisk")]
+        [InlineData("property+with+plus")]
+        [InlineData("property!with!exclamation")]
+        [InlineData("property?with?question")]
+        public void IsValidPropertyName_InvalidCharacters_ReturnsFalse(string propertyName)
+        {
+            // Arrange
+            using var connection = CreateMinimalConnection();
+
+            // Act
+            var result = connection.IsValidPropertyName(propertyName);
+
+            // Assert
+            Assert.False(result, $"Property name '{propertyName}' should be invalid");
+        }
+
+        /// <summary>
+        /// Tests that empty or whitespace property names are rejected.
+        /// </summary>
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        [InlineData("\n")]
+        public void IsValidPropertyName_EmptyOrWhitespace_ReturnsFalse(string propertyName)
+        {
+            // Arrange
+            using var connection = CreateMinimalConnection();
+
+            // Act
+            var result = connection.IsValidPropertyName(propertyName);
+
+            // Assert
+            Assert.False(result, $"Property name '{propertyName}' should be invalid");
+        }
+
+        /// <summary>
+        /// Tests that property names starting with dots or ending with dots are handled correctly.
+        /// </summary>
+        [Theory]
+        [InlineData(".property")] // Starts with dot - currently allowed
+        [InlineData("property.")] // Ends with dot - currently allowed
+        [InlineData(".")] // Just a dot - currently allowed
+        [InlineData("..")] // Multiple dots - currently allowed
+        public void IsValidPropertyName_DotEdgeCases_BehaviorDocumented(string propertyName)
+        {
+            // Arrange
+            using var connection = CreateMinimalConnection();
+
+            // Act
+            var result = connection.IsValidPropertyName(propertyName);
+
+            // Assert
+            // Current regex pattern ^[a-zA-Z0-9_.]+$ allows dots anywhere
+            // This test documents the current behavior
+            Assert.True(result, $"Property name '{propertyName}' is currently accepted by the regex");
+        }
+
+        /// <summary>
+        /// Tests property names that start with numbers.
+        /// </summary>
+        [Theory]
+        [InlineData("123property")] // Starts with number - currently allowed
+        [InlineData("1.property")] // Starts with number followed by dot - currently allowed
+        public void IsValidPropertyName_StartsWithNumber_CurrentlyAllowed(string propertyName)
+        {
+            // Arrange
+            using var connection = CreateMinimalConnection();
+
+            // Act
+            var result = connection.IsValidPropertyName(propertyName);
+
+            // Assert
+            // Current regex pattern ^[a-zA-Z0-9_.]+$ allows starting with numbers
+            // This test documents the current behavior
+            Assert.True(result, $"Property name '{propertyName}' is currently accepted by the regex");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Improves server-side property name validation to support standard Spark configuration naming conventions while maintaining security against SQL injection attacks.

### Changes

- **Updated validation regex**: Changed from `^[a-zA-Z_]+$` to `^[a-zA-Z0-9_.]+$`
  - Now supports dots (e.g., `spark.databricks.sql.metricViewV2.enabled `)
  - Now supports numbers (e.g., `spark.databricks.sql.metricViewV2.enabled `)
  - Maintains security by blocking special characters

- **Refactored validation logic**:
  - Moved validation into `GetServerSideProperties()` for centralized filtering
  - Changed `IsValidPropertyName` from `private` to `internal` for testability
  - Removed duplicate validation code from `ApplyServerSidePropertiesAsync`

- **Enhanced observability**:
  - Added Activity tracing with `connection.server_side_property.filtered` event
  - Added Activity tracing for SET query failures
  - Wrapped `ApplyServerSidePropertiesAsync` in `TraceActivityAsync`

- **Added comprehensive tests**:
  - Created `DatabricksConnectionUnitTests.cs` with 41 test cases
  - Tests cover valid patterns, invalid characters, and edge cases
  - All tests passing ✅

### Test Plan

```bash
dotnet test --filter "FullyQualifiedName~DatabricksConnectionUnitTests"
```

**Result**: All 41 tests passed

### Examples of Now-Supported Properties

- ✅ `spark.sql.adaptive.enabled`
- ✅ `spark.executor.instances`
- ✅ `spark.databricks.delta.optimizeWrite.enabled`
- ✅ `my_custom_property123`

### Security

Still blocks potentially dangerous input:
- ❌ Hyphens, spaces, semicolons
- ❌ Quotes, equals signs
- ❌ Special characters that could enable SQL injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)