### PR TITLE
feat(csharp): implement MetricsAggregator (WI-3.5)

### DIFF
--- a/csharp/doc/telemetry-implementation-plan.md
+++ b/csharp/doc/telemetry-implementation-plan.md
@@ -1,0 +1,556 @@
+<!--
+Copyright (c) 2025 ADBC Drivers Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Telemetry Implementation Plan: Activity Tag to Proto Schema Mapping
+
+This document outlines the implementation plan for the telemetry changes documented in Section 4.4 of `telemetry-design.md`.
+
+## Overview
+
+The implementation ensures that:
+1. Activity tags are properly mapped to proto schema fields
+2. MetricsAggregator uses proto types (`OssSqlDriverTelemetryLog`) instead of old model classes
+3. New chunk latency metrics are collected from CloudFetchDownloader
+4. All enum values are correctly mapped to proto enums
+
+## Implementation Phases
+
+### Phase 1: Proto Type Migration (COMPLETED)
+
+**Status**: Done in commits c7d8ae8 and subsequent fixes
+
+**Files Changed**:
+- `csharp/src/Telemetry/MetricsAggregator.cs`
+- `csharp/test/Unit/Telemetry/MetricsAggregatorTests.cs`
+
+**Changes**:
+- [x] Replace `TelemetryEvent` with `OssSqlDriverTelemetryLog`
+- [x] Replace `TelemetryEvent.SqlExecutionEvent` with `OssSqlDriverTelemetryLog.SqlOperation`
+- [x] Replace `TelemetryEvent.ConnectionParameters` with `OssSqlDriverTelemetryLog.DriverConnectionParams`
+- [x] Update `DriverErrorInfo` to use proto fields (`ErrorName`, `StackTrace`)
+- [x] Add `using AdbcDrivers.Databricks.Telemetry.Proto;` import
+- [x] Update `WrapInFrontendLog` method signature
+- [x] Remove unused `ExtractHttpStatusCode` method
+- [x] Update tests to use proto types
+
+---
+
+### Phase 2: Tag Definitions Update
+
+**Status**: COMPLETED
+
+**Files to Change**:
+- `csharp/src/Telemetry/TagDefinitions/StatementExecutionEvent.cs`
+
+**Changes**:
+
+#### 2.1 Add Chunk Latency Tags
+
+```csharp
+// Add after PollLatencyMs definition (around line 103)
+
+/// <summary>
+/// Latency of first chunk download in milliseconds.
+/// Exported to Databricks telemetry service.
+/// </summary>
+[TelemetryTag("chunk.initial_latency_ms",
+    ExportScope = TagExportScope.ExportDatabricks,
+    Description = "Latency of first chunk download in milliseconds")]
+public const string ChunkInitialLatencyMs = "chunk.initial_latency_ms";
+
+/// <summary>
+/// Latency of slowest chunk download in milliseconds.
+/// Exported to Databricks telemetry service.
+/// </summary>
+[TelemetryTag("chunk.slowest_latency_ms",
+    ExportScope = TagExportScope.ExportDatabricks,
+    Description = "Latency of slowest chunk download in milliseconds")]
+public const string ChunkSlowestLatencyMs = "chunk.slowest_latency_ms";
+```
+
+#### 2.2 Update GetDatabricksExportTags()
+
+```csharp
+public static HashSet<string> GetDatabricksExportTags()
+{
+    return new HashSet<string>
+    {
+        StatementId,
+        SessionId,
+        ResultFormat,
+        ResultChunkCount,
+        ResultBytesDownloaded,
+        ResultCompressionEnabled,
+        PollCount,
+        PollLatencyMs,
+        ChunkInitialLatencyMs,    // NEW
+        ChunkSlowestLatencyMs     // NEW
+    };
+}
+```
+
+---
+
+### Phase 3: CloudFetchDownloader Latency Tracking
+
+**Status**: COMPLETED
+
+**Files to Change**:
+- `csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs`
+
+**Changes**:
+
+#### 3.1 Add Tracking Fields (around line 60)
+
+```csharp
+// Add after existing fields
+private long _initialChunkLatencyMs = -1;
+private long _slowestChunkLatencyMs = 0;
+private readonly object _latencyLock = new object();
+```
+
+#### 3.2 Track Latency After Each Download (in DownloadFileAsync, after line 652)
+
+```csharp
+// After: activity?.AddEvent("cloudfetch.download_complete", [...]);
+// Add latency tracking:
+lock (_latencyLock)
+{
+    long latencyMs = stopwatch.ElapsedMilliseconds;
+
+    // Track initial chunk latency (first successful download)
+    if (_initialChunkLatencyMs < 0)
+    {
+        _initialChunkLatencyMs = latencyMs;
+    }
+
+    // Track slowest chunk latency (max)
+    if (latencyMs > _slowestChunkLatencyMs)
+    {
+        _slowestChunkLatencyMs = latencyMs;
+    }
+}
+```
+
+#### 3.3 Update Download Summary Event (around line 430)
+
+```csharp
+activity?.AddEvent("cloudfetch.download_summary", [
+    new("total_files", totalFiles),
+    new("successful_downloads", successfulDownloads),
+    new("failed_downloads", failedDownloads),
+    new("total_bytes", totalBytes),
+    new("total_mb", totalBytes / 1024.0 / 1024.0),
+    new("total_time_ms", overallStopwatch.ElapsedMilliseconds),
+    new("total_time_sec", overallStopwatch.ElapsedMilliseconds / 1000.0),
+    new("initial_chunk_latency_ms", _initialChunkLatencyMs),  // NEW
+    new("slowest_chunk_latency_ms", _slowestChunkLatencyMs),  // NEW
+]);
+```
+
+#### 3.4 Reset Latency Tracking (optional, for reuse scenarios)
+
+If the downloader can be reused, add a reset method or reset in StartAsync:
+
+```csharp
+public async Task StartAsync(CancellationToken cancellationToken)
+{
+    // Reset latency tracking
+    lock (_latencyLock)
+    {
+        _initialChunkLatencyMs = -1;
+        _slowestChunkLatencyMs = 0;
+    }
+
+    // ... existing code ...
+}
+```
+
+---
+
+### Phase 4: StatementTelemetryContext Update
+
+**Status**: COMPLETED
+
+**Files to Change**:
+- `csharp/src/Telemetry/MetricsAggregator.cs` (inner class `StatementTelemetryContext`)
+
+**Changes**:
+
+#### 4.1 Add Backing Fields (around line 813)
+
+```csharp
+// Add after existing backing fields
+private long _initialChunkLatencyMs = -1;
+private long _slowestChunkLatencyMs;
+private volatile bool _hasInitialChunkLatency;
+private volatile bool _hasSlowestChunkLatency;
+```
+
+#### 4.2 Add Properties (around line 834)
+
+```csharp
+// Add after existing properties
+public long? InitialChunkLatencyMs => _hasInitialChunkLatency ? _initialChunkLatencyMs : (long?)null;
+public long? SlowestChunkLatencyMs => _hasSlowestChunkLatency ? Interlocked.Read(ref _slowestChunkLatencyMs) : (long?)null;
+```
+
+#### 4.3 Add Methods (around line 855)
+
+```csharp
+/// <summary>
+/// Sets the initial chunk latency. Only the first call has effect.
+/// </summary>
+public void SetInitialChunkLatency(long latencyMs)
+{
+    // Only set once (first chunk)
+    if (!_hasInitialChunkLatency && latencyMs >= 0)
+    {
+        _initialChunkLatencyMs = latencyMs;
+        _hasInitialChunkLatency = true;
+    }
+}
+
+/// <summary>
+/// Updates the slowest chunk latency if the new value is greater.
+/// Thread-safe using Interlocked.
+/// </summary>
+public void UpdateSlowestChunkLatency(long latencyMs)
+{
+    if (latencyMs <= 0) return;
+
+    // Thread-safe max update using compare-and-swap
+    long current;
+    do
+    {
+        current = Interlocked.Read(ref _slowestChunkLatencyMs);
+        if (latencyMs <= current) return;
+    } while (Interlocked.CompareExchange(ref _slowestChunkLatencyMs, latencyMs, current) != current);
+
+    _hasSlowestChunkLatency = true;
+}
+```
+
+---
+
+### Phase 5: MetricsAggregator Tag Processing
+
+**Status**: COMPLETED
+
+**Files to Change**:
+- `csharp/src/Telemetry/MetricsAggregator.cs`
+
+**Changes**:
+
+#### 5.1 Update AggregateActivityTags Method
+
+Add cases for chunk latency tags in the switch statement:
+
+```csharp
+private void AggregateActivityTags(StatementTelemetryContext context, Activity activity)
+{
+    foreach (var tag in activity.Tags)
+    {
+        var tagValue = tag.Value;
+        if (string.IsNullOrEmpty(tagValue)) continue;
+
+        switch (tag.Key)
+        {
+            // ... existing cases ...
+
+            // Chunk latency metrics (from CloudFetch download_summary event)
+            case "chunk.initial_latency_ms":
+            case "initial_chunk_latency_ms":  // Alternative name from download_summary
+                if (long.TryParse(tagValue, out var initialLatency))
+                {
+                    context.SetInitialChunkLatency(initialLatency);
+                }
+                break;
+
+            case "chunk.slowest_latency_ms":
+            case "slowest_chunk_latency_ms":  // Alternative name from download_summary
+                if (long.TryParse(tagValue, out var slowestLatency))
+                {
+                    context.UpdateSlowestChunkLatency(slowestLatency);
+                }
+                break;
+
+            // ... existing cases ...
+        }
+    }
+}
+```
+
+#### 5.2 Update CreateTelemetryEvent Method
+
+Update ChunkDetails to include latency fields:
+
+```csharp
+private OssSqlDriverTelemetryLog CreateTelemetryEvent(StatementTelemetryContext context)
+{
+    var telemetryLog = new OssSqlDriverTelemetryLog
+    {
+        SessionId = context.SessionId ?? string.Empty,
+        SqlStatementId = context.StatementId,
+        OperationLatencyMs = context.TotalLatencyMs,
+        SqlOperation = new SqlExecutionEvent
+        {
+            IsCompressed = context.CompressionEnabled ?? false,
+            ChunkDetails = new ChunkDetails
+            {
+                TotalChunksPresent = context.ChunkCount ?? 0,
+                SumChunksDownloadTimeMillis = context.BytesDownloaded ?? 0,
+                InitialChunkLatencyMillis = context.InitialChunkLatencyMs ?? 0,  // NEW
+                SlowestChunkLatencyMillis = context.SlowestChunkLatencyMs ?? 0   // NEW
+            },
+            OperationDetail = new OperationDetail
+            {
+                NOperationStatusCalls = context.PollCount ?? 0,
+                OperationStatusLatencyMillis = context.PollLatencyMs ?? 0
+            }
+        }
+    };
+
+    // ... rest of method unchanged ...
+}
+```
+
+---
+
+### Phase 6: Activity Event Processing
+
+**Status**: COMPLETED
+
+**Files to Change**:
+- `csharp/src/Telemetry/MetricsAggregator.cs`
+
+**Changes**:
+
+#### 6.1 Process Activity Events (cloudfetch.download_summary)
+
+The `MetricsAggregator` needs to process Activity events to extract chunk latency metrics. Add event processing in `ProcessActivity` or `AggregateActivityTags`:
+
+```csharp
+private void ProcessActivityEvents(StatementTelemetryContext context, Activity activity)
+{
+    foreach (var activityEvent in activity.Events)
+    {
+        if (activityEvent.Name == "cloudfetch.download_summary")
+        {
+            foreach (var tag in activityEvent.Tags)
+            {
+                switch (tag.Key)
+                {
+                    case "initial_chunk_latency_ms":
+                        if (tag.Value is long initialLatency)
+                        {
+                            context.SetInitialChunkLatency(initialLatency);
+                        }
+                        break;
+
+                    case "slowest_chunk_latency_ms":
+                        if (tag.Value is long slowestLatency)
+                        {
+                            context.UpdateSlowestChunkLatency(slowestLatency);
+                        }
+                        break;
+
+                    case "total_files":
+                        if (tag.Value is int totalFiles)
+                        {
+                            context.AddChunkCount(totalFiles);
+                        }
+                        break;
+
+                    case "total_bytes":
+                        if (tag.Value is long totalBytes)
+                        {
+                            context.AddBytesDownloaded(totalBytes);
+                        }
+                        break;
+                }
+            }
+        }
+    }
+}
+```
+
+#### 6.2 Call Event Processing
+
+In `ProcessStatementActivity`, call the event processor:
+
+```csharp
+private void ProcessStatementActivity(Activity activity)
+{
+    // ... existing code to get statementId, sessionId ...
+
+    // Get or create context for this statement
+    var context = _statementContexts.GetOrAdd(
+        statementId,
+        _ => new StatementTelemetryContext(statementId, sessionId));
+
+    // Aggregate metrics from tags
+    context.AddLatency((long)activity.Duration.TotalMilliseconds);
+    AggregateActivityTags(context, activity);
+
+    // Process Activity events (like cloudfetch.download_summary)
+    ProcessActivityEvents(context, activity);  // NEW
+}
+```
+
+---
+
+### Phase 7: Unit Tests
+
+**Status**: COMPLETED
+
+**Files to Change**:
+- `csharp/test/Unit/Telemetry/MetricsAggregatorTests.cs`
+- `csharp/test/Unit/Reader/CloudFetch/CloudFetchDownloaderTests.cs` (new or existing)
+
+**Changes**:
+
+#### 7.1 MetricsAggregator Tests
+
+```csharp
+[Fact]
+public void StatementTelemetryContext_ChunkLatency_TracksInitialAndSlowest()
+{
+    // Arrange
+    var context = new StatementTelemetryContext("stmt-1", "session-1");
+
+    // Act - simulate multiple chunk downloads
+    context.SetInitialChunkLatency(100);  // First chunk
+    context.SetInitialChunkLatency(50);   // Should be ignored (not first)
+    context.UpdateSlowestChunkLatency(100);
+    context.UpdateSlowestChunkLatency(200);  // New max
+    context.UpdateSlowestChunkLatency(150);  // Should not update
+
+    // Assert
+    Assert.Equal(100, context.InitialChunkLatencyMs);
+    Assert.Equal(200, context.SlowestChunkLatencyMs);
+}
+
+[Fact]
+public void StatementTelemetryContext_ChunkLatency_NullWhenNotSet()
+{
+    // Arrange
+    var context = new StatementTelemetryContext("stmt-1", "session-1");
+
+    // Assert - no values set
+    Assert.Null(context.InitialChunkLatencyMs);
+    Assert.Null(context.SlowestChunkLatencyMs);
+}
+
+[Fact]
+public async Task MetricsAggregator_CreateTelemetryEvent_IncludesChunkLatency()
+{
+    // Arrange
+    _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+    // Create activity with chunk latency tags
+    using var activity = CreateStatementActivity("stmt-chunk-latency", "session-1");
+    activity.SetTag("chunk.initial_latency_ms", "100");
+    activity.SetTag("chunk.slowest_latency_ms", "500");
+    activity.Stop();
+
+    // Act
+    _aggregator.ProcessActivity(activity);
+    _aggregator.CompleteStatement("stmt-chunk-latency");
+    await _aggregator.FlushAsync();
+
+    // Assert
+    Assert.Equal(1, _mockExporter.ExportCallCount);
+    var log = _mockExporter.ExportedLogs.First();
+    Assert.NotNull(log.Entry?.SqlDriverLog?.SqlOperation?.ChunkDetails);
+    Assert.Equal(100, log.Entry.SqlDriverLog.SqlOperation.ChunkDetails.InitialChunkLatencyMillis);
+    Assert.Equal(500, log.Entry.SqlDriverLog.SqlOperation.ChunkDetails.SlowestChunkLatencyMillis);
+}
+```
+
+#### 7.2 CloudFetchDownloader Tests
+
+```csharp
+[Fact]
+public async Task CloudFetchDownloader_TracksChunkLatency_InDownloadSummary()
+{
+    // Arrange - set up mock HTTP client, queues, etc.
+    // ...
+
+    // Act - download multiple chunks
+    // ...
+
+    // Assert - verify download_summary event contains latency metrics
+    var summaryEvent = activity.Events.FirstOrDefault(e => e.Name == "cloudfetch.download_summary");
+    Assert.NotNull(summaryEvent);
+
+    var initialLatency = summaryEvent.Tags.FirstOrDefault(t => t.Key == "initial_chunk_latency_ms");
+    var slowestLatency = summaryEvent.Tags.FirstOrDefault(t => t.Key == "slowest_chunk_latency_ms");
+
+    Assert.NotNull(initialLatency.Value);
+    Assert.NotNull(slowestLatency.Value);
+    Assert.True((long)slowestLatency.Value >= (long)initialLatency.Value);
+}
+```
+
+---
+
+## Implementation Order
+
+Recommended order to minimize integration issues:
+
+1. **Phase 2**: Tag Definitions (no dependencies)
+2. **Phase 4**: StatementTelemetryContext (no dependencies)
+3. **Phase 3**: CloudFetchDownloader latency tracking
+4. **Phase 5**: MetricsAggregator tag processing
+5. **Phase 6**: Activity event processing
+6. **Phase 7**: Unit tests
+
+Phase 1 is already completed.
+
+---
+
+## Verification Checklist
+
+After implementation, verify:
+
+- [ ] `dotnet build` succeeds for all target frameworks (netstandard2.0, net472, net8.0)
+- [ ] `dotnet test` passes all existing tests
+- [ ] New unit tests pass
+- [ ] CloudFetch downloads emit `initial_chunk_latency_ms` and `slowest_chunk_latency_ms` in download_summary
+- [ ] MetricsAggregator correctly maps chunk latency to proto `ChunkDetails`
+- [ ] Exported telemetry contains non-zero chunk latency values for CloudFetch queries
+
+---
+
+## Files Summary
+
+| File | Phase | Changes |
+|------|-------|---------|
+| `TagDefinitions/StatementExecutionEvent.cs` | 2 | Add chunk latency tag definitions |
+| `Reader/CloudFetch/CloudFetchDownloader.cs` | 3 | Track initial/slowest chunk latency |
+| `Telemetry/MetricsAggregator.cs` | 4, 5, 6 | Add context fields, tag processing, event processing |
+| `test/Unit/Telemetry/MetricsAggregatorTests.cs` | 7 | Add chunk latency tests |
+| `test/Unit/Reader/CloudFetch/CloudFetchDownloaderTests.cs` | 7 | Add latency tracking tests |
+
+---
+
+## Rollback Plan
+
+If issues arise:
+1. Chunk latency fields are optional (nullable) - missing values won't break telemetry
+2. Proto schema supports the fields - no backend changes needed
+3. Can revert individual phases independently since they're loosely coupled

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -63,6 +63,11 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
         private Exception? _error;
         private readonly object _errorLock = new object();
 
