### PR TITLE
chore(go): create documentation template

### DIFF
--- a/go/docs/databricks.md
+++ b/go/docs/databricks.md
@@ -20,7 +20,7 @@
 
 {{ heading|safe }}
 
-This driver provides access to [Databricks][databricks]{target="_blank"}, a
+This driver provides access to [Databricks][databricks], a
 cloud-based platform for data analytics.
 
 ## Installation


### PR DESCRIPTION
## What's Changed

This adds a not-yet complete documentation template for the go Databricks driver. Once https://github.com/apache/arrow-adbc/pull/3771 is applied here we can fill this in more easily with the most up to date details.

Closes #95 