### PR TITLE
chore: add CloudFetch call verification to proxy tests

### DIFF
--- a/.github/workflows/proxy-tests.yml
+++ b/.github/workflows/proxy-tests.yml
@@ -1,0 +1,138 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Proxy Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/proxy-tests.yml'
+      - 'test-infrastructure/proxy-server/**'
+      - 'test-infrastructure/tests/csharp/**'
+      - 'csharp/src/**'
+  pull_request:
+    # Only runs on PRs from the repo itself, not forks
+    paths:
+      - '.github/workflows/proxy-tests.yml'
+      - 'test-infrastructure/proxy-server/**'
+      - 'test-infrastructure/tests/csharp/**'
+      - 'csharp/src/**'
+  workflow_dispatch:
+    inputs:
+      run_all_tests:
+        description: 'Run all tests (ignores path filters)'
+        required: false
+        default: 'true'
+        type: boolean
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  proxy-tests:
+    name: "Proxy Tests"
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test-infrastructure/proxy-server/requirements.txt
+
+      - name: Generate mitmproxy certificates
+        run: |
+          # Start mitmdump in background to generate certificates
+          mitmdump &
+          MITM_PID=$!
+          # Wait for certificate generation (happens on first run)
+          sleep 5
+          # Stop mitmdump forcefully
+          kill -9 $MITM_PID || true
+          wait $MITM_PID 2>/dev/null || true
+          # Ensure no mitmdump processes are running
+          pkill -9 mitmdump || true
+          sleep 2
+          # Verify certificate was created
+          ls -la ~/.mitmproxy/
+          cat ~/.mitmproxy/mitmproxy-ca-cert.pem
+
+      - name: Trust mitmproxy certificate
+        run: |
+          sudo cp ~/.mitmproxy/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/mitmproxy.crt
+          sudo update-ca-certificates
+
+      - name: Build test project
+        run: |
+          cd test-infrastructure/tests/csharp
+          dotnet build
+
+      - name: Create test configuration
+        env:
+          DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_HTTP_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
+        run: |
+          cat > databricks-test-config.json << EOF
+          {
+            "uri": "https://${{ env.DATABRICKS_SERVER_HOSTNAME }}${{ env.DATABRICKS_HTTP_PATH }}",
+            "auth_type": "token",
+            "token": "${{ env.DATABRICKS_TOKEN }}"
+          }
+          EOF
+          echo "Configuration file created:"
+          echo "URI: https://${{ env.DATABRICKS_SERVER_HOSTNAME }}${{ env.DATABRICKS_HTTP_PATH }}"
+          echo "Auth type: token"
+
+      - name: Run proxy infrastructure tests
+        env:
+          DATABRICKS_TEST_CONFIG_FILE: ${{ github.workspace }}/databricks-test-config.json
+        run: |
+          cd test-infrastructure/tests/csharp
+          dotnet test --filter "FullyQualifiedName~ProxyInfrastructureTests" \
+            --logger "console;verbosity=normal" \
+            --no-build
+
+      - name: Run CloudFetch proxy tests
+        env:
+          DATABRICKS_TEST_CONFIG_FILE: ${{ github.workspace }}/databricks-test-config.json
+        run: |
+          cd test-infrastructure/tests/csharp
+          dotnet test --filter "FullyQualifiedName~CloudFetchTests" \
+            --logger "console;verbosity=normal" \
+            --no-build


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/111/files) to review incremental changes.
- [**stack/e.wang/add-thrift-call-verification**](https://github.com/adbc-drivers/databricks/pull/111) [[Files changed](https://github.com/adbc-drivers/databricks/pull/111/files)]
  - [stack/e.wang/fix-cloudfetch-timeout](https://github.com/adbc-drivers/databricks/pull/112) [[Files changed](https://github.com/adbc-drivers/databricks/pull/112/files/fbd12dc00750ec405c2130138ce59f4d1db9c46d..277c10fc5ba030ae3f3f18d4026c38186fc8941f)]

---------
## What's Changed

This PR adds comprehensive call verification to CloudFetch proxy tests using dynamic baseline measurement.

### Changes

- **Dynamic baseline verification**: Tests now establish baselines by running queries without failure scenarios, then compare actual vs expected call counts
- **CloudFetch failure scenarios**: Added verification for:
  - cloudfetch_expired_link: Verifies FetchResults is called again to refresh expired links
  - cloudfetch_403: Verifies FetchResults is called again after 403 Forbidden
  - cloudfetch_timeout: Verifies retry behavior with configurable timeout
  - cloudfetch_connection_reset: Verifies retry behavior on connection reset
- **Helper methods**: Added CreateProxiedConnectionWithParameters for tests requiring custom configuration
- **Test infrastructure**: Uses ProxyControlClient to count Thrift method calls and cloud downloads

### Testing

The tests validate that the driver correctly:
1. Refreshes CloudFetch download links by calling FetchResults again when links expire or return 403
2. Retries CloudFetch downloads with exponential backoff on timeout or connection reset
3. Uses dynamic baselines to account for different result set sizes and prefetch behavior

Note: The CloudFetchTimeout test currently fails because the Thrift driver does not apply the configured CloudFetch timeout to the HttpClient. This will be addressed in a follow-up PR.
