### PR TITLE
feat(csharp): implement Statement.SetOption for adbc.telemetry.trace_parent

### DIFF
--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -236,6 +236,9 @@ namespace AdbcDrivers.Databricks
                         throw new ArgumentOutOfRangeException(key, value, $"The value '{value}' for option '{key}' is invalid. Must be a numeric value greater than zero.");
                     }
                     break;
+                case AdbcOptions.Telemetry.TraceParent:
+                    ((IActivityTracer)this).Trace.TraceParent = string.IsNullOrWhiteSpace(value) ? null : value;
+                    break;
                 default:
                     base.SetOption(key, value);
                     break;

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -31,6 +32,7 @@ using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Drivers.Apache;
 using Apache.Arrow.Adbc.Tests.Drivers.Apache.Common;
+using Apache.Arrow.Adbc.Tracing;
 using Apache.Arrow.Types;
 using Xunit;
 using Xunit.Abstractions;
@@ -1226,6 +1228,50 @@ namespace AdbcDrivers.Databricks.Tests
                 var emptyField = emptyFkSchema.FieldsList[i];
                 AssertField(emptyField, realField.Name, realField.DataType, realField.IsNullable);
             }
+        }
+
+        [SkippableFact]
+        public void SetOptionTraceParent()
+        {
+            // Create a statement
+            using var connection = NewConnection();
+            using var statement = connection.CreateStatement();
+
+            const string traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+            const string spanId = "00f067aa0ba902b7";
+            const string traceParent = $"00-{traceId}-{spanId}-01";
+
+            // Set the trace parent via SetOption
+            statement.SetOption(AdbcOptions.Telemetry.TraceParent, traceParent);
+
+            // Ensure the trace parent sets the TraceId on subsequent activities ...
+            IActivityTracer? statementTracer = statement as IActivityTracer;
+            Assert.NotNull(statementTracer);
+            Assert.Equal(traceParent, statementTracer.TraceParent);
+
+            // Ensure we have a listener to validate the activity
+            using ActivityListener listener = new()
+            {
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                ShouldListenTo = (activitySource) => true /* activitySource.Name == tracer.Trace.ActivitySourceName */,
+                ActivityStopped = (activity) =>
+                {
+                    Assert.NotNull(activity);
+                    Assert.Equal(traceParent, activity.ParentId);
+                    Assert.Equal(traceId, activity.TraceId.ToString());
+                    Assert.NotEqual(spanId, activity.SpanId.ToString());
+                }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            // Trace some activity and validate
+            statementTracer.TraceActivity(activity =>
+            {
+                Assert.NotNull(activity);
+                Assert.Equal(traceParent, activity.ParentId);
+                Assert.Equal(traceId, activity.TraceId.ToString());
+                Assert.NotEqual(spanId, activity.SpanId.ToString());
+            });
         }
 
         private void AssertField(Field field, string expectedName, IArrowType expectedType, bool expectedNullable)


### PR DESCRIPTION
## What's Changed

- Implement adbc.telemetry.trace_parent option on DatabricksStatement.SetOption
- Add test to confirm its affect.

Closes #129.
