### PR TITLE
chore: regenerate workflows

### DIFF
--- a/.github/workflows/dev_issues.yaml
+++ b/.github/workflows/dev_issues.yaml
@@ -11,7 +11,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -34,7 +34,7 @@ jobs:
     permissions:
       issues: write
     if: github.event.comment.body == 'take'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:

--- a/.github/workflows/dev_pr.yaml
+++ b/.github/workflows/dev_pr.yaml
@@ -40,9 +40,14 @@ permissions:
 jobs:
   pr_standard:
     name: "Check PR"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Check PR title format
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/go/pixi.toml
+++ b/go/pixi.toml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
## What's Changed

The generated workflows were out of date and the dev_pr.yml workflow specifically needed a fix to address CI failures. See https://github.com/adbc-drivers/databricks/pull/113.

To create this PR, I installed `adbc-drivers/dev` and ran `adbc-gen-workflow generate .` in this repo.