### PR TITLE
chore: fix minor generate.toml syntax issue

### DIFF
--- a/.github/workflows/generate.toml
+++ b/.github/workflows/generate.toml
@@ -15,4 +15,4 @@
 driver = "databricks"
 
 [lang]
-go = "true"
+go = true


### PR DESCRIPTION
## What's Changed

Fixes a very minor syntax issue in generate.toml. This field is a boolean. I've tested adbc-gen-workflow still runs fine in either case so this is just about levels of correct.
