### PR TITLE
feat(csharp): implement Tag Definition System for telemetry (WI-1.2)

### DIFF
--- a/csharp/doc/coding-guideline.md
+++ b/csharp/doc/coding-guideline.md
@@ -1,0 +1,424 @@
+<!--
+Copyright (c) 2025 ADBC Drivers Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# C# ADBC Driver Coding Guidelines
+
+## 1. Framework Compatibility
+
+### Target Frameworks
+All code **MUST** be compatible with:
+- **.NET Framework 4.7.2** (`net472`)
+- **.NET Standard 2.0** (`netstandard2.0`)
+- **.NET 8.0** (`net8.0`)
+
+### Compatibility Rules
+
+| Feature | Allowed | Alternative |
+|---------|---------|-------------|
+| `async/await` | ✅ Yes | - |
+| `ValueTask` | ❌ No | Use `Task` |
+| `IAsyncEnumerable` | ❌ No | Use callbacks or `Task<IEnumerable>` |
+| `Span<T>`, `Memory<T>` | ⚠️ Limited | Available via System.Memory package |
+| `Record` types | ❌ No | Use `class` with properties |
+| `init` accessors | ❌ No | Use `set` or constructor |
+| `required` modifier | ❌ No | Validate in constructor |
+| Nullable reference types | ✅ Yes | Use `#nullable enable` |
+| `System.Text.Json` | ⚠️ Limited | Use package, check API availability |
+| `HttpClient.GetAsync` | ✅ Yes | - |
+
+### Testing Compatibility
+```bash
+# Always build and test against all target frameworks
+dotnet build -f net472
+dotnet build -f netstandard2.0
+dotnet build -f net8.0
+```
+
+---
+
+## 2. Code Style and Conventions
+
+### File Structure
+
+```csharp
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* ...
+*/
+
+using System;                          // System namespaces first
+using System.Collections.Generic;
+using AdbcDrivers.Databricks;          // Project namespaces
+using Apache.Arrow.Adbc;               // External dependencies
+
+namespace AdbcDrivers.Databricks.Feature
+{
+    /// <summary>
+    /// XML documentation for public types.
+    /// </summary>
+    public class MyClass
+    {
+        // Order: constants, static fields, instance fields, constructors, properties, methods
+    }
+}
+```
+
+### Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Namespace | PascalCase | `AdbcDrivers.Databricks.Telemetry` |
+| Class/Interface | PascalCase | `TelemetryConfiguration`, `ITelemetryClient` |
+| Method | PascalCase | `ExportAsync`, `GetOrCreateClient` |
+| Property | PascalCase | `BatchSize`, `Enabled` |
+| Private field | `_camelCase` | `_httpClient`, `_configuration` |
+| Constant | PascalCase | `DefaultBatchSize`, `PropertyKeyEnabled` |
+| Parameter | camelCase | `connectionProperties`, `cancellationToken` |
+| Local variable | camelCase | `result`, `httpResponse` |
+
+### Property Keys and Environment Variables
+
+```csharp
+// Property keys: lowercase with dots
+public const string PropertyKeyEnabled = "telemetry.enabled";
+public const string PropertyKeyBatchSize = "telemetry.batch_size";
+
+// Environment variables: SCREAMING_SNAKE_CASE
+public const string EnvKeyEnabled = "DATABRICKS_TELEMETRY_ENABLED";
+```
+
+### Access Modifiers
+- Prefer `internal` over `public` for implementation classes
+- Use `sealed` for classes not designed for inheritance
+- Use `readonly` for fields that shouldn't change after construction
+
+```csharp
+internal sealed class TelemetryExporter : ITelemetryExporter
+{
+    private readonly HttpClient _httpClient;
+    private readonly TelemetryConfiguration _config;
+}
+```
+
+---
+
+## 3. Tracing and Diagnostics
+
+### Activity-Based Tracing
+
+Follow the existing `System.Diagnostics.Activity` pattern for tracing:
+
+```csharp
+using System.Diagnostics;
+
+internal class MyComponent
+{
+    private static readonly ActivitySource s_activitySource =
+        new ActivitySource("Databricks.Adbc.Driver");
+
+    public async Task DoWorkAsync()
+    {
+        using var activity = s_activitySource.StartActivity("MyComponent.DoWork");
+        activity?.SetTag("operation.type", "export");
+
+        try
+        {
+            // ... work
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+}
+```
+
+### Logging Levels
+
+| Level | Use Case | Example |
+|-------|----------|---------|
+| `Trace.WriteLine` with `[TRACE]` | Detailed debugging | `[TRACE] Exporting 5 events to endpoint` |
+| `Debug.WriteLine` with `[DEBUG]` | Development info | `[DEBUG] Circuit breaker state: Open` |
+| **Never** | User-visible logs | Telemetry must be silent to users |
+
+```csharp
+// Correct: Use Debug/Trace for internal diagnostics only
+Debug.WriteLine($"[DEBUG] Circuit breaker opened after {failureCount} failures");
+
+// WRONG: Never use Console.WriteLine or throw for telemetry failures
+// Console.WriteLine("Telemetry export failed");  // DON'T DO THIS
+```
+
+### Telemetry-Specific Rules
+
+1. **Never throw exceptions** from telemetry code paths
+2. **Never log at INFO or higher** - telemetry is invisible to users
+3. **Always wrap in try-catch** at entry points
+
+```csharp
+public async Task ExportAsync(IReadOnlyList<TelemetryEvent> events)
+{
+    try
+    {
+        await ExportInternalAsync(events);
+    }
+    catch (Exception ex)
+    {
+        // Swallow - telemetry failures must not affect driver operations
+        Debug.WriteLine($"[TRACE] Telemetry export failed: {ex.Message}");
+    }
+}
+```
+
+---
+
+## 4. Error Handling
+
+### Graceful Degradation
+
+For configuration parsing, use defaults instead of throwing:
+
+```csharp
+// Correct: Graceful degradation
+public static int ParseBatchSize(string? value, int defaultValue)
+{
+    if (int.TryParse(value, out int result) && result > 0)
+    {
+        return result;
+    }
+    return defaultValue;  // Invalid input uses default
+}
+
+// WRONG: Throwing on invalid config
+public static int ParseBatchSize(string value)
+{
+    return int.Parse(value);  // Throws on invalid input - DON'T DO THIS
+}
+```
+
+### Exception Classification
+
+For telemetry, classify exceptions as terminal vs retryable:
+
+```csharp
+// Terminal exceptions (flush immediately):
+// - HTTP 400, 401, 403, 404
+// - AuthenticationException
+
+// Retryable exceptions (buffer and retry):
+// - HTTP 429, 500, 503
+// - TimeoutException
+// - Network errors
+```
+
+---
+
+## 5. Testing Requirements
+
+### Test Organization
+
+```
+csharp/test/
+├── Unit/                    # Fast, isolated unit tests
+│   └── Telemetry/
+│       ├── TelemetryConfigurationTests.cs
+│       └── CircuitBreakerTests.cs
+└── E2E/                     # End-to-end tests against real services
+    └── Telemetry/
+        └── TelemetryExporterE2ETests.cs
+```
+
+### Unit Test Pattern
+
+Use Arrange-Act-Assert with clear naming:
+
+```csharp
+[Fact]
+public void ClassName_MethodName_ExpectedBehavior()
+{
+    // Arrange
+    var config = new TelemetryConfiguration { BatchSize = 50 };
+
+    // Act
+    var errors = config.Validate();
+
+    // Assert
+    Assert.Empty(errors);
+}
+```
+
+### E2E Test Requirements
+
+**Never skip E2E tests.** Use tracing to verify expected behavior:
+
+```csharp
+[Fact]
+public async Task TelemetryExporter_ExportAsync_RealEndpoint_Succeeds()
+{
+    // Arrange
+    var events = CreateTestEvents();
+    var exporter = CreateExporter();
+
+    // Act
+    await exporter.ExportAsync(events);
+
+    // Assert - Use ActivityListener to verify calls were made
+    Assert.True(_activityListener.RecordedActivities
+        .Any(a => a.OperationName == "TelemetryExporter.Export"));
+}
+```
+
+### Test Naming Convention
+
+```
+{ClassName}_{MethodName}_{Scenario}_{ExpectedResult}
+```
+
+Examples:
+- `TelemetryConfiguration_FromProperties_ValidInput_ParsesCorrectly`
+- `CircuitBreaker_Execute_ThresholdReached_TransitionsToOpen`
+- `ExceptionClassifier_IsTerminal_Http401_ReturnsTrue`
+
+---
+
+## 6. Async Patterns
+
+### Async Method Guidelines
+
+```csharp
+// Always use Async suffix
+public async Task ExportAsync(CancellationToken ct = default)
+
+// Always accept CancellationToken
+public async Task<bool> CheckFlagAsync(string host, CancellationToken ct)
+
+// Use ConfigureAwait(false) in library code
+var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
+
+// Never use .Result or .Wait() - causes deadlocks in .NET Framework
+// WRONG: var result = task.Result;
+// CORRECT: var result = await task;
+```
+
+### Fire-and-Forget Pattern
+
+For telemetry that shouldn't block:
+
+```csharp
+// Correct: Explicit fire-and-forget with discard
+_ = ExportAsync(events);  // Discards the task intentionally
+
+// For tracking failures, use a helper:
+private void FireAndForget(Task task)
+{
+    task.ContinueWith(t =>
+    {
+        if (t.IsFaulted)
+            Debug.WriteLine($"[TRACE] Background task failed: {t.Exception?.Message}");
+    }, TaskContinuationOptions.OnlyOnFaulted);
+}
+```
+
+---
+
+## 7. Documentation
+
+### XML Documentation Required For:
+- All `public` types and members
+- All `protected` members
+- Complex `internal` classes
+
+```csharp
+/// <summary>
+/// Configuration class for telemetry settings.
+/// </summary>
+/// <remarks>
+/// Configuration values are read from connection properties with fallback to
+/// environment variables, then defaults.
+/// Priority: Connection Properties > Environment Variables > Defaults.
+/// </remarks>
+public sealed class TelemetryConfiguration
+{
+    /// <summary>
+    /// Gets or sets whether telemetry is enabled. Default is true.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+}
+```
+
+### Code Comments
+
+```csharp
+// Use comments to explain WHY, not WHAT
+// Good: Explains reasoning
+// Buffer retryable exceptions until statement completes to avoid
+// sending incomplete error context
+private readonly Dictionary<string, List<Exception>> _bufferedExceptions;
+
+// Bad: States the obvious
+// Create a new dictionary
+private readonly Dictionary<string, List<Exception>> _bufferedExceptions;
+```
+
+---
+
+## 8. Pull Request Guidelines
+
+### PR Title Format
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(csharp): add telemetry exporter with JDBC-compatible format
+fix(csharp): handle null workspace ID in telemetry events
+refactor(csharp): extract circuit breaker to separate class
+test(csharp): add E2E tests for telemetry export
+docs(csharp): update coding guidelines
+```
+
+### PR Checklist
+
+- [ ] Code builds on all target frameworks (`net472`, `netstandard2.0`, `net8.0`)
+- [ ] All unit tests pass
+- [ ] E2E tests pass (not skipped)
+- [ ] XML documentation added for public APIs
+- [ ] No `Console.WriteLine` or user-visible logging for telemetry
+- [ ] Exceptions are properly handled (no throws from telemetry paths)
+- [ ] Pre-commit hooks pass: `pre-commit run --all-files`
+
+---
+
+## Quick Reference
+
+### Do's
+- ✅ Target `netstandard2.0` compatibility
+- ✅ Use `async/await` with `ConfigureAwait(false)`
+- ✅ Use `Activity` for tracing
+- ✅ Swallow exceptions in telemetry code
+- ✅ Use graceful degradation for config parsing
+- ✅ Write comprehensive E2E tests
+- ✅ Use XML documentation
+
+### Don'ts
+- ❌ Use C# 9+ features (records, init, required)
+- ❌ Use `Task.Result` or `Task.Wait()`
+- ❌ Throw exceptions from telemetry code paths
+- ❌ Log at INFO level or higher for telemetry
+- ❌ Skip E2E tests
+- ❌ Use `Console.WriteLine`

--- a/csharp/doc/telemetry-sprint-plan.md
+++ b/csharp/doc/telemetry-sprint-plan.md
@@ -120,7 +120,7 @@ Implement the core telemetry infrastructure including feature flag management, p
 #### WI-1.2: Tag Definition System
 **Description**: Create centralized tag definitions with export scope annotations.
 
-**Status**: ❌ **NOT STARTED**
+**Status**: ✅ **COMPLETED**
 
 **Location**: `csharp/src/Telemetry/TagDefinitions/`
 
@@ -147,6 +147,13 @@ Implement the core telemetry infrastructure including feature flag management, p
 | Unit | `TelemetryTagRegistry_ShouldExportToDatabricks_SensitiveTag_ReturnsFalse` | EventType.StatementExecution, "db.statement" | false |
 | Unit | `TelemetryTagRegistry_ShouldExportToDatabricks_SafeTag_ReturnsTrue` | EventType.StatementExecution, "statement.id" | true |
 | Unit | `ConnectionOpenEvent_GetDatabricksExportTags_ExcludesServerAddress` | N/A | Set does NOT contain "server.address" |
+
+**Implementation Notes**:
+- Used `IReadOnlyCollection<string>` instead of `IReadOnlySet<string>` for netstandard2.0 compatibility
+- Each event class has its own `ShouldExportToDatabricks(tagName)` method using internal `HashSet<string>` for O(1) lookup
+- Added `TelemetryTagRegistry.FilterForDatabricksExport()` helper for filtering tag collections
+- Added `TelemetryTagRegistry.DetermineEventType()` for mapping Activity operation names to event types
+- Test file: `test/Unit/Telemetry/TagDefinitions/TelemetryTagRegistryTests.cs` with 40 comprehensive tests
 
 ---
 

--- a/csharp/src/Telemetry/TagDefinitions/ConnectionOpenEvent.cs
+++ b/csharp/src/Telemetry/TagDefinitions/ConnectionOpenEvent.cs
@@ -1,0 +1,211 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace AdbcDrivers.Databricks.Telemetry.TagDefinitions
+{
+    /// <summary>
+    /// Tag definitions for Connection.Open events.
+    /// Defines all Activity tags used when a connection is opened.
+    /// </summary>
+    internal static class ConnectionOpenEvent
+    {
+        /// <summary>
+        /// The event name for connection open activities.
+        /// </summary>
+        public const string EventName = "Connection.Open";
+
+        // ============================================================================
+        // Standard identification tags
+        // ============================================================================
+
+        /// <summary>
+        /// Databricks workspace ID. Required for Databricks export.
+        /// </summary>
+        [TelemetryTag("workspace.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Databricks workspace ID",
+            Required = true)]
+        public const string WorkspaceId = "workspace.id";
+
+        /// <summary>
+        /// Connection session ID. Required for correlation across events.
+        /// </summary>
+        [TelemetryTag("session.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Connection session ID",
+            Required = true)]
+        public const string SessionId = "session.id";
+
+        // ============================================================================
+        // Driver configuration tags
+        // ============================================================================
+
+        /// <summary>
+        /// ADBC driver version string.
+        /// </summary>
+        [TelemetryTag("driver.version",
+            ExportScope = TagExportScope.ExportAll,
+            Description = "ADBC driver version")]
+        public const string DriverVersion = "driver.version";
+
+        /// <summary>
+        /// Operating system name.
+        /// </summary>
+        [TelemetryTag("driver.os",
+            ExportScope = TagExportScope.ExportAll,
+            Description = "Operating system")]
+        public const string DriverOS = "driver.os";
+
+        /// <summary>
+        /// .NET runtime version.
+        /// </summary>
+        [TelemetryTag("driver.runtime",
+            ExportScope = TagExportScope.ExportAll,
+            Description = ".NET runtime version")]
+        public const string DriverRuntime = "driver.runtime";
+
+        /// <summary>
+        /// Driver name identifier.
+        /// </summary>
+        [TelemetryTag("driver.name",
+            ExportScope = TagExportScope.ExportAll,
+            Description = "Driver name")]
+        public const string DriverName = "driver.name";
+
+        /// <summary>
+        /// System locale name.
+        /// </summary>
+        [TelemetryTag("driver.locale",
+            ExportScope = TagExportScope.ExportAll,
+            Description = "System locale name")]
+        public const string DriverLocale = "driver.locale";
+
+        // ============================================================================
+        // Feature flag tags
+        // ============================================================================
+
+        /// <summary>
+        /// Whether CloudFetch is enabled.
+        /// </summary>
+        [TelemetryTag("feature.cloudfetch",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "CloudFetch enabled")]
+        public const string FeatureCloudFetch = "feature.cloudfetch";
+
+        /// <summary>
+        /// Whether LZ4 compression is enabled.
+        /// </summary>
+        [TelemetryTag("feature.lz4",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "LZ4 compression enabled")]
+        public const string FeatureLz4 = "feature.lz4";
+
+        /// <summary>
+        /// Whether direct results are enabled.
+        /// </summary>
+        [TelemetryTag("feature.direct_results",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Direct results enabled")]
+        public const string FeatureDirectResults = "feature.direct_results";
+
+        // ============================================================================
+        // Connection parameters tags
+        // ============================================================================
+
+        /// <summary>
+        /// HTTP path for the connection.
+        /// </summary>
+        [TelemetryTag("connection.http_path",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "HTTP path for connection")]
+        public const string ConnectionHttpPath = "connection.http_path";
+
+        /// <summary>
+        /// Connection mode (thrift or sea).
+        /// </summary>
+        [TelemetryTag("connection.mode",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Connection mode (thrift/sea)")]
+        public const string ConnectionMode = "connection.mode";
+
+        /// <summary>
+        /// Authentication mechanism type.
+        /// </summary>
+        [TelemetryTag("connection.auth_mech",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Authentication mechanism")]
+        public const string ConnectionAuthMech = "connection.auth_mech";
+
+        // ============================================================================
+        // Sensitive tags - NOT exported to Databricks
+        // ============================================================================
+
+        /// <summary>
+        /// Workspace host address. Local diagnostics only.
+        /// </summary>
+        [TelemetryTag("server.address",
+            ExportScope = TagExportScope.ExportLocal,
+            Description = "Workspace host (local diagnostics only)")]
+        public const string ServerAddress = "server.address";
+
+        /// <summary>
+        /// User identity. Local diagnostics only.
+        /// </summary>
+        [TelemetryTag("user.id",
+            ExportScope = TagExportScope.ExportLocal,
+            Description = "User identity (local diagnostics only)")]
+        public const string UserId = "user.id";
+
+        // Cached set of Databricks export tags for performance
+        private static readonly HashSet<string> s_databricksExportTags = new HashSet<string>
+        {
+            WorkspaceId,
+            SessionId,
+            DriverVersion,
+            DriverOS,
+            DriverRuntime,
+            DriverName,
+            DriverLocale,
+            FeatureCloudFetch,
+            FeatureLz4,
+            FeatureDirectResults,
+            ConnectionHttpPath,
+            ConnectionMode,
+            ConnectionAuthMech
+        };
+
+        /// <summary>
+        /// Get all tags that should be exported to Databricks for this event type.
+        /// </summary>
+        /// <returns>Set of tag names allowed for Databricks export.</returns>
+        public static IReadOnlyCollection<string> GetDatabricksExportTags()
+        {
+            return s_databricksExportTags;
+        }
+
+        /// <summary>
+        /// Check if a tag should be exported to Databricks.
+        /// </summary>
+        /// <param name="tagName">The tag name to check.</param>
+        /// <returns>True if the tag should be exported to Databricks.</returns>
+        public static bool ShouldExportToDatabricks(string tagName)
+        {
+            return s_databricksExportTags.Contains(tagName);
+        }
+    }
+}

--- a/csharp/src/Telemetry/TagDefinitions/ErrorEvent.cs
+++ b/csharp/src/Telemetry/TagDefinitions/ErrorEvent.cs
@@ -1,0 +1,169 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace AdbcDrivers.Databricks.Telemetry.TagDefinitions
+{
+    /// <summary>
+    /// Tag definitions for Error events.
+    /// Defines all Activity tags used when errors occur.
+    /// </summary>
+    internal static class ErrorEvent
+    {
+        /// <summary>
+        /// The event name for error activities.
+        /// </summary>
+        public const string EventName = "Error";
+
+        // ============================================================================
+        // Identification tags
+        // ============================================================================
+
+        /// <summary>
+        /// Connection session ID. Required for correlation.
+        /// </summary>
+        [TelemetryTag("session.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Connection session ID",
+            Required = true)]
+        public const string SessionId = "session.id";
+
+        /// <summary>
+        /// Statement ID if error occurred during statement execution.
+        /// </summary>
+        [TelemetryTag("statement.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Statement execution ID")]
+        public const string StatementId = "statement.id";
+
+        /// <summary>
+        /// Workspace ID for the connection.
+        /// </summary>
+        [TelemetryTag("workspace.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Databricks workspace ID")]
+        public const string WorkspaceId = "workspace.id";
+
+        // ============================================================================
+        // Error identification tags
+        // ============================================================================
+
+        /// <summary>
+        /// Error type/class name.
+        /// </summary>
+        [TelemetryTag("error.type",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Error type/exception class name",
+            Required = true)]
+        public const string ErrorType = "error.type";
+
+        /// <summary>
+        /// Error name (short identifier).
+        /// </summary>
+        [TelemetryTag("error.name",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Error name")]
+        public const string ErrorName = "error.name";
+
+        /// <summary>
+        /// Error code if applicable.
+        /// </summary>
+        [TelemetryTag("error.code",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Error code")]
+        public const string ErrorCode = "error.code";
+
+        /// <summary>
+        /// HTTP status code if error is HTTP-related.
+        /// </summary>
+        [TelemetryTag("error.http_status",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "HTTP status code")]
+        public const string ErrorHttpStatus = "error.http_status";
+
+        /// <summary>
+        /// SQL state if error is SQL-related.
+        /// </summary>
+        [TelemetryTag("error.sql_state",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "SQL state code")]
+        public const string ErrorSqlState = "error.sql_state";
+
+        /// <summary>
+        /// Whether the error is terminal (non-retryable).
+        /// </summary>
+        [TelemetryTag("error.terminal",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Whether error is terminal (non-retryable)")]
+        public const string ErrorTerminal = "error.terminal";
+
+        // ============================================================================
+        // Sensitive tags - NOT exported to Databricks
+        // ============================================================================
+
+        /// <summary>
+        /// Detailed error message. Local diagnostics only.
+        /// May contain sensitive information from queries or data.
+        /// </summary>
+        [TelemetryTag("error.message",
+            ExportScope = TagExportScope.ExportLocal,
+            Description = "Detailed error message (local diagnostics only)")]
+        public const string ErrorMessage = "error.message";
+
+        /// <summary>
+        /// Stack trace. Local diagnostics only.
+        /// May contain sensitive paths or data.
+        /// </summary>
+        [TelemetryTag("error.stack_trace",
+            ExportScope = TagExportScope.ExportLocal,
+            Description = "Stack trace (local diagnostics only)")]
+        public const string ErrorStackTrace = "error.stack_trace";
+
+        // Cached set of Databricks export tags for performance
+        private static readonly HashSet<string> s_databricksExportTags = new HashSet<string>
+        {
+            SessionId,
+            StatementId,
+            WorkspaceId,
+            ErrorType,
+            ErrorName,
+            ErrorCode,
+            ErrorHttpStatus,
+            ErrorSqlState,
+            ErrorTerminal
+        };
+
+        /// <summary>
+        /// Get all tags that should be exported to Databricks for this event type.
+        /// </summary>
+        /// <returns>Set of tag names allowed for Databricks export.</returns>
+        public static IReadOnlyCollection<string> GetDatabricksExportTags()
+        {
+            return s_databricksExportTags;
+        }
+
+        /// <summary>
+        /// Check if a tag should be exported to Databricks.
+        /// </summary>
+        /// <param name="tagName">The tag name to check.</param>
+        /// <returns>True if the tag should be exported to Databricks.</returns>
+        public static bool ShouldExportToDatabricks(string tagName)
+        {
+            return s_databricksExportTags.Contains(tagName);
+        }
+    }
+}

--- a/csharp/src/Telemetry/TagDefinitions/StatementExecutionEvent.cs
+++ b/csharp/src/Telemetry/TagDefinitions/StatementExecutionEvent.cs
@@ -1,0 +1,219 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace AdbcDrivers.Databricks.Telemetry.TagDefinitions
+{
+    /// <summary>
+    /// Tag definitions for Statement execution events.
+    /// Defines all Activity tags used during SQL statement execution.
+    /// </summary>
+    internal static class StatementExecutionEvent
+    {
+        /// <summary>
+        /// The event name for statement execution activities.
+        /// </summary>
+        public const string EventName = "Statement.Execute";
+
+        // ============================================================================
+        // Statement identification tags
+        // ============================================================================
+
+        /// <summary>
+        /// Statement execution ID. Required for statement-level correlation.
+        /// </summary>
+        [TelemetryTag("statement.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Statement execution ID",
+            Required = true)]
+        public const string StatementId = "statement.id";
+
+        /// <summary>
+        /// Connection session ID. Required for connection-level correlation.
+        /// </summary>
+        [TelemetryTag("session.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Connection session ID",
+            Required = true)]
+        public const string SessionId = "session.id";
+
+        /// <summary>
+        /// Workspace ID for the connection.
+        /// </summary>
+        [TelemetryTag("workspace.id",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Databricks workspace ID")]
+        public const string WorkspaceId = "workspace.id";
+
+        // ============================================================================
+        // Statement type and operation tags
+        // ============================================================================
+
+        /// <summary>
+        /// Type of statement (QUERY, UPDATE, etc.).
+        /// </summary>
+        [TelemetryTag("statement.type",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Statement type (QUERY, UPDATE, etc.)")]
+        public const string StatementType = "statement.type";
+
+        // ============================================================================
+        // Result format tags
+        // ============================================================================
+
+        /// <summary>
+        /// Result format: inline or cloudfetch.
+        /// </summary>
+        [TelemetryTag("result.format",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Result format: inline, cloudfetch")]
+        public const string ResultFormat = "result.format";
+
+        /// <summary>
+        /// Number of CloudFetch chunks downloaded.
+        /// </summary>
+        [TelemetryTag("result.chunk_count",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Number of CloudFetch chunks")]
+        public const string ResultChunkCount = "result.chunk_count";
+
+        /// <summary>
+        /// Total bytes downloaded from results.
+        /// </summary>
+        [TelemetryTag("result.bytes_downloaded",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Total bytes downloaded")]
+        public const string ResultBytesDownloaded = "result.bytes_downloaded";
+
+        /// <summary>
+        /// Whether compression was enabled for results.
+        /// </summary>
+        [TelemetryTag("result.compression_enabled",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Compression enabled for results")]
+        public const string ResultCompressionEnabled = "result.compression_enabled";
+
+        /// <summary>
+        /// Total number of rows returned.
+        /// </summary>
+        [TelemetryTag("result.row_count",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Total number of rows returned")]
+        public const string ResultRowCount = "result.row_count";
+
+        // ============================================================================
+        // Polling metrics tags
+        // ============================================================================
+
+        /// <summary>
+        /// Number of status poll requests made.
+        /// </summary>
+        [TelemetryTag("poll.count",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Number of status poll requests")]
+        public const string PollCount = "poll.count";
+
+        /// <summary>
+        /// Total polling latency in milliseconds.
+        /// </summary>
+        [TelemetryTag("poll.latency_ms",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Total polling latency")]
+        public const string PollLatencyMs = "poll.latency_ms";
+
+        // ============================================================================
+        // Retry metrics tags
+        // ============================================================================
+
+        /// <summary>
+        /// Number of retry attempts made.
+        /// </summary>
+        [TelemetryTag("retry.count",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Number of retry attempts")]
+        public const string RetryCount = "retry.count";
+
+        // ============================================================================
+        // Latency tags
+        // ============================================================================
+
+        /// <summary>
+        /// Total operation latency in milliseconds.
+        /// </summary>
+        [TelemetryTag("operation.latency_ms",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Total operation latency in milliseconds")]
+        public const string OperationLatencyMs = "operation.latency_ms";
+
+        // ============================================================================
+        // Sensitive tags - NOT exported to Databricks
+        // ============================================================================
+
+        /// <summary>
+        /// SQL query text. Local diagnostics only.
+        /// </summary>
+        [TelemetryTag("db.statement",
+            ExportScope = TagExportScope.ExportLocal,
+            Description = "SQL query text (local diagnostics only)")]
+        public const string DbStatement = "db.statement";
+
+        /// <summary>
+        /// Query parameters. Local diagnostics only.
+        /// </summary>
+        [TelemetryTag("db.parameters",
+            ExportScope = TagExportScope.ExportLocal,
+            Description = "Query parameters (local diagnostics only)")]
+        public const string DbParameters = "db.parameters";
+
+        // Cached set of Databricks export tags for performance
+        private static readonly HashSet<string> s_databricksExportTags = new HashSet<string>
+        {
+            StatementId,
+            SessionId,
+            WorkspaceId,
+            StatementType,
+            ResultFormat,
+            ResultChunkCount,
+            ResultBytesDownloaded,
+            ResultCompressionEnabled,
+            ResultRowCount,
+            PollCount,
+            PollLatencyMs,
+            RetryCount,
+            OperationLatencyMs
+        };
+
+        /// <summary>
+        /// Get all tags that should be exported to Databricks for this event type.
+        /// </summary>
+        /// <returns>Set of tag names allowed for Databricks export.</returns>
+        public static IReadOnlyCollection<string> GetDatabricksExportTags()
+        {
+            return s_databricksExportTags;
+        }
+
+        /// <summary>
+        /// Check if a tag should be exported to Databricks.
+        /// </summary>
+        /// <param name="tagName">The tag name to check.</param>
+        /// <returns>True if the tag should be exported to Databricks.</returns>
+        public static bool ShouldExportToDatabricks(string tagName)
+        {
+            return s_databricksExportTags.Contains(tagName);
+        }
+    }
+}

--- a/csharp/src/Telemetry/TagDefinitions/TelemetryTag.cs
+++ b/csharp/src/Telemetry/TagDefinitions/TelemetryTag.cs
@@ -1,0 +1,111 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace AdbcDrivers.Databricks.Telemetry.TagDefinitions
+{
+    /// <summary>
+    /// Defines export scope for telemetry tags.
+    /// Controls which destinations receive each tag.
+    /// </summary>
+    [Flags]
+    internal enum TagExportScope
+    {
+        /// <summary>
+        /// Tag is not exported to any destination.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Export to local diagnostics only (file listener, console, etc.).
+        /// Suitable for sensitive data that should not leave the client.
+        /// </summary>
+        ExportLocal = 1,
+
+        /// <summary>
+        /// Export to Databricks telemetry service.
+        /// Only non-sensitive data should use this scope.
+        /// </summary>
+        ExportDatabricks = 2,
+
+        /// <summary>
+        /// Export to all destinations (local and Databricks).
+        /// </summary>
+        ExportAll = ExportLocal | ExportDatabricks
+    }
+
+    /// <summary>
+    /// Telemetry event types for categorizing activities.
+    /// </summary>
+    internal enum TelemetryEventType
+    {
+        /// <summary>
+        /// Connection open event.
+        /// </summary>
+        ConnectionOpen,
+
+        /// <summary>
+        /// Statement execution event.
+        /// </summary>
+        StatementExecution,
+
+        /// <summary>
+        /// Error event.
+        /// </summary>
+        Error
+    }
+
+    /// <summary>
+    /// Attribute to annotate Activity tag definitions with metadata.
+    /// Used to centrally define which tags are exported to which destinations.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    internal sealed class TelemetryTagAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the tag name as it appears in Activity tags.
+        /// </summary>
+        public string TagName { get; }
+
+        /// <summary>
+        /// Gets or sets the export scope for this tag.
+        /// Default is ExportAll (exported to both local and Databricks).
+        /// </summary>
+        public TagExportScope ExportScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a human-readable description of this tag.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this tag is required for the event.
+        /// </summary>
+        public bool Required { get; set; }
+
+        /// <summary>
+        /// Creates a new TelemetryTagAttribute with the specified tag name.
+        /// </summary>
+        /// <param name="tagName">The tag name as it appears in Activity tags.</param>
+        public TelemetryTagAttribute(string tagName)
+        {
+            TagName = tagName ?? throw new ArgumentNullException(nameof(tagName));
+            ExportScope = TagExportScope.ExportAll;
+            Required = false;
+        }
+    }
+}

--- a/csharp/src/Telemetry/TagDefinitions/TelemetryTagRegistry.cs
+++ b/csharp/src/Telemetry/TagDefinitions/TelemetryTagRegistry.cs
@@ -1,0 +1,168 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace AdbcDrivers.Databricks.Telemetry.TagDefinitions
+{
+    /// <summary>
+    /// Central registry for all telemetry tags and events.
+    /// Provides methods to query which tags should be exported to which destinations.
+    /// </summary>
+    internal static class TelemetryTagRegistry
+    {
+        /// <summary>
+        /// Get all tags allowed for Databricks export by event type.
+        /// </summary>
+        /// <param name="eventType">The telemetry event type.</param>
+        /// <returns>Collection of tag names that should be exported to Databricks for this event type.</returns>
+        public static IReadOnlyCollection<string> GetDatabricksExportTags(TelemetryEventType eventType)
+        {
+            switch (eventType)
+            {
+                case TelemetryEventType.ConnectionOpen:
+                    return ConnectionOpenEvent.GetDatabricksExportTags();
+                case TelemetryEventType.StatementExecution:
+                    return StatementExecutionEvent.GetDatabricksExportTags();
+                case TelemetryEventType.Error:
+                    return ErrorEvent.GetDatabricksExportTags();
+                default:
+                    return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>
+        /// Check if a tag should be exported to Databricks for a given event type.
+        /// </summary>
+        /// <param name="eventType">The telemetry event type.</param>
+        /// <param name="tagName">The tag name to check.</param>
+        /// <returns>True if the tag should be exported to Databricks, false otherwise.</returns>
+        public static bool ShouldExportToDatabricks(TelemetryEventType eventType, string tagName)
+        {
+            if (string.IsNullOrEmpty(tagName))
+            {
+                return false;
+            }
+
+            switch (eventType)
+            {
+                case TelemetryEventType.ConnectionOpen:
+                    return ConnectionOpenEvent.ShouldExportToDatabricks(tagName);
+                case TelemetryEventType.StatementExecution:
+                    return StatementExecutionEvent.ShouldExportToDatabricks(tagName);
+                case TelemetryEventType.Error:
+                    return ErrorEvent.ShouldExportToDatabricks(tagName);
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Check if a tag should be exported to local diagnostics for a given event type.
+        /// All tags can be exported to local diagnostics by default.
+        /// </summary>
+        /// <param name="eventType">The telemetry event type.</param>
+        /// <param name="tagName">The tag name to check.</param>
+        /// <returns>True if the tag should be exported to local diagnostics.</returns>
+        public static bool ShouldExportToLocal(TelemetryEventType eventType, string tagName)
+        {
+            // All tags can be exported to local diagnostics
+            // This provides full visibility for debugging while protecting privacy on Databricks
+            return !string.IsNullOrEmpty(tagName);
+        }
+
+        /// <summary>
+        /// Filter a collection of tags to only those that should be exported to Databricks.
+        /// </summary>
+        /// <param name="eventType">The telemetry event type.</param>
+        /// <param name="tags">The tags to filter.</param>
+        /// <returns>A new dictionary containing only the tags that should be exported.</returns>
+        public static IReadOnlyDictionary<string, string?> FilterForDatabricksExport(
+            TelemetryEventType eventType,
+            IEnumerable<KeyValuePair<string, string?>> tags)
+        {
+            if (tags == null)
+            {
+                return new Dictionary<string, string?>();
+            }
+
+            var result = new Dictionary<string, string?>();
+
+            foreach (var tag in tags)
+            {
+                if (ShouldExportToDatabricks(eventType, tag.Key))
+                {
+                    result[tag.Key] = tag.Value;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Get the event name for a given event type.
+        /// </summary>
+        /// <param name="eventType">The telemetry event type.</param>
+        /// <returns>The event name string.</returns>
+        public static string GetEventName(TelemetryEventType eventType)
+        {
+            switch (eventType)
+            {
+                case TelemetryEventType.ConnectionOpen:
+                    return ConnectionOpenEvent.EventName;
+                case TelemetryEventType.StatementExecution:
+                    return StatementExecutionEvent.EventName;
+                case TelemetryEventType.Error:
+                    return ErrorEvent.EventName;
+                default:
+                    return "Unknown";
+            }
+        }
+
+        /// <summary>
+        /// Determine the event type from an Activity operation name.
+        /// </summary>
+        /// <param name="operationName">The Activity operation name.</param>
+        /// <param name="hasErrorTag">Whether the activity has an error.type tag.</param>
+        /// <returns>The determined TelemetryEventType.</returns>
+        public static TelemetryEventType DetermineEventType(string operationName, bool hasErrorTag)
+        {
+            // Check for errors first (error tag presence takes precedence)
+            if (hasErrorTag)
+            {
+                return TelemetryEventType.Error;
+            }
+
+            // Map based on operation name prefix
+            if (!string.IsNullOrEmpty(operationName))
+            {
+                if (operationName.StartsWith("Connection.", StringComparison.OrdinalIgnoreCase))
+                {
+                    return TelemetryEventType.ConnectionOpen;
+                }
+
+                if (operationName.StartsWith("Statement.", StringComparison.OrdinalIgnoreCase))
+                {
+                    return TelemetryEventType.StatementExecution;
+                }
+            }
+
+            // Default to StatementExecution for unknown operations
+            return TelemetryEventType.StatementExecution;
+        }
+    }
+}

--- a/csharp/test/Unit/Telemetry/TagDefinitions/TelemetryTagRegistryTests.cs
+++ b/csharp/test/Unit/Telemetry/TagDefinitions/TelemetryTagRegistryTests.cs
@@ -1,0 +1,591 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry.TagDefinitions
+{
+    /// <summary>
+    /// Tests for TelemetryTagRegistry class.
+    /// </summary>
+    public class TelemetryTagRegistryTests
+    {
+        // ============================================================================
+        // GetDatabricksExportTags Tests - ConnectionOpen
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_GetDatabricksExportTags_ConnectionOpen_ReturnsCorrectTags()
+        {
+            // Act
+            var tags = TelemetryTagRegistry.GetDatabricksExportTags(TelemetryEventType.ConnectionOpen);
+
+            // Assert
+            Assert.NotNull(tags);
+            Assert.NotEmpty(tags);
+
+            // Should contain standard identification tags
+            Assert.Contains(ConnectionOpenEvent.WorkspaceId, tags);
+            Assert.Contains(ConnectionOpenEvent.SessionId, tags);
+
+            // Should contain driver configuration tags
+            Assert.Contains(ConnectionOpenEvent.DriverVersion, tags);
+            Assert.Contains(ConnectionOpenEvent.DriverOS, tags);
+            Assert.Contains(ConnectionOpenEvent.DriverRuntime, tags);
+
+            // Should contain feature flag tags
+            Assert.Contains(ConnectionOpenEvent.FeatureCloudFetch, tags);
+            Assert.Contains(ConnectionOpenEvent.FeatureLz4, tags);
+        }
+
+        [Fact]
+        public void ConnectionOpenEvent_GetDatabricksExportTags_ExcludesServerAddress()
+        {
+            // Act
+            var tags = ConnectionOpenEvent.GetDatabricksExportTags();
+
+            // Assert - server.address should NOT be exported to Databricks (sensitive)
+            Assert.DoesNotContain(ConnectionOpenEvent.ServerAddress, tags);
+        }
+
+        [Fact]
+        public void ConnectionOpenEvent_GetDatabricksExportTags_ExcludesUserId()
+        {
+            // Act
+            var tags = ConnectionOpenEvent.GetDatabricksExportTags();
+
+            // Assert - user.id should NOT be exported to Databricks (sensitive)
+            Assert.DoesNotContain(ConnectionOpenEvent.UserId, tags);
+        }
+
+        // ============================================================================
+        // GetDatabricksExportTags Tests - StatementExecution
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_GetDatabricksExportTags_StatementExecution_ReturnsCorrectTags()
+        {
+            // Act
+            var tags = TelemetryTagRegistry.GetDatabricksExportTags(TelemetryEventType.StatementExecution);
+
+            // Assert
+            Assert.NotNull(tags);
+            Assert.NotEmpty(tags);
+
+            // Should contain statement identification tags
+            Assert.Contains(StatementExecutionEvent.StatementId, tags);
+            Assert.Contains(StatementExecutionEvent.SessionId, tags);
+
+            // Should contain result format tags
+            Assert.Contains(StatementExecutionEvent.ResultFormat, tags);
+            Assert.Contains(StatementExecutionEvent.ResultChunkCount, tags);
+            Assert.Contains(StatementExecutionEvent.ResultBytesDownloaded, tags);
+
+            // Should contain polling metrics tags
+            Assert.Contains(StatementExecutionEvent.PollCount, tags);
+            Assert.Contains(StatementExecutionEvent.PollLatencyMs, tags);
+        }
+
+        [Fact]
+        public void StatementExecutionEvent_GetDatabricksExportTags_ExcludesDbStatement()
+        {
+            // Act
+            var tags = StatementExecutionEvent.GetDatabricksExportTags();
+
+            // Assert - db.statement should NOT be exported to Databricks (SQL query text is sensitive)
+            Assert.DoesNotContain(StatementExecutionEvent.DbStatement, tags);
+        }
+
+        [Fact]
+        public void StatementExecutionEvent_GetDatabricksExportTags_ExcludesDbParameters()
+        {
+            // Act
+            var tags = StatementExecutionEvent.GetDatabricksExportTags();
+
+            // Assert - db.parameters should NOT be exported to Databricks (sensitive)
+            Assert.DoesNotContain(StatementExecutionEvent.DbParameters, tags);
+        }
+
+        // ============================================================================
+        // GetDatabricksExportTags Tests - Error
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_GetDatabricksExportTags_Error_ReturnsCorrectTags()
+        {
+            // Act
+            var tags = TelemetryTagRegistry.GetDatabricksExportTags(TelemetryEventType.Error);
+
+            // Assert
+            Assert.NotNull(tags);
+            Assert.NotEmpty(tags);
+
+            // Should contain error identification tags
+            Assert.Contains(ErrorEvent.ErrorType, tags);
+            Assert.Contains(ErrorEvent.ErrorName, tags);
+            Assert.Contains(ErrorEvent.ErrorCode, tags);
+
+            // Should contain correlation tags
+            Assert.Contains(ErrorEvent.SessionId, tags);
+            Assert.Contains(ErrorEvent.StatementId, tags);
+        }
+
+        [Fact]
+        public void ErrorEvent_GetDatabricksExportTags_ExcludesErrorMessage()
+        {
+            // Act
+            var tags = ErrorEvent.GetDatabricksExportTags();
+
+            // Assert - error.message should NOT be exported to Databricks (may contain sensitive data)
+            Assert.DoesNotContain(ErrorEvent.ErrorMessage, tags);
+        }
+
+        [Fact]
+        public void ErrorEvent_GetDatabricksExportTags_ExcludesStackTrace()
+        {
+            // Act
+            var tags = ErrorEvent.GetDatabricksExportTags();
+
+            // Assert - error.stack_trace should NOT be exported to Databricks (may contain sensitive paths)
+            Assert.DoesNotContain(ErrorEvent.ErrorStackTrace, tags);
+        }
+
+        // ============================================================================
+        // ShouldExportToDatabricks Tests
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToDatabricks_SensitiveTag_ReturnsFalse()
+        {
+            // Act & Assert - Statement execution sensitive tags
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, StatementExecutionEvent.DbStatement));
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, StatementExecutionEvent.DbParameters));
+
+            // Connection open sensitive tags
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.ConnectionOpen, ConnectionOpenEvent.ServerAddress));
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.ConnectionOpen, ConnectionOpenEvent.UserId));
+
+            // Error sensitive tags
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.Error, ErrorEvent.ErrorMessage));
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.Error, ErrorEvent.ErrorStackTrace));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToDatabricks_SafeTag_ReturnsTrue()
+        {
+            // Act & Assert - Statement execution safe tags
+            Assert.True(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, StatementExecutionEvent.StatementId));
+            Assert.True(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, StatementExecutionEvent.ResultFormat));
+            Assert.True(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, StatementExecutionEvent.ResultChunkCount));
+
+            // Connection open safe tags
+            Assert.True(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.ConnectionOpen, ConnectionOpenEvent.WorkspaceId));
+            Assert.True(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.ConnectionOpen, ConnectionOpenEvent.DriverVersion));
+
+            // Error safe tags
+            Assert.True(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.Error, ErrorEvent.ErrorType));
+            Assert.True(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.Error, ErrorEvent.ErrorCode));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToDatabricks_UnknownTag_ReturnsFalse()
+        {
+            // Act & Assert - Unknown tags should not be exported
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, "unknown.tag"));
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.ConnectionOpen, "random.tag.name"));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToDatabricks_NullTag_ReturnsFalse()
+        {
+            // Act & Assert
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, null!));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToDatabricks_EmptyTag_ReturnsFalse()
+        {
+            // Act & Assert
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, ""));
+            Assert.False(TelemetryTagRegistry.ShouldExportToDatabricks(
+                TelemetryEventType.StatementExecution, "   "));
+        }
+
+        // ============================================================================
+        // ShouldExportToLocal Tests
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToLocal_AllTags_ReturnsTrue()
+        {
+            // Act & Assert - All tags should be exportable to local diagnostics
+            Assert.True(TelemetryTagRegistry.ShouldExportToLocal(
+                TelemetryEventType.StatementExecution, StatementExecutionEvent.DbStatement));
+            Assert.True(TelemetryTagRegistry.ShouldExportToLocal(
+                TelemetryEventType.ConnectionOpen, ConnectionOpenEvent.ServerAddress));
+            Assert.True(TelemetryTagRegistry.ShouldExportToLocal(
+                TelemetryEventType.Error, ErrorEvent.ErrorMessage));
+            Assert.True(TelemetryTagRegistry.ShouldExportToLocal(
+                TelemetryEventType.Error, ErrorEvent.ErrorStackTrace));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToLocal_NullTag_ReturnsFalse()
+        {
+            // Act & Assert
+            Assert.False(TelemetryTagRegistry.ShouldExportToLocal(
+                TelemetryEventType.StatementExecution, null!));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_ShouldExportToLocal_EmptyTag_ReturnsFalse()
+        {
+            // Act & Assert
+            Assert.False(TelemetryTagRegistry.ShouldExportToLocal(
+                TelemetryEventType.StatementExecution, ""));
+        }
+
+        // ============================================================================
+        // FilterForDatabricksExport Tests
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_FilterForDatabricksExport_RemovesSensitiveTags()
+        {
+            // Arrange
+            var tags = new Dictionary<string, string?>
+            {
+                { StatementExecutionEvent.StatementId, "stmt-123" },
+                { StatementExecutionEvent.SessionId, "session-456" },
+                { StatementExecutionEvent.DbStatement, "SELECT * FROM users WHERE id = 1" }, // sensitive
+                { StatementExecutionEvent.ResultFormat, "cloudfetch" }
+            };
+
+            // Act
+            var filtered = TelemetryTagRegistry.FilterForDatabricksExport(
+                TelemetryEventType.StatementExecution, tags);
+
+            // Assert
+            Assert.Equal(3, filtered.Count);
+            Assert.Contains(StatementExecutionEvent.StatementId, filtered.Keys);
+            Assert.Contains(StatementExecutionEvent.SessionId, filtered.Keys);
+            Assert.Contains(StatementExecutionEvent.ResultFormat, filtered.Keys);
+            Assert.DoesNotContain(StatementExecutionEvent.DbStatement, filtered.Keys);
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_FilterForDatabricksExport_PreservesValues()
+        {
+            // Arrange
+            var tags = new Dictionary<string, string?>
+            {
+                { StatementExecutionEvent.StatementId, "stmt-123" },
+                { StatementExecutionEvent.ResultChunkCount, "5" }
+            };
+
+            // Act
+            var filtered = TelemetryTagRegistry.FilterForDatabricksExport(
+                TelemetryEventType.StatementExecution, tags);
+
+            // Assert
+            Assert.Equal("stmt-123", filtered[StatementExecutionEvent.StatementId]);
+            Assert.Equal("5", filtered[StatementExecutionEvent.ResultChunkCount]);
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_FilterForDatabricksExport_NullTags_ReturnsEmptyDictionary()
+        {
+            // Act
+            var filtered = TelemetryTagRegistry.FilterForDatabricksExport(
+                TelemetryEventType.StatementExecution, null!);
+
+            // Assert
+            Assert.NotNull(filtered);
+            Assert.Empty(filtered);
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_FilterForDatabricksExport_EmptyTags_ReturnsEmptyDictionary()
+        {
+            // Arrange
+            var tags = new Dictionary<string, string?>();
+
+            // Act
+            var filtered = TelemetryTagRegistry.FilterForDatabricksExport(
+                TelemetryEventType.StatementExecution, tags);
+
+            // Assert
+            Assert.NotNull(filtered);
+            Assert.Empty(filtered);
+        }
+
+        // ============================================================================
+        // GetEventName Tests
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_GetEventName_ConnectionOpen_ReturnsCorrectName()
+        {
+            // Act
+            var eventName = TelemetryTagRegistry.GetEventName(TelemetryEventType.ConnectionOpen);
+
+            // Assert
+            Assert.Equal(ConnectionOpenEvent.EventName, eventName);
+            Assert.Equal("Connection.Open", eventName);
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_GetEventName_StatementExecution_ReturnsCorrectName()
+        {
+            // Act
+            var eventName = TelemetryTagRegistry.GetEventName(TelemetryEventType.StatementExecution);
+
+            // Assert
+            Assert.Equal(StatementExecutionEvent.EventName, eventName);
+            Assert.Equal("Statement.Execute", eventName);
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_GetEventName_Error_ReturnsCorrectName()
+        {
+            // Act
+            var eventName = TelemetryTagRegistry.GetEventName(TelemetryEventType.Error);
+
+            // Assert
+            Assert.Equal(ErrorEvent.EventName, eventName);
+            Assert.Equal("Error", eventName);
+        }
+
+        // ============================================================================
+        // DetermineEventType Tests
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagRegistry_DetermineEventType_ConnectionOpen_ReturnsConnectionOpen()
+        {
+            // Act & Assert
+            Assert.Equal(TelemetryEventType.ConnectionOpen,
+                TelemetryTagRegistry.DetermineEventType("Connection.Open", false));
+            Assert.Equal(TelemetryEventType.ConnectionOpen,
+                TelemetryTagRegistry.DetermineEventType("Connection.OpenAsync", false));
+            Assert.Equal(TelemetryEventType.ConnectionOpen,
+                TelemetryTagRegistry.DetermineEventType("Connection.Close", false));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_DetermineEventType_StatementExecution_ReturnsStatementExecution()
+        {
+            // Act & Assert
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType("Statement.Execute", false));
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType("Statement.ExecuteQuery", false));
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType("Statement.ExecuteUpdate", false));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_DetermineEventType_WithErrorTag_ReturnsError()
+        {
+            // Act & Assert - Error tag takes precedence over operation name
+            Assert.Equal(TelemetryEventType.Error,
+                TelemetryTagRegistry.DetermineEventType("Statement.Execute", true));
+            Assert.Equal(TelemetryEventType.Error,
+                TelemetryTagRegistry.DetermineEventType("Connection.Open", true));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_DetermineEventType_UnknownOperation_ReturnsStatementExecution()
+        {
+            // Act & Assert - Default to StatementExecution for unknown operations
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType("Unknown.Operation", false));
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType("CloudFetch.Download", false));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_DetermineEventType_NullOrEmptyOperation_ReturnsStatementExecution()
+        {
+            // Act & Assert
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType(null!, false));
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType("", false));
+        }
+
+        [Fact]
+        public void TelemetryTagRegistry_DetermineEventType_CaseInsensitive()
+        {
+            // Act & Assert - Should be case insensitive
+            Assert.Equal(TelemetryEventType.ConnectionOpen,
+                TelemetryTagRegistry.DetermineEventType("connection.open", false));
+            Assert.Equal(TelemetryEventType.StatementExecution,
+                TelemetryTagRegistry.DetermineEventType("STATEMENT.EXECUTE", false));
+        }
+
+        // ============================================================================
+        // Tag Constant Value Tests
+        // ============================================================================
+
+        [Fact]
+        public void ConnectionOpenEvent_TagConstants_HaveCorrectValues()
+        {
+            // Assert
+            Assert.Equal("workspace.id", ConnectionOpenEvent.WorkspaceId);
+            Assert.Equal("session.id", ConnectionOpenEvent.SessionId);
+            Assert.Equal("driver.version", ConnectionOpenEvent.DriverVersion);
+            Assert.Equal("driver.os", ConnectionOpenEvent.DriverOS);
+            Assert.Equal("driver.runtime", ConnectionOpenEvent.DriverRuntime);
+            Assert.Equal("feature.cloudfetch", ConnectionOpenEvent.FeatureCloudFetch);
+            Assert.Equal("feature.lz4", ConnectionOpenEvent.FeatureLz4);
+            Assert.Equal("server.address", ConnectionOpenEvent.ServerAddress);
+        }
+
+        [Fact]
+        public void StatementExecutionEvent_TagConstants_HaveCorrectValues()
+        {
+            // Assert
+            Assert.Equal("statement.id", StatementExecutionEvent.StatementId);
+            Assert.Equal("session.id", StatementExecutionEvent.SessionId);
+            Assert.Equal("result.format", StatementExecutionEvent.ResultFormat);
+            Assert.Equal("result.chunk_count", StatementExecutionEvent.ResultChunkCount);
+            Assert.Equal("result.bytes_downloaded", StatementExecutionEvent.ResultBytesDownloaded);
+            Assert.Equal("poll.count", StatementExecutionEvent.PollCount);
+            Assert.Equal("poll.latency_ms", StatementExecutionEvent.PollLatencyMs);
+            Assert.Equal("db.statement", StatementExecutionEvent.DbStatement);
+        }
+
+        [Fact]
+        public void ErrorEvent_TagConstants_HaveCorrectValues()
+        {
+            // Assert
+            Assert.Equal("error.type", ErrorEvent.ErrorType);
+            Assert.Equal("error.name", ErrorEvent.ErrorName);
+            Assert.Equal("error.code", ErrorEvent.ErrorCode);
+            Assert.Equal("error.message", ErrorEvent.ErrorMessage);
+            Assert.Equal("error.stack_trace", ErrorEvent.ErrorStackTrace);
+            Assert.Equal("session.id", ErrorEvent.SessionId);
+            Assert.Equal("statement.id", ErrorEvent.StatementId);
+        }
+
+        // ============================================================================
+        // TagExportScope Enum Tests
+        // ============================================================================
+
+        [Fact]
+        public void TagExportScope_Values_AreCorrect()
+        {
+            // Assert
+            Assert.Equal(0, (int)TagExportScope.None);
+            Assert.Equal(1, (int)TagExportScope.ExportLocal);
+            Assert.Equal(2, (int)TagExportScope.ExportDatabricks);
+            Assert.Equal(3, (int)TagExportScope.ExportAll);
+        }
+
+        [Fact]
+        public void TagExportScope_ExportAll_IsCombinationOfLocalAndDatabricks()
+        {
+            // Assert
+            Assert.Equal(TagExportScope.ExportLocal | TagExportScope.ExportDatabricks, TagExportScope.ExportAll);
+        }
+
+        // ============================================================================
+        // TelemetryEventType Enum Tests
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryEventType_Values_AreCorrect()
+        {
+            // Assert
+            Assert.Equal(0, (int)TelemetryEventType.ConnectionOpen);
+            Assert.Equal(1, (int)TelemetryEventType.StatementExecution);
+            Assert.Equal(2, (int)TelemetryEventType.Error);
+        }
+
+        // ============================================================================
+        // TelemetryTagAttribute Tests
+        // ============================================================================
+
+        [Fact]
+        public void TelemetryTagAttribute_Constructor_SetsTagName()
+        {
+            // Act
+            var attr = new TelemetryTagAttribute("test.tag");
+
+            // Assert
+            Assert.Equal("test.tag", attr.TagName);
+        }
+
+        [Fact]
+        public void TelemetryTagAttribute_DefaultExportScope_IsExportAll()
+        {
+            // Act
+            var attr = new TelemetryTagAttribute("test.tag");
+
+            // Assert
+            Assert.Equal(TagExportScope.ExportAll, attr.ExportScope);
+        }
+
+        [Fact]
+        public void TelemetryTagAttribute_DefaultRequired_IsFalse()
+        {
+            // Act
+            var attr = new TelemetryTagAttribute("test.tag");
+
+            // Assert
+            Assert.False(attr.Required);
+        }
+
+        [Fact]
+        public void TelemetryTagAttribute_SetProperties_Works()
+        {
+            // Act
+            var attr = new TelemetryTagAttribute("test.tag")
+            {
+                ExportScope = TagExportScope.ExportLocal,
+                Description = "Test description",
+                Required = true
+            };
+
+            // Assert
+            Assert.Equal("test.tag", attr.TagName);
+            Assert.Equal(TagExportScope.ExportLocal, attr.ExportScope);
+            Assert.Equal("Test description", attr.Description);
+            Assert.True(attr.Required);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement centralized tag definitions with export scope annotations for controlling which Activity tags are exported to Databricks telemetry service vs local diagnostics
- Add TelemetryTagAttribute, TagExportScope enum, and event-specific tag definition classes
- Add TelemetryTagRegistry as central registry with filtering and lookup methods
- Include 40 comprehensive unit tests

## Changes
- `csharp/src/Telemetry/TagDefinitions/TelemetryTag.cs` - Attribute and enums for export scope
- `csharp/src/Telemetry/TagDefinitions/ConnectionOpenEvent.cs` - Connection event tag definitions
- `csharp/src/Telemetry/TagDefinitions/StatementExecutionEvent.cs` - Statement execution tag definitions
- `csharp/src/Telemetry/TagDefinitions/ErrorEvent.cs` - Error event tag definitions
- `csharp/src/Telemetry/TagDefinitions/TelemetryTagRegistry.cs` - Central registry
- `csharp/test/Unit/Telemetry/TagDefinitions/TelemetryTagRegistryTests.cs` - Unit tests

## Design Decisions
- Used `IReadOnlyCollection<string>` instead of `IReadOnlySet<string>` for netstandard2.0 compatibility
- Each event class has its own `ShouldExportToDatabricks()` method using internal `HashSet<string>` for O(1) lookup
- Sensitive tags (db.statement, error.message, server.address, etc.) are marked with ExportLocal scope
- Added helper methods: `FilterForDatabricksExport()`, `DetermineEventType()`

## Test plan
- [x] TelemetryTagRegistry_GetDatabricksExportTags_ConnectionOpen_ReturnsCorrectTags
- [x] TelemetryTagRegistry_ShouldExportToDatabricks_SensitiveTag_ReturnsFalse
- [x] TelemetryTagRegistry_ShouldExportToDatabricks_SafeTag_ReturnsTrue
- [x] ConnectionOpenEvent_GetDatabricksExportTags_ExcludesServerAddress
- [x] All 40 unit tests pass
- [x] Build succeeds on all target frameworks (netstandard2.0, net8.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)