### PR TITLE
fix(ci): change pull_request_target to pull_request for workflows without secrets

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -18,7 +18,7 @@
 name: C#
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 'maint-*'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@
 name: Pre-commit
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 'maint-*'


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability in two GitHub Actions workflows that use `pull_request_target` but check out and execute PR code without using any repository secrets.

## Changes

- `.github/workflows/csharp.yml`: Changed `pull_request_target` to `pull_request` on line 21
- `.github/workflows/pre-commit.yml`: Changed `pull_request_target` to `pull_request` on line 21

## Security Issue

Both workflows were using `pull_request_target` which:
- Runs with write permissions to the repository
- Has access to repository secrets
- Runs in the context of the base branch (main)

However, both workflows check out the PR code (`ref: ${{ github.event.pull_request.head.sha }}`) and execute it via:
- `csharp.yml`: Executes `./ci/scripts/csharp_build.sh` and `./ci/scripts/csharp_test.sh`
- `pre-commit.yml`: Executes pre-commit hooks

This creates a security vulnerability where malicious PRs could exploit the elevated permissions or access secrets.

## Fix

Since neither workflow uses repository secrets, they should use the `pull_request` trigger instead, which:
- Runs with read-only permissions
- Cannot access repository secrets
- Still runs the checks on the PR code

This is the standard and secure approach for CI workflows that don't need secrets.

Fixes #75