### PR TITLE
fix(csharp): revert "updated driver name info to Databricks ADBC Driver"

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -57,8 +57,6 @@ namespace AdbcDrivers.Databricks
 
         public const string DefaultInitialSchema = "default";
 
-        private new const string DriverName = "Databricks ADBC Driver";
-
         internal static readonly Dictionary<string, string> timestampConfig = new Dictionary<string, string>
         {
             { "spark.thriftserver.arrowBasedRowSet.timestampAsString", "false" },
@@ -511,8 +509,6 @@ namespace AdbcDrivers.Databricks
         }
 
         protected override bool GetObjectsPatternsRequireLowerCase => true;
-
-        protected override string InfoDriverName => DriverName;
 
         internal override IArrowArrayStream NewReader<T>(T statement, Schema schema, IResponse response, TGetResultSetMetadataResp? metadataResp = null)
         {


### PR DESCRIPTION
This reverts commit 9d32e1ac36aa04ffc70d8439315a73d0094e5ebb.

## What's Changed

Please fill in a description of the changes here.

The current way of overriding driver name does not work, it will need to change the base class impl to allow overriding. https://github.com/apache/arrow-adbc/pull/3893
Since the databricks driver has a pinned version of ADBC, this currently does not work.
