### PR TITLE
feat(csharp): updated driver name info to Databricks ADBC Driver

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -57,6 +57,8 @@ namespace AdbcDrivers.Databricks
 
         public const string DefaultInitialSchema = "default";
 
+        private new const string DriverName = "Databricks ADBC Driver";
+
         internal static readonly Dictionary<string, string> timestampConfig = new Dictionary<string, string>
         {
             { "spark.thriftserver.arrowBasedRowSet.timestampAsString", "false" },
@@ -509,6 +511,8 @@ namespace AdbcDrivers.Databricks
         }
 
         protected override bool GetObjectsPatternsRequireLowerCase => true;
+
+        protected override string InfoDriverName => DriverName;
 
         internal override IArrowArrayStream NewReader<T>(T statement, Schema schema, IResponse response, TGetResultSetMetadataResp? metadataResp = null)
         {


### PR DESCRIPTION
## What's Changed

 Changes the driver name from the generic "ADBC Spark Driver" (inherited from base Spark driver) to "Databricks ADBC Driver" for proper identification. 
  - GetInfo API: Returns "Databricks ADBC Driver" instead of "ADBC Spark Driver"                                                                                             
  - HTTP User-Agent: Now "DatabricksADBCDriver/1.0.0" instead of "ADBCSparkDriver/1.0.0" 
