### PR TITLE
chore: add compact flag to jq command in benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -99,7 +99,7 @@ jobs:
             else
               QUERY="select * from main.tpcds_sf1_delta.catalog_sales"
             fi
-            QUERIES=$(jq -n --arg q "$QUERY" '[{
+            QUERIES=$(jq -nc --arg q "$QUERY" '[{
               "name": "default",
               "description": "Custom or default query",
               "query": $q,


### PR DESCRIPTION
The jq command in single-query mode was missing the -c (compact) flag, causing it to output pretty-printed multi-line JSON. This breaks GitHub Actions' $GITHUB_OUTPUT format which requires single-line values.

This fix adds the -c flag to match the pattern used in all other branches of the conditional logic.

Fixes workflow run: https://github.com/adbc-drivers/databricks/actions/runs/20305493449

## What's Changed

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