+        // Chunk latency tracking for telemetry
+        private long _initialChunkLatencyMs = -1;
+        private long _slowestChunkLatencyMs = 0;
+        private readonly object _latencyLock = new object();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFetchDownloader"/> class.
         /// </summary>
@@ -434,7 +439,9 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                         new("total_bytes", totalBytes),
                         new("total_mb", totalBytes / 1024.0 / 1024.0),
                         new("total_time_ms", overallStopwatch.ElapsedMilliseconds),
-                        new("total_time_sec", overallStopwatch.ElapsedMilliseconds / 1000.0)
+                        new("total_time_sec", overallStopwatch.ElapsedMilliseconds / 1000.0),
+                        new("initial_chunk_latency_ms", _initialChunkLatencyMs),
+                        new("slowest_chunk_latency_ms", _slowestChunkLatencyMs)
                     ]);
 
                     // If there's an error, add the error to the result queue
@@ -642,15 +649,32 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
 
                 // Stop the stopwatch and log download completion
                 stopwatch.Stop();
-                double throughputMBps = (actualSize / 1024.0 / 1024.0) / (stopwatch.ElapsedMilliseconds / 1000.0);
+                long chunkLatencyMs = stopwatch.ElapsedMilliseconds;
+                double throughputMBps = (actualSize / 1024.0 / 1024.0) / (chunkLatencyMs / 1000.0);
                 activity?.AddEvent("cloudfetch.download_complete", [
                     new("offset", downloadResult.StartRowOffset),
                     new("sanitized_url", sanitizedUrl),
                     new("actual_size_bytes", actualSize),
                     new("actual_size_kb", actualSize / 1024.0),
-                    new("latency_ms", stopwatch.ElapsedMilliseconds),
+                    new("latency_ms", chunkLatencyMs),
                     new("throughput_mbps", throughputMBps)
                 ]);
