### PR TITLE
fix: add repository checkout step before PR title validation

### DIFF
--- a/.github/workflows/dev_pr.yaml
+++ b/.github/workflows/dev_pr.yaml
@@ -43,6 +43,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Check PR title format
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Problem

The `dev_pr.yaml` workflow runs PR title validation but doesn't check out the repository first. This causes the validation script to fail when verifying that component names (like `csharp`) match actual directories in the repo.

Error:
```
Invalid component: must reference a file or directory in the repo: csharp
```

## Solution

Add a checkout step before running the title validation, matching the implementation in the upstream apache/arrow-adbc workflow.

## Changes

- Add `actions/checkout@v4` step with `persist-credentials: false`
- This allows the validation script to verify component names against actual repo directories

## Testing

This fix will allow PRs with valid component names like `fix(csharp):` to pass validation.

## Note

This is a critical CI fix that should be merged first to unblock other PRs that are failing validation due to this bug.