### PR TITLE
feat(csharp): restricting conf_overlay to query tags

### DIFF
--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -104,14 +104,11 @@ namespace AdbcDrivers.Databricks
         public const string ServerSidePropertyPrefix = "adbc.databricks.ssp_";
 
         /// <summary>
-        /// Prefix for configuration overlay parameters. Properties with this prefix will be passed
-        /// to the server in the confOverlay field of the execute statement request.
-        /// These properties apply to the statement only and will not affect the subsequent state of the Session.
-        /// For example, a property with key "adbc.databricks.conf_overlay_spark.sql.adaptive.enabled"
-        /// and value "true" will result in passing {"spark.sql.adaptive.enabled": "true"} in confOverlay.
-        /// The prefix "adbc.databricks.conf_overlay_" will be stripped when passing to the server.
+        /// Query tags to be sent with the statement execution.
+        /// Tags are sent to the server in the confOverlay and apply to the statement only.
+        /// Format: comma-separated key:value pairs, e.g., "team:analytics,app:myapp"
         /// </summary>
-        public const string ConfOverlayPrefix = "adbc.databricks.conf_overlay_";
+        public const string QueryTags = "adbc.databricks.query_tags";
 
         /// <summary>
         /// Controls whether to retry requests that receive retryable responses (408, 502, 503, 504).

--- a/csharp/test/Unit/DatabricksParametersTests.cs
+++ b/csharp/test/Unit/DatabricksParametersTests.cs
@@ -77,9 +77,9 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         }
 
         [Fact]
-        public void TestConfOverlayPrefixParameterExists()
+        public void TestQueryTagsParameterExists()
         {
-            Assert.Equal("adbc.databricks.conf_overlay_", DatabricksParameters.ConfOverlayPrefix);
+            Assert.Equal("adbc.databricks.query_tags", DatabricksParameters.QueryTags);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             Assert.StartsWith("adbc.databricks.", DatabricksParameters.Protocol);
             Assert.StartsWith("adbc.databricks.", DatabricksParameters.EnableSessionManagement);
             Assert.StartsWith("adbc.databricks.", DatabricksParameters.EnableDirectResults);
-            Assert.StartsWith("adbc.databricks.", DatabricksParameters.ConfOverlayPrefix);
+            Assert.StartsWith("adbc.databricks.", DatabricksParameters.QueryTags);
         }
     }
 }


### PR DESCRIPTION
## What's Changed

This is a follow up PR to https://github.com/adbc-drivers/databricks/pull/152 to restrict conf_overlay support to query tags