+
+                // Track chunk latency for telemetry
+                lock (_latencyLock)
+                {
+                    // Track initial chunk latency (first successful download)
+                    if (_initialChunkLatencyMs < 0)
+                    {
+                        _initialChunkLatencyMs = chunkLatencyMs;
+                    }
+
+                    // Track slowest chunk latency (max)
+                    if (chunkLatencyMs > _slowestChunkLatencyMs)
+                    {
+                        _slowestChunkLatencyMs = chunkLatencyMs;
+                    }
+                }
 
                 // Set the download as completed with the original size
                 downloadResult.SetCompleted(dataStream, size);

--- a/csharp/src/Telemetry/MetricsAggregator.cs
+++ b/csharp/src/Telemetry/MetricsAggregator.cs
@@ -1,0 +1,737 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.Telemetry.Models;
+using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
+
+namespace AdbcDrivers.Databricks.Telemetry
+{
+    /// <summary>
+    /// Aggregates metrics from activities by statement_id and includes session_id.
+    /// Follows JDBC driver pattern: aggregation by statement, export with both IDs.
+    /// </summary>
+    /// <remarks>
+    /// This class:
+    /// - Aggregates Activity data by statement_id using ConcurrentDictionary
+    /// - Connection events emit immediately (no aggregation needed)
+    /// - Statement events aggregate until CompleteStatement is called
+    /// - Terminal exceptions flush immediately, retryable exceptions buffer until complete
+    /// - Uses TelemetryTagRegistry to filter tags
+    /// - Creates TelemetryFrontendLog wrapper with workspace_id
+    /// - All exceptions swallowed (logged at TRACE level)
+    ///
+    /// JDBC Reference: TelemetryCollector.java
+    /// </remarks>
+    internal sealed class MetricsAggregator : IDisposable
+    {
+        private readonly ITelemetryExporter _exporter;
+        private readonly TelemetryConfiguration _config;
+        private readonly long _workspaceId;
+        private readonly string _userAgent;
+        private readonly ConcurrentDictionary<string, StatementTelemetryContext> _statementContexts;
+        private readonly ConcurrentQueue<TelemetryFrontendLog> _pendingEvents;
+        private readonly object _flushLock = new object();
+        private readonly Timer _flushTimer;
+        private bool _disposed;
+
+        /// <summary>
+        /// Gets the number of pending events waiting to be flushed.
+        /// </summary>
+        internal int PendingEventCount => _pendingEvents.Count;
+
+        /// <summary>
+        /// Gets the number of active statement contexts being tracked.
+        /// </summary>
+        internal int ActiveStatementCount => _statementContexts.Count;
+
+        /// <summary>
+        /// Creates a new MetricsAggregator.
+        /// </summary>
+        /// <param name="exporter">The telemetry exporter to use for flushing events.</param>
+        /// <param name="config">The telemetry configuration.</param>
+        /// <param name="workspaceId">The Databricks workspace ID for all events.</param>
+        /// <param name="userAgent">The user agent string for client context.</param>
+        /// <exception cref="ArgumentNullException">Thrown when exporter or config is null.</exception>
+        public MetricsAggregator(
+            ITelemetryExporter exporter,
+            TelemetryConfiguration config,
+            long workspaceId,
+            string? userAgent = null)
+        {
+            _exporter = exporter ?? throw new ArgumentNullException(nameof(exporter));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _workspaceId = workspaceId;
+            _userAgent = userAgent ?? "AdbcDatabricksDriver";
+            _statementContexts = new ConcurrentDictionary<string, StatementTelemetryContext>();
+            _pendingEvents = new ConcurrentQueue<TelemetryFrontendLog>();
+
+            // Start flush timer
+            _flushTimer = new Timer(
+                OnFlushTimerTick,
+                null,
+                _config.FlushIntervalMs,
+                _config.FlushIntervalMs);
+        }
+
+        /// <summary>
+        /// Processes a completed activity and extracts telemetry metrics.
+        /// </summary>
+        /// <param name="activity">The activity to process.</param>
+        /// <remarks>
+        /// This method determines the event type based on the activity operation name:
+        /// - Connection.* activities emit connection events immediately
+        /// - Statement.* activities are aggregated by statement_id
+        /// - Activities with error.type tag are treated as error events
+        ///
+        /// All exceptions are swallowed and logged at TRACE level.
+        /// </remarks>
+        public void ProcessActivity(Activity? activity)
+        {
+            if (activity == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var eventType = DetermineEventType(activity);
+
+                switch (eventType)
+                {
+                    case TelemetryEventType.ConnectionOpen:
+                        ProcessConnectionActivity(activity);
+                        break;
+
+                    case TelemetryEventType.StatementExecution:
+                        ProcessStatementActivity(activity);
+                        break;
+
+                    case TelemetryEventType.Error:
+                        ProcessErrorActivity(activity);
+                        break;
+                }
+
+                // Check if we should flush based on batch size
+                if (_pendingEvents.Count >= _config.BatchSize)
+                {
+                    _ = FlushAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Swallow all exceptions per telemetry requirement
+                // Log at TRACE level to avoid customer anxiety
+                Debug.WriteLine($"[TRACE] MetricsAggregator: Error processing activity: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Marks a statement as complete and emits the aggregated telemetry event.
+        /// </summary>
+        /// <param name="statementId">The statement ID to complete.</param>
+        /// <param name="failed">Whether the statement execution failed.</param>
+        /// <remarks>
+        /// This method:
+        /// - Removes the statement context from the aggregation dictionary
+        /// - Emits the aggregated event with all collected metrics
+        /// - If failed, also emits any buffered retryable exception events
+        ///
+        /// All exceptions are swallowed and logged at TRACE level.
+        /// </remarks>
+        public void CompleteStatement(string statementId, bool failed = false)
+        {
+            if (string.IsNullOrEmpty(statementId))
+            {
+                return;
+            }
+
+            try
+            {
+                if (_statementContexts.TryRemove(statementId, out var context))
+                {
+                    // Emit the aggregated statement event
+                    var telemetryEvent = CreateTelemetryEvent(context);
+                    var frontendLog = WrapInFrontendLog(telemetryEvent);
+                    _pendingEvents.Enqueue(frontendLog);
+
+                    // If statement failed and we have buffered exceptions, emit them
+                    if (failed && context.BufferedExceptions.Count > 0)
+                    {
+                        foreach (var exception in context.BufferedExceptions)
+                        {
+                            var errorEvent = CreateErrorTelemetryEvent(
+                                context.SessionId,
+                                statementId,
+                                exception);
+                            var errorLog = WrapInFrontendLog(errorEvent);
+                            _pendingEvents.Enqueue(errorLog);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Swallow all exceptions per telemetry requirement
+                Debug.WriteLine($"[TRACE] MetricsAggregator: Error completing statement: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Records an exception for a statement.
+        /// </summary>
+        /// <param name="statementId">The statement ID.</param>
+        /// <param name="sessionId">The session ID.</param>
+        /// <param name="exception">The exception to record.</param>
+        /// <remarks>
+        /// Terminal exceptions are flushed immediately.
+        /// Retryable exceptions are buffered until CompleteStatement is called.
+        ///
+        /// All exceptions are swallowed and logged at TRACE level.
+        /// </remarks>
+        public void RecordException(string statementId, string sessionId, Exception? exception)
+        {
+            if (exception == null || string.IsNullOrEmpty(statementId))
+            {
+                return;
+            }
+
+            try
+            {
+                if (ExceptionClassifier.IsTerminalException(exception))
+                {
+                    // Terminal exception: flush immediately
+                    var errorEvent = CreateErrorTelemetryEvent(sessionId, statementId, exception);
+                    var errorLog = WrapInFrontendLog(errorEvent);
+                    _pendingEvents.Enqueue(errorLog);
+
+                    Debug.WriteLine($"[TRACE] MetricsAggregator: Terminal exception recorded, flushing immediately");
+                }
+                else
+                {
+                    // Retryable exception: buffer until statement completes
+                    var context = _statementContexts.GetOrAdd(
+                        statementId,
+                        _ => new StatementTelemetryContext(statementId, sessionId));
+                    context.BufferedExceptions.Add(exception);
+
+                    Debug.WriteLine($"[TRACE] MetricsAggregator: Retryable exception buffered for statement {statementId}");
+                }
+            }
+            catch (Exception ex)
+            {
+                // Swallow all exceptions per telemetry requirement
+                Debug.WriteLine($"[TRACE] MetricsAggregator: Error recording exception: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Flushes all pending telemetry events to the exporter.
+        /// </summary>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>A task representing the flush operation.</returns>
+        /// <remarks>
+        /// This method is thread-safe and uses a lock to prevent concurrent flushes.
+        /// All exceptions are swallowed and logged at TRACE level.
+        /// </remarks>
+        public async Task FlushAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                List<TelemetryFrontendLog> eventsToFlush;
+
+                lock (_flushLock)
+                {
+                    if (_pendingEvents.IsEmpty)
+                    {
+                        return;
+                    }
+
+                    eventsToFlush = new List<TelemetryFrontendLog>();
+                    while (_pendingEvents.TryDequeue(out var eventLog))
+                    {
+                        eventsToFlush.Add(eventLog);
+                    }
+                }
+
+                if (eventsToFlush.Count > 0)
+                {
+                    Debug.WriteLine($"[TRACE] MetricsAggregator: Flushing {eventsToFlush.Count} events");
+                    await _exporter.ExportAsync(eventsToFlush, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Don't swallow cancellation
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Swallow all other exceptions per telemetry requirement
+                Debug.WriteLine($"[TRACE] MetricsAggregator: Error flushing events: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Disposes the MetricsAggregator and flushes any remaining events.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            try
+            {
+                _flushTimer.Dispose();
+
+                // Final flush
+                FlushAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[TRACE] MetricsAggregator: Error during dispose: {ex.Message}");
+            }
+        }
+
+        #region Private Methods
+
+        /// <summary>
+        /// Timer callback for periodic flushing.
+        /// </summary>
+        private void OnFlushTimerTick(object? state)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            try
+            {
+                _ = FlushAsync();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[TRACE] MetricsAggregator: Error in flush timer: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Determines the telemetry event type based on the activity.
+        /// </summary>
+        private static TelemetryEventType DetermineEventType(Activity activity)
+        {
+            // Check for errors first
+            if (activity.GetTagItem("error.type") != null)
+            {
+                return TelemetryEventType.Error;
+            }
+
+            // Map based on operation name
+            var operationName = activity.OperationName ?? string.Empty;
+
+            if (operationName.StartsWith("Connection.", StringComparison.OrdinalIgnoreCase) ||
+                operationName.Equals("OpenConnection", StringComparison.OrdinalIgnoreCase) ||
+                operationName.Equals("OpenAsync", StringComparison.OrdinalIgnoreCase))
+            {
+                return TelemetryEventType.ConnectionOpen;
+            }
+
+            // Default to statement execution for statement operations and others
+            return TelemetryEventType.StatementExecution;
+        }
+
+        /// <summary>
+        /// Processes a connection activity and emits it immediately.
+        /// </summary>
+        private void ProcessConnectionActivity(Activity activity)
+        {
+            var sessionId = GetTagValue(activity, "session.id");
+            var telemetryEvent = new TelemetryEvent
+            {
+                SessionId = sessionId,
+                OperationLatencyMs = (long)activity.Duration.TotalMilliseconds,
+                SystemConfiguration = ExtractSystemConfiguration(activity),
+                ConnectionParameters = ExtractConnectionParameters(activity)
+            };
+
+            var frontendLog = WrapInFrontendLog(telemetryEvent);
+            _pendingEvents.Enqueue(frontendLog);
+
+            Debug.WriteLine($"[TRACE] MetricsAggregator: Connection event emitted immediately");
+        }
+
+        /// <summary>
+        /// Processes a statement activity and aggregates it by statement_id.
+        /// </summary>
+        private void ProcessStatementActivity(Activity activity)
+        {
+            var statementId = GetTagValue(activity, "statement.id");
+            var sessionId = GetTagValue(activity, "session.id");
+
+            if (string.IsNullOrEmpty(statementId))
+            {
+                // No statement ID, cannot aggregate - emit immediately
+                var telemetryEvent = new TelemetryEvent
+                {
+                    SessionId = sessionId,
+                    OperationLatencyMs = (long)activity.Duration.TotalMilliseconds,
+                    SqlExecutionEvent = ExtractSqlExecutionEvent(activity)
+                };
+
+                var frontendLog = WrapInFrontendLog(telemetryEvent);
+                _pendingEvents.Enqueue(frontendLog);
+                return;
+            }
+
+            // Get or create context for this statement
+            var context = _statementContexts.GetOrAdd(
+                statementId,
+                _ => new StatementTelemetryContext(statementId, sessionId));
+
+            // Aggregate metrics
+            context.AddLatency((long)activity.Duration.TotalMilliseconds);
+            AggregateActivityTags(context, activity);
+        }
+
+        /// <summary>
+        /// Processes an error activity and emits it immediately.
+        /// </summary>
+        private void ProcessErrorActivity(Activity activity)
+        {
+            var statementId = GetTagValue(activity, "statement.id");
+            var sessionId = GetTagValue(activity, "session.id");
+            var errorType = GetTagValue(activity, "error.type");
+            var errorMessage = GetTagValue(activity, "error.message");
+            var errorCode = GetTagValue(activity, "error.code");
+
+            var telemetryEvent = new TelemetryEvent
+            {
+                SessionId = sessionId,
+                SqlStatementId = statementId,
+                OperationLatencyMs = (long)activity.Duration.TotalMilliseconds,
+                ErrorInfo = new DriverErrorInfo
+                {
+                    ErrorType = errorType,
+                    ErrorMessage = errorMessage,
+                    ErrorCode = errorCode
+                }
+            };
+
+            var frontendLog = WrapInFrontendLog(telemetryEvent);
+            _pendingEvents.Enqueue(frontendLog);
+
+            Debug.WriteLine($"[TRACE] MetricsAggregator: Error event emitted immediately");
+        }
+
+        /// <summary>
+        /// Aggregates activity tags into the statement context.
+        /// </summary>
+        private void AggregateActivityTags(StatementTelemetryContext context, Activity activity)
+        {
+            var eventType = TelemetryEventType.StatementExecution;
+
+            foreach (var tag in activity.Tags)
+            {
+                // Filter using TelemetryTagRegistry
+                if (!TelemetryTagRegistry.ShouldExportToDatabricks(eventType, tag.Key))
+                {
+                    continue;
+                }
+
+                switch (tag.Key)
+                {
+                    case "result.format":
+                        context.ResultFormat = tag.Value;
+                        break;
+                    case "result.chunk_count":
+                        if (int.TryParse(tag.Value, out int chunkCount))
+                        {
+                            context.ChunkCount = (context.ChunkCount ?? 0) + chunkCount;
+                        }
+                        break;
+                    case "result.bytes_downloaded":
+                        if (long.TryParse(tag.Value, out long bytesDownloaded))
+                        {
+                            context.BytesDownloaded = (context.BytesDownloaded ?? 0) + bytesDownloaded;
+                        }
+                        break;
+                    case "result.compression_enabled":
+                        if (bool.TryParse(tag.Value, out bool compressionEnabled))
+                        {
+                            context.CompressionEnabled = compressionEnabled;
+                        }
+                        break;
+                    case "result.row_count":
+                        if (long.TryParse(tag.Value, out long rowCount))
+                        {
+                            context.RowCount = rowCount;
+                        }
+                        break;
+                    case "poll.count":
+                        if (int.TryParse(tag.Value, out int pollCount))
+                        {
+                            context.PollCount = (context.PollCount ?? 0) + pollCount;
+                        }
+                        break;
+                    case "poll.latency_ms":
+                        if (long.TryParse(tag.Value, out long pollLatencyMs))
+                        {
+                            context.PollLatencyMs = (context.PollLatencyMs ?? 0) + pollLatencyMs;
+                        }
+                        break;
+                    case "execution.status":
+                        context.ExecutionStatus = tag.Value;
+                        break;
+                    case "statement.type":
+                        context.StatementType = tag.Value;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a TelemetryEvent from a statement context.
+        /// </summary>
+        private TelemetryEvent CreateTelemetryEvent(StatementTelemetryContext context)
+        {
+            return new TelemetryEvent
+            {
+                SessionId = context.SessionId,
+                SqlStatementId = context.StatementId,
+                OperationLatencyMs = context.TotalLatencyMs,
+                SqlExecutionEvent = new SqlExecutionEvent
+                {
+                    ResultFormat = context.ResultFormat,
+                    ChunkCount = context.ChunkCount,
+                    BytesDownloaded = context.BytesDownloaded,
+                    CompressionEnabled = context.CompressionEnabled,
+                    RowCount = context.RowCount,
+                    PollCount = context.PollCount,
+                    PollLatencyMs = context.PollLatencyMs,
+                    ExecutionStatus = context.ExecutionStatus,
+                    StatementType = context.StatementType
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates an error TelemetryEvent from an exception.
+        /// </summary>
+        private TelemetryEvent CreateErrorTelemetryEvent(
+            string? sessionId,
+            string statementId,
+            Exception exception)
+        {
+            var isTerminal = ExceptionClassifier.IsTerminalException(exception);
+            int? httpStatusCode = null;
+
+#if NET5_0_OR_GREATER
+            if (exception is System.Net.Http.HttpRequestException httpEx && httpEx.StatusCode.HasValue)
+            {
+                httpStatusCode = (int)httpEx.StatusCode.Value;
+            }
+#endif
+
+            return new TelemetryEvent
+            {
+                SessionId = sessionId,
+                SqlStatementId = statementId,
+                ErrorInfo = new DriverErrorInfo
+                {
+                    ErrorType = exception.GetType().Name,
+                    ErrorMessage = SanitizeErrorMessage(exception.Message),
+                    IsTerminal = isTerminal,
+                    HttpStatusCode = httpStatusCode
+                }
+            };
+        }
+
+        /// <summary>
+        /// Sanitizes an error message to remove potential PII.
+        /// </summary>
+        private static string SanitizeErrorMessage(string? message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                return string.Empty;
+            }
+
+            // Truncate long messages
+            const int maxLength = 200;
+            if (message.Length > maxLength)
+            {
+                message = message.Substring(0, maxLength) + "...";
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Wraps a TelemetryEvent in a TelemetryFrontendLog.
+        /// </summary>
+        internal TelemetryFrontendLog WrapInFrontendLog(TelemetryEvent telemetryEvent)
+        {
+            return new TelemetryFrontendLog
+            {
+                WorkspaceId = _workspaceId,
+                FrontendLogEventId = Guid.NewGuid().ToString(),
+                Context = new FrontendLogContext
+                {
+                    ClientContext = new TelemetryClientContext
+                    {
+                        UserAgent = _userAgent
+                    },
+                    TimestampMillis = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                },
+                Entry = new FrontendLogEntry
+                {
+                    SqlDriverLog = telemetryEvent
+                }
+            };
+        }
+
+        /// <summary>
+        /// Extracts system configuration from activity tags.
+        /// </summary>
+        private static DriverSystemConfiguration? ExtractSystemConfiguration(Activity activity)
+        {
+            var driverVersion = GetTagValue(activity, "driver.version");
+            var osName = GetTagValue(activity, "driver.os");
+            var runtime = GetTagValue(activity, "driver.runtime");
+
+            if (driverVersion == null && osName == null && runtime == null)
+            {
+                return null;
+            }
+
+            return new DriverSystemConfiguration
+            {
+                DriverName = "Databricks ADBC Driver",
+                DriverVersion = driverVersion,
+                OsName = osName,
+                RuntimeName = ".NET",
+                RuntimeVersion = runtime
+            };
+        }
+
+        /// <summary>
+        /// Extracts connection parameters from activity tags.
+        /// </summary>
+        private static DriverConnectionParameters? ExtractConnectionParameters(Activity activity)
+        {
+            var cloudFetchEnabled = GetTagValue(activity, "feature.cloudfetch");
+            var lz4Enabled = GetTagValue(activity, "feature.lz4");
+            var directResultsEnabled = GetTagValue(activity, "feature.direct_results");
+
+            if (cloudFetchEnabled == null && lz4Enabled == null && directResultsEnabled == null)
+            {
+                return null;
+            }
+
+            return new DriverConnectionParameters
+            {
+                CloudFetchEnabled = bool.TryParse(cloudFetchEnabled, out var cf) ? cf : (bool?)null,
+                Lz4CompressionEnabled = bool.TryParse(lz4Enabled, out var lz4) ? lz4 : (bool?)null,
+                DirectResultsEnabled = bool.TryParse(directResultsEnabled, out var dr) ? dr : (bool?)null
+            };
+        }
+
+        /// <summary>
+        /// Extracts SQL execution event details from activity tags.
+        /// </summary>
+        private static SqlExecutionEvent? ExtractSqlExecutionEvent(Activity activity)
+        {
+            var resultFormat = GetTagValue(activity, "result.format");
+            var chunkCountStr = GetTagValue(activity, "result.chunk_count");
+            var bytesDownloadedStr = GetTagValue(activity, "result.bytes_downloaded");
+            var pollCountStr = GetTagValue(activity, "poll.count");
+
+            if (resultFormat == null && chunkCountStr == null && bytesDownloadedStr == null && pollCountStr == null)
+            {
+                return null;
+            }
+
+            return new SqlExecutionEvent
+            {
+                ResultFormat = resultFormat,
+                ChunkCount = int.TryParse(chunkCountStr, out var cc) ? cc : (int?)null,
+                BytesDownloaded = long.TryParse(bytesDownloadedStr, out var bd) ? bd : (long?)null,
+                PollCount = int.TryParse(pollCountStr, out var pc) ? pc : (int?)null
+            };
+        }
+
+        /// <summary>
+        /// Gets a tag value from an activity.
+        /// </summary>
+        private static string? GetTagValue(Activity activity, string tagName)
+        {
+            return activity.GetTagItem(tagName)?.ToString();
+        }
+
+        #endregion
+
+        #region Nested Classes
+
+        /// <summary>
+        /// Holds aggregated telemetry data for a statement.
+        /// </summary>
+        internal sealed class StatementTelemetryContext
+        {
+            private long _totalLatencyMs;
+
+            public string StatementId { get; }
+            public string? SessionId { get; set; }
+            public long TotalLatencyMs => Interlocked.Read(ref _totalLatencyMs);
+
+            // Aggregated metrics
+            public string? ResultFormat { get; set; }
+            public int? ChunkCount { get; set; }
+            public long? BytesDownloaded { get; set; }
+            public bool? CompressionEnabled { get; set; }
+            public long? RowCount { get; set; }
+            public int? PollCount { get; set; }
+            public long? PollLatencyMs { get; set; }
+            public string? ExecutionStatus { get; set; }
+            public string? StatementType { get; set; }
+
+            // Buffered exceptions for retryable errors
+            public ConcurrentBag<Exception> BufferedExceptions { get; } = new ConcurrentBag<Exception>();
+
+            public StatementTelemetryContext(string statementId, string? sessionId)
+            {
+                StatementId = statementId ?? throw new ArgumentNullException(nameof(statementId));
+                SessionId = sessionId;
+            }
+
+            public void AddLatency(long latencyMs)
+            {
+                Interlocked.Add(ref _totalLatencyMs, latencyMs);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/csharp/src/Telemetry/TagDefinitions/StatementExecutionEvent.cs
+++ b/csharp/src/Telemetry/TagDefinitions/StatementExecutionEvent.cs
@@ -103,6 +103,24 @@ namespace AdbcDrivers.Databricks.Telemetry.TagDefinitions
         public const string PollLatencyMs = "poll.latency_ms";
 
         /// <summary>
+        /// Latency of first chunk download in milliseconds.
+        /// Exported to Databricks telemetry service.
+        /// </summary>
+        [TelemetryTag("chunk.initial_latency_ms",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Latency of first chunk download in milliseconds")]
+        public const string ChunkInitialLatencyMs = "chunk.initial_latency_ms";
+
+        /// <summary>
+        /// Latency of slowest chunk download in milliseconds.
+        /// Exported to Databricks telemetry service.
+        /// </summary>
+        [TelemetryTag("chunk.slowest_latency_ms",
+            ExportScope = TagExportScope.ExportDatabricks,
+            Description = "Latency of slowest chunk download in milliseconds")]
+        public const string ChunkSlowestLatencyMs = "chunk.slowest_latency_ms";
+
+        /// <summary>
         /// SQL query text.
         /// Only exported to local diagnostics (sensitive data).
         /// </summary>
@@ -126,7 +144,9 @@ namespace AdbcDrivers.Databricks.Telemetry.TagDefinitions
                 ResultBytesDownloaded,
                 ResultCompressionEnabled,
                 PollCount,
-                PollLatencyMs
+                PollLatencyMs,
+                ChunkInitialLatencyMs,
+                ChunkSlowestLatencyMs
             };
         }
     }

--- a/csharp/test/Unit/Telemetry/MetricsAggregatorTests.cs
+++ b/csharp/test/Unit/Telemetry/MetricsAggregatorTests.cs
@@ -1,0 +1,812 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.Telemetry;
+using AdbcDrivers.Databricks.Telemetry.Models;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Tests for MetricsAggregator class.
+    /// </summary>
+    public class MetricsAggregatorTests : IDisposable
+    {
+        private readonly ActivitySource _activitySource;
+        private readonly MockTelemetryExporter _mockExporter;
+        private readonly TelemetryConfiguration _config;
+        private MetricsAggregator? _aggregator;
+
+        private const long TestWorkspaceId = 12345;
+        private const string TestUserAgent = "TestAgent/1.0";
+
+        public MetricsAggregatorTests()
+        {
+            _activitySource = new ActivitySource("TestSource");
+            _mockExporter = new MockTelemetryExporter();
+            _config = new TelemetryConfiguration
+            {
+                BatchSize = 10,
+                FlushIntervalMs = 60000 // Set high to control when flush happens
+            };
+        }
+
+        public void Dispose()
+        {
+            _aggregator?.Dispose();
+            _activitySource.Dispose();
+        }
+
+        #region Constructor Tests
+
+        [Fact]
+        public void MetricsAggregator_Constructor_NullExporter_ThrowsException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new MetricsAggregator(null!, _config, TestWorkspaceId));
+        }
+
+        [Fact]
+        public void MetricsAggregator_Constructor_NullConfig_ThrowsException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new MetricsAggregator(_mockExporter, null!, TestWorkspaceId));
+        }
+
+        [Fact]
+        public void MetricsAggregator_Constructor_ValidParameters_CreatesInstance()
+        {
+            // Act
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Assert
+            Assert.NotNull(_aggregator);
+            Assert.Equal(0, _aggregator.PendingEventCount);
+            Assert.Equal(0, _aggregator.ActiveStatementCount);
+        }
+
+        #endregion
+
+        #region ProcessActivity Tests - Connection Events
+
+        [Fact]
+        public void MetricsAggregator_ProcessActivity_ConnectionOpen_EmitsImmediately()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var activity = _activitySource.StartActivity("Connection.Open");
+            Assert.NotNull(activity);
+            activity.SetTag("session.id", "test-session-123");
+            activity.Stop();
+
+            // Act
+            _aggregator.ProcessActivity(activity);
+
+            // Assert
+            Assert.Equal(1, _aggregator.PendingEventCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_ProcessActivity_ConnectionOpenAsync_EmitsImmediately()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var activity = _activitySource.StartActivity("OpenAsync");
+            Assert.NotNull(activity);
+            activity.SetTag("session.id", "test-session-456");
+            activity.SetTag("driver.version", "1.0.0");
+            activity.Stop();
+
+            // Act
+            _aggregator.ProcessActivity(activity);
+
+            // Assert
+            Assert.Equal(1, _aggregator.PendingEventCount);
+        }
+
+        #endregion
+
+        #region ProcessActivity Tests - Statement Events
+
+        [Fact]
+        public void MetricsAggregator_ProcessActivity_Statement_AggregatesByStatementId()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var statementId = "stmt-123";
+            var sessionId = "session-456";
+
+            // First activity
+            using (var activity1 = _activitySource.StartActivity("Statement.Execute"))
+            {
+                Assert.NotNull(activity1);
+                activity1.SetTag("statement.id", statementId);
+                activity1.SetTag("session.id", sessionId);
+                activity1.SetTag("result.chunk_count", "5");
+                activity1.Stop();
+
+                _aggregator.ProcessActivity(activity1);
+            }
+
+            // Second activity with same statement_id
+            using (var activity2 = _activitySource.StartActivity("Statement.FetchResults"))
+            {
+                Assert.NotNull(activity2);
+                activity2.SetTag("statement.id", statementId);
+                activity2.SetTag("session.id", sessionId);
+                activity2.SetTag("result.chunk_count", "3");
+                activity2.Stop();
+
+                _aggregator.ProcessActivity(activity2);
+            }
+
+            // Assert - should not emit until CompleteStatement
+            Assert.Equal(0, _aggregator.PendingEventCount);
+            Assert.Equal(1, _aggregator.ActiveStatementCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_ProcessActivity_Statement_WithoutStatementId_EmitsImmediately()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var activity = _activitySource.StartActivity("Statement.Execute");
+            Assert.NotNull(activity);
+            // No statement.id tag
+            activity.SetTag("session.id", "session-123");
+            activity.Stop();
+
+            // Act
+            _aggregator.ProcessActivity(activity);
+
+            // Assert - should emit immediately since no statement_id
+            Assert.Equal(1, _aggregator.PendingEventCount);
+        }
+
+        #endregion
+
+        #region CompleteStatement Tests
+
+        [Fact]
+        public void MetricsAggregator_CompleteStatement_EmitsAggregatedEvent()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var statementId = "stmt-complete-123";
+            var sessionId = "session-complete-456";
+
+            using (var activity = _activitySource.StartActivity("Statement.Execute"))
+            {
+                Assert.NotNull(activity);
+                activity.SetTag("statement.id", statementId);
+                activity.SetTag("session.id", sessionId);
+                activity.SetTag("result.format", "cloudfetch");
+                activity.SetTag("result.chunk_count", "10");
+                activity.Stop();
+
+                _aggregator.ProcessActivity(activity);
+            }
+
+            Assert.Equal(0, _aggregator.PendingEventCount);
+            Assert.Equal(1, _aggregator.ActiveStatementCount);
+
+            // Act
+            _aggregator.CompleteStatement(statementId);
+
+            // Assert
+            Assert.Equal(1, _aggregator.PendingEventCount);
+            Assert.Equal(0, _aggregator.ActiveStatementCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_CompleteStatement_NullStatementId_NoOp()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Act - should not throw
+            _aggregator.CompleteStatement(null!);
+            _aggregator.CompleteStatement(string.Empty);
+
+            // Assert
+            Assert.Equal(0, _aggregator.PendingEventCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_CompleteStatement_UnknownStatementId_NoOp()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Act - should not throw
+            _aggregator.CompleteStatement("unknown-statement-id");
+
+            // Assert
+            Assert.Equal(0, _aggregator.PendingEventCount);
+        }
+
+        #endregion
+
+        #region FlushAsync Tests
+
+        [Fact]
+        public async Task MetricsAggregator_FlushAsync_BatchSizeReached_ExportsEvents()
+        {
+            // Arrange
+            var config = new TelemetryConfiguration { BatchSize = 2, FlushIntervalMs = 60000 };
+            _aggregator = new MetricsAggregator(_mockExporter, config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            // Add events that should trigger flush
+            for (int i = 0; i < 3; i++)
+            {
+                using var activity = _activitySource.StartActivity("Connection.Open");
+                Assert.NotNull(activity);
+                activity.SetTag("session.id", $"session-{i}");
+                activity.Stop();
+                _aggregator.ProcessActivity(activity);
+            }
+
+            // Wait for any background flush to complete
+            await Task.Delay(100);
+
+            // Assert - exporter should have been called
+            Assert.True(_mockExporter.ExportCallCount > 0);
+        }
+
+        [Fact]
+        public async Task MetricsAggregator_FlushAsync_TimeInterval_ExportsEvents()
+        {
+            // Arrange
+            var config = new TelemetryConfiguration { BatchSize = 100, FlushIntervalMs = 100 }; // 100ms interval
+            _aggregator = new MetricsAggregator(_mockExporter, config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var activity = _activitySource.StartActivity("Connection.Open");
+            Assert.NotNull(activity);
+            activity.SetTag("session.id", "session-timer");
+            activity.Stop();
+            _aggregator.ProcessActivity(activity);
+
+            // Act - wait for timer to trigger flush
+            await Task.Delay(250);
+
+            // Assert - exporter should have been called by timer
+            Assert.True(_mockExporter.ExportCallCount > 0);
+        }
+
+        [Fact]
+        public async Task MetricsAggregator_FlushAsync_EmptyQueue_NoExport()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Act
+            await _aggregator.FlushAsync();
+
+            // Assert
+            Assert.Equal(0, _mockExporter.ExportCallCount);
+        }
+
+        [Fact]
+        public async Task MetricsAggregator_FlushAsync_MultipleEvents_ExportsAll()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            for (int i = 0; i < 5; i++)
+            {
+                using var activity = _activitySource.StartActivity("Connection.Open");
+                Assert.NotNull(activity);
+                activity.SetTag("session.id", $"session-{i}");
+                activity.Stop();
+                _aggregator.ProcessActivity(activity);
+            }
+
+            Assert.Equal(5, _aggregator.PendingEventCount);
+
+            // Act
+            await _aggregator.FlushAsync();
+
+            // Assert
+            Assert.Equal(0, _aggregator.PendingEventCount);
+            Assert.Equal(1, _mockExporter.ExportCallCount);
+            Assert.Equal(5, _mockExporter.TotalExportedEvents);
+        }
+
+        #endregion
+
+        #region RecordException Tests
+
+        [Fact]
+        public void MetricsAggregator_RecordException_Terminal_FlushesImmediately()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            var terminalException = new HttpRequestException("401 (Unauthorized)");
+
+            // Act
+            _aggregator.RecordException("stmt-123", "session-456", terminalException);
+
+            // Assert - terminal exception should be queued immediately
+            Assert.Equal(1, _aggregator.PendingEventCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_RecordException_Retryable_BuffersUntilComplete()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            var retryableException = new HttpRequestException("503 (Service Unavailable)");
+            var statementId = "stmt-retryable-123";
+            var sessionId = "session-retryable-456";
+
+            // Act
+            _aggregator.RecordException(statementId, sessionId, retryableException);
+
+            // Assert - retryable exception should be buffered, not queued
+            Assert.Equal(0, _aggregator.PendingEventCount);
+            Assert.Equal(1, _aggregator.ActiveStatementCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_RecordException_Retryable_EmittedOnFailedComplete()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            var retryableException = new HttpRequestException("503 (Service Unavailable)");
+            var statementId = "stmt-failed-123";
+            var sessionId = "session-failed-456";
+
+            _aggregator.RecordException(statementId, sessionId, retryableException);
+            Assert.Equal(0, _aggregator.PendingEventCount);
+
+            // Act - complete statement as failed
+            _aggregator.CompleteStatement(statementId, failed: true);
+
+            // Assert - both statement event and error event should be emitted
+            Assert.Equal(2, _aggregator.PendingEventCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_RecordException_Retryable_NotEmittedOnSuccessComplete()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            var retryableException = new HttpRequestException("503 (Service Unavailable)");
+            var statementId = "stmt-success-123";
+            var sessionId = "session-success-456";
+
+            _aggregator.RecordException(statementId, sessionId, retryableException);
+
+            // Act - complete statement as success
+            _aggregator.CompleteStatement(statementId, failed: false);
+
+            // Assert - only statement event should be emitted, not the error
+            Assert.Equal(1, _aggregator.PendingEventCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_RecordException_NullException_NoOp()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Act - should not throw
+            _aggregator.RecordException("stmt-123", "session-456", null);
+
+            // Assert
+            Assert.Equal(0, _aggregator.PendingEventCount);
+        }
+
+        [Fact]
+        public void MetricsAggregator_RecordException_NullStatementId_NoOp()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Act - should not throw
+            _aggregator.RecordException(null!, "session-456", new Exception("test"));
+            _aggregator.RecordException(string.Empty, "session-456", new Exception("test"));
+
+            // Assert
+            Assert.Equal(0, _aggregator.PendingEventCount);
+        }
+
+        #endregion
+
+        #region Exception Swallowing Tests
+
+        [Fact]
+        public void MetricsAggregator_ProcessActivity_ExceptionSwallowed_NoThrow()
+        {
+            // Arrange
+            var throwingExporter = new ThrowingTelemetryExporter();
+            _aggregator = new MetricsAggregator(throwingExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Act & Assert - should not throw even with throwing exporter
+            _aggregator.ProcessActivity(null);
+        }
+
+        [Fact]
+        public async Task MetricsAggregator_FlushAsync_ExceptionSwallowed_NoThrow()
+        {
+            // Arrange
+            var throwingExporter = new ThrowingTelemetryExporter();
+            _aggregator = new MetricsAggregator(throwingExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var activity = _activitySource.StartActivity("Connection.Open");
+            Assert.NotNull(activity);
+            activity.SetTag("session.id", "session-throw");
+            activity.Stop();
+            _aggregator.ProcessActivity(activity);
+
+            // Act & Assert - should not throw
+            await _aggregator.FlushAsync();
+        }
+
+        #endregion
+
+        #region Tag Filtering Tests
+
+        [Fact]
+        public void MetricsAggregator_ProcessActivity_FiltersTags_UsingRegistry()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var statementId = "stmt-filter-123";
+
+            using (var activity = _activitySource.StartActivity("Statement.Execute"))
+            {
+                Assert.NotNull(activity);
+                activity.SetTag("statement.id", statementId);
+                activity.SetTag("session.id", "session-filter");
+                activity.SetTag("result.format", "cloudfetch");
+                // This sensitive tag should be filtered out
+                activity.SetTag("db.statement", "SELECT * FROM sensitive_table");
+                // This tag should be included
+                activity.SetTag("result.chunk_count", "5");
+                activity.Stop();
+
+                _aggregator.ProcessActivity(activity);
+            }
+
+            // Complete to emit
+            _aggregator.CompleteStatement(statementId);
+
+            // Assert - event should be created (we can verify via export)
+            Assert.Equal(1, _aggregator.PendingEventCount);
+        }
+
+        #endregion
+
+        #region WrapInFrontendLog Tests
+
+        [Fact]
+        public void MetricsAggregator_WrapInFrontendLog_CreatesValidStructure()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            var telemetryEvent = new TelemetryEvent
+            {
+                SessionId = "session-wrap-123",
+                SqlStatementId = "stmt-wrap-456",
+                OperationLatencyMs = 100
+            };
+
+            // Act
+            var frontendLog = _aggregator.WrapInFrontendLog(telemetryEvent);
+
+            // Assert
+            Assert.NotNull(frontendLog);
+            Assert.Equal(TestWorkspaceId, frontendLog.WorkspaceId);
+            Assert.NotEmpty(frontendLog.FrontendLogEventId);
+            Assert.NotNull(frontendLog.Context);
+            Assert.NotNull(frontendLog.Context.ClientContext);
+            Assert.Equal(TestUserAgent, frontendLog.Context.ClientContext.UserAgent);
+            Assert.True(frontendLog.Context.TimestampMillis > 0);
+            Assert.NotNull(frontendLog.Entry);
+            Assert.NotNull(frontendLog.Entry.SqlDriverLog);
+            Assert.Equal(telemetryEvent.SessionId, frontendLog.Entry.SqlDriverLog.SessionId);
+            Assert.Equal(telemetryEvent.SqlStatementId, frontendLog.Entry.SqlDriverLog.SqlStatementId);
+        }
+
+        [Fact]
+        public void MetricsAggregator_WrapInFrontendLog_GeneratesUniqueEventIds()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            var telemetryEvent = new TelemetryEvent { SessionId = "session-unique" };
+
+            // Act
+            var frontendLog1 = _aggregator.WrapInFrontendLog(telemetryEvent);
+            var frontendLog2 = _aggregator.WrapInFrontendLog(telemetryEvent);
+
+            // Assert
+            Assert.NotEqual(frontendLog1.FrontendLogEventId, frontendLog2.FrontendLogEventId);
+        }
+
+        #endregion
+
+        #region Dispose Tests
+
+        [Fact]
+        public void MetricsAggregator_Dispose_FlushesRemainingEvents()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var activity = _activitySource.StartActivity("Connection.Open");
+            Assert.NotNull(activity);
+            activity.SetTag("session.id", "session-dispose");
+            activity.Stop();
+            _aggregator.ProcessActivity(activity);
+
+            Assert.Equal(1, _aggregator.PendingEventCount);
+
+            // Act
+            _aggregator.Dispose();
+
+            // Assert - events should have been flushed
+            Assert.True(_mockExporter.ExportCallCount > 0);
+        }
+
+        [Fact]
+        public void MetricsAggregator_Dispose_CanBeCalledMultipleTimes()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            // Act & Assert - should not throw
+            _aggregator.Dispose();
+            _aggregator.Dispose();
+        }
+
+        #endregion
+
+        #region Integration Tests
+
+        [Fact]
+        public async Task MetricsAggregator_EndToEnd_StatementLifecycle()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var statementId = "stmt-e2e-123";
+            var sessionId = "session-e2e-456";
+
+            // Simulate statement execution
+            using (var executeActivity = _activitySource.StartActivity("Statement.Execute"))
+            {
+                Assert.NotNull(executeActivity);
+                executeActivity.SetTag("statement.id", statementId);
+                executeActivity.SetTag("session.id", sessionId);
+                executeActivity.SetTag("result.format", "cloudfetch");
+                executeActivity.Stop();
+                _aggregator.ProcessActivity(executeActivity);
+            }
+
+            // Simulate chunk downloads
+            for (int i = 0; i < 3; i++)
+            {
+                using var downloadActivity = _activitySource.StartActivity("CloudFetch.Download");
+                Assert.NotNull(downloadActivity);
+                downloadActivity.SetTag("statement.id", statementId);
+                downloadActivity.SetTag("session.id", sessionId);
+                downloadActivity.SetTag("result.chunk_count", "1");
+                downloadActivity.SetTag("result.bytes_downloaded", "1000");
+                downloadActivity.Stop();
+                _aggregator.ProcessActivity(downloadActivity);
+            }
+
+            // Complete statement
+            _aggregator.CompleteStatement(statementId);
+
+            // Flush
+            await _aggregator.FlushAsync();
+
+            // Assert
+            Assert.Equal(1, _mockExporter.ExportCallCount);
+            Assert.Equal(1, _mockExporter.TotalExportedEvents);
+            Assert.Equal(0, _aggregator.ActiveStatementCount);
+        }
+
+        [Fact]
+        public async Task MetricsAggregator_EndToEnd_MultipleStatements()
+        {
+            // Arrange
+            _aggregator = new MetricsAggregator(_mockExporter, _config, TestWorkspaceId, TestUserAgent);
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var sessionId = "session-multi";
+
+            // Execute 3 statements
+            for (int i = 0; i < 3; i++)
+            {
+                var statementId = $"stmt-multi-{i}";
+
+                using var activity = _activitySource.StartActivity("Statement.Execute");
+                Assert.NotNull(activity);
+                activity.SetTag("statement.id", statementId);
+                activity.SetTag("session.id", sessionId);
+                activity.Stop();
+                _aggregator.ProcessActivity(activity);
+
+                _aggregator.CompleteStatement(statementId);
+            }
+
+            // Flush
+            await _aggregator.FlushAsync();
+
+            // Assert
+            Assert.Equal(3, _mockExporter.TotalExportedEvents);
+        }
+
+        #endregion
+
+        #region Mock Classes
+
+        /// <summary>
+        /// Mock telemetry exporter for testing.
+        /// </summary>
+        private class MockTelemetryExporter : ITelemetryExporter
+        {
+            private int _exportCallCount;
+            private int _totalExportedEvents;
+            private readonly ConcurrentBag<TelemetryFrontendLog> _exportedLogs = new ConcurrentBag<TelemetryFrontendLog>();
+
+            public int ExportCallCount => _exportCallCount;
+            public int TotalExportedEvents => _totalExportedEvents;
+            public IReadOnlyCollection<TelemetryFrontendLog> ExportedLogs => _exportedLogs.ToList();
+
+            public Task ExportAsync(IReadOnlyList<TelemetryFrontendLog> logs, CancellationToken ct = default)
+            {
+                Interlocked.Increment(ref _exportCallCount);
+                Interlocked.Add(ref _totalExportedEvents, logs.Count);
+
+                foreach (var log in logs)
+                {
+                    _exportedLogs.Add(log);
+                }
+
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        /// Telemetry exporter that always throws for testing exception handling.
+        /// </summary>
+        private class ThrowingTelemetryExporter : ITelemetryExporter
+        {
+            public Task ExportAsync(IReadOnlyList<TelemetryFrontendLog> logs, CancellationToken ct = default)
+            {
+                throw new InvalidOperationException("Test exception from exporter");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/csharp/test/Unit/Telemetry/TagDefinitions/TelemetryTagRegistryTests.cs
+++ b/csharp/test/Unit/Telemetry/TagDefinitions/TelemetryTagRegistryTests.cs
@@ -221,8 +221,10 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry.TagDefinitions
             // Act
             var tags = StatementExecutionEvent.GetDatabricksExportTags();
 
-            // Assert - 8 tags should be exported (excludes db.statement)
-            Assert.Equal(8, tags.Count);
+            // Assert - 10 tags should be exported (excludes db.statement)
+            // Includes: StatementId, SessionId, ResultFormat, ResultChunkCount, ResultBytesDownloaded,
+            //           ResultCompressionEnabled, PollCount, PollLatencyMs, ChunkInitialLatencyMs, ChunkSlowestLatencyMs
+            Assert.Equal(10, tags.Count);
         }
 
         #endregion


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/167/files) to review incremental changes.
- [**stack/wi-3.5-metrics-aggregator**](https://github.com/adbc-drivers/databricks/pull/167) [[Files changed](https://github.com/adbc-drivers/databricks/pull/167/files)]
  - [stack/wi-3.5-circuit-breaker-manager](https://github.com/adbc-drivers/databricks/pull/168) [[Files changed](https://github.com/adbc-drivers/databricks/pull/168/files/2bf4693e40f73fe2e511806302468feba85b96ca..b9270bc9f5d4baccbc51cbf2381454ea278aea15)]
    - [stack/e2e-feature-flag-cache-tests](https://github.com/adbc-drivers/databricks/pull/169) [[Files changed](https://github.com/adbc-drivers/databricks/pull/169/files/b9270bc9f5d4baccbc51cbf2381454ea278aea15..39f0c379f5417478f830fd4de7425816e0b8ac80)]
      - [stack/databricks-activity-listener](https://github.com/adbc-drivers/databricks/pull/170) [[Files changed](https://github.com/adbc-drivers/databricks/pull/170/files/39f0c379f5417478f830fd4de7425816e0b8ac80..b8e27f28411a08e7efb34761e80f7e54967462f6)]
        - [stack/circuit-breaker-telemetry-exporter](https://github.com/adbc-drivers/databricks/pull/171) [[Files changed](https://github.com/adbc-drivers/databricks/pull/171/files/b8e27f28411a08e7efb34761e80f7e54967462f6..2c0a48c50d53699aecb2eee05665d8e0c89791a5)]
          - [stack/telemetry-client-manager-wi-3.2](https://github.com/adbc-drivers/databricks/pull/172) [[Files changed](https://github.com/adbc-drivers/databricks/pull/172/files/2c0a48c50d53699aecb2eee05665d8e0c89791a5..615ae9709017245d346cc5d4a822280755a2a659)]
            - [stack/telemetry-client-wi-5.5](https://github.com/adbc-drivers/databricks/pull/173) [[Files changed](https://github.com/adbc-drivers/databricks/pull/173/files/615ae9709017245d346cc5d4a822280755a2a659..25ac81a95ef5379334d931ae45ccb37ffa08cdb7)]
              - [stack/telemetry-client-manager-e2e-wi-7](https://github.com/adbc-drivers/databricks/pull/174) [[Files changed](https://github.com/adbc-drivers/databricks/pull/174/files/25ac81a95ef5379334d931ae45ccb37ffa08cdb7..0de4c510802f55e2ce68c0605c0c0e205e04ec3e)]
                - [stack/telemetry-client-e2e-tests-wi-7-standalone](https://github.com/adbc-drivers/databricks/pull/175) [[Files changed](https://github.com/adbc-drivers/databricks/pull/175/files/0de4c510802f55e2ce68c0605c0c0e205e04ec3e..f163f89b418d3c2bde4d05b2d138717ed692ae6c)]
                  - [stack/wi-6.1-databricks-connection-telemetry-integration](https://github.com/adbc-drivers/databricks/pull/176) [[Files changed](https://github.com/adbc-drivers/databricks/pull/176/files/f163f89b418d3c2bde4d05b2d138717ed692ae6c..9e27ef08f9a2611c7e7fc1d6ede2508da3b83063)]
                    - [stack/wi-6.2-telemetry-tags-driver-activities](https://github.com/adbc-drivers/databricks/pull/177) [[Files changed](https://github.com/adbc-drivers/databricks/pull/177/files/9e27ef08f9a2611c7e7fc1d6ede2508da3b83063..35a4a012ae5274405e98b23c09dff6e7ae50d4b9)]
                      - [stack/wi-9-full-integration-e2e-tests](https://github.com/adbc-drivers/databricks/pull/178) [[Files changed](https://github.com/adbc-drivers/databricks/pull/178/files/35a4a012ae5274405e98b23c09dff6e7ae50d4b9..dda50713da541830e3955f58a00db2075bec01ef)]

---------
