### PR TITLE
fix(csharp): apply CloudFetch timeout and remove redundant HttpClient

### DIFF
--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -91,6 +91,9 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
 
             if (config == null) throw new ArgumentNullException(nameof(config));
 
+            // Apply CloudFetch timeout configuration to HttpClient
+            _httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
+
             _maxParallelDownloads = config.ParallelDownloads;
             _isLz4Compressed = config.IsLz4Compressed;
             _maxRetries = config.MaxRetries;

--- a/csharp/src/Reader/CloudFetch/CloudFetchReaderFactory.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchReaderFactory.cs
@@ -104,7 +104,6 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 memoryManager,
                 downloadQueue,
                 resultQueue,
-                httpClient,
                 config);
 
             // Start the download manager
@@ -196,7 +195,6 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 memoryManager,
                 downloadQueue,
                 resultQueue,
-                httpClient,
                 config);
 
             // Start the download manager

--- a/test-infrastructure/proxy-server/mitmproxy_addon.py
+++ b/test-infrastructure/proxy-server/mitmproxy_addon.py
@@ -444,9 +444,10 @@ class FailureInjectionAddon:
             import asyncio
             duration_seconds = scenario_config.get("duration_seconds", 5)
             ctx.log.info(f"[INJECT] Delaying {duration_seconds}s for scenario: {scenario_name}")
-            await asyncio.sleep(duration_seconds)
-            ctx.log.info(f"[INJECT] Delay complete, auto-disabled scenario: {scenario_name}")
+            # Disable BEFORE the delay so new requests don't trigger this scenario
             self._disable_scenario(scenario_name)
+            await asyncio.sleep(duration_seconds)
+            ctx.log.info(f"[INJECT] Delay complete for scenario: {scenario_name}")
             # Let request continue after delay
 
         elif action == "close_connection":


### PR DESCRIPTION
## What's Changed

This PR addresses two issues in the CloudFetch implementation and one fix in the proxy test infrastructure:

### 1. Apply CloudFetch Timeout Configuration

**Problem**: The `adbc.databricks.cloudfetch.timeout_minutes` configuration parameter was being read but never applied to the HttpClient. The HttpClient used its default 100-second timeout instead of the configured value (default: 5 minutes).

**Solution**: Added timeout configuration in `CloudFetchDownloader` constructor:
```csharp
_httpClient.Timeout = TimeSpan.FromMinutes(config.TimeoutMinutes);
```

**Impact**: The CloudFetch HTTP client now correctly respects the user-configured timeout value, allowing for proper timeout behavior in CloudFetch downloads.

**Files Changed**:
- `csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs`

### 2. Remove Redundant HttpClient from CloudFetchDownloadManager

**Problem**: `CloudFetchDownloadManager` accepted an `HttpClient` parameter but never used it for any operations. It only disposed of it, which is incorrect since it doesn't own the resource. The actual HTTP operations are performed by `CloudFetchDownloader`.

**Solution**: Removed the redundant `httpClient` parameter from:
- `CloudFetchDownloadManager` constructor and field
- `CloudFetchReaderFactory.CreateThriftReader()` call
- `CloudFetchReaderFactory.CreateStatementExecutionReader()` call

**Impact**: Cleaner code architecture with proper resource ownership. The HttpClient is now owned solely by CloudFetchDownloader, which actually uses it for HTTP operations.

**Files Changed**:
- `csharp/src/Reader/CloudFetch/CloudFetchDownloadManager.cs`
- `csharp/src/Reader/CloudFetch/CloudFetchReaderFactory.cs`

### 3. Fix Proxy Timing for Test Reliability

**Problem**: The mitmproxy addon was disabling failure scenarios AFTER the delay completed, causing race conditions. When the client timed out and retried, the scenario was still enabled, triggering the delay again.

**Solution**: Modified `mitmproxy_addon.py` to disable the scenario immediately when triggered, before the delay starts:
```python
self._disable_scenario(scenario_name)  # Disable BEFORE delay
await asyncio.sleep(duration_seconds)
```

**Impact**: CloudFetch timeout tests now behave correctly - only the first request is delayed, and retry attempts succeed immediately.

**Files Changed**:
- `test-infrastructure/proxy-server/mitmproxy_addon.py`

## Testing

All 5 CloudFetch proxy tests now pass:
- ✅ `CloudFetchConnectionReset_RetriesWithExponentialBackoff`
- ✅ `CloudFetchExpiredLink_RefreshesLinkViaFetchResults`
- ✅ `NormalCloudFetch_SucceedsWithoutFailureScenarios`
- ✅ `CloudFetchTimeout_RetriesWithExponentialBackoff`
- ✅ `CloudFetch403_RefreshesLinkViaFetchResults`