### PR TITLE
feat(rust): create metadata module structure for connection metadata methods

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -81,6 +81,7 @@ pub mod connection;
 pub mod database;
 pub mod driver;
 pub mod error;
+pub mod metadata;
 pub mod reader;
 pub mod result;
 pub mod statement;

--- a/rust/src/metadata/builder.rs
+++ b/rust/src/metadata/builder.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Arrow builder for `get_objects` responses.
+//!
+//! Constructs the nested Arrow struct hierarchy required by the ADBC
+//! `get_objects` specification (`GET_OBJECTS_SCHEMA`). Groups parsed
+//! metadata into catalog → schema → table → column hierarchy and
+//! builds the corresponding `RecordBatch`.

--- a/rust/src/metadata/mod.rs
+++ b/rust/src/metadata/mod.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Metadata helpers for ADBC Connection metadata methods.
+//!
+//! This module provides:
+//! - [`SqlCommandBuilder`] — Builds SHOW SQL commands for metadata queries
+//! - Result parsing — Parses `ExecuteResult` readers into intermediate structs
+//! - Arrow builder — Constructs nested Arrow structs for `get_objects` responses
+//! - Type mapping — Maps Databricks types to Arrow/XDBC types
+
+pub mod builder;
+pub mod parse;
+pub mod sql;
+pub mod type_mapping;
+
+pub use sql::SqlCommandBuilder;

--- a/rust/src/metadata/parse.rs
+++ b/rust/src/metadata/parse.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Result parsing for metadata queries.
+//!
+//! Parses `ExecuteResult` readers from SHOW SQL commands into intermediate
+//! structs (`CatalogInfo`, `SchemaInfo`, `TableInfo`, `ColumnInfo`) that
+//! the builder module uses to construct nested Arrow responses.

--- a/rust/src/metadata/sql.rs
+++ b/rust/src/metadata/sql.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SQL command builder for metadata queries.
+//!
+//! Builds SHOW SQL commands (SHOW CATALOGS, SHOW SCHEMAS, SHOW TABLES,
+//! SHOW COLUMNS, SHOW KEYS, SHOW FOREIGN KEYS) with optional pattern
+//! filters and identifier escaping.
+
+/// Builds SQL commands for metadata queries.
+///
+/// Uses the builder pattern to construct SHOW SQL commands with optional
+/// catalog, schema, table, and column pattern filters.
+pub struct SqlCommandBuilder;

--- a/rust/src/metadata/type_mapping.rs
+++ b/rust/src/metadata/type_mapping.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Databricks type mapping to Arrow and XDBC types.
+//!
+//! Provides functions to map Databricks SQL type names (e.g., "STRING",
+//! "DECIMAL(10,2)") to Arrow `DataType` and XDBC/JDBC type codes.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](#) to review incremental changes.

---------
Add the metadata/ module directory with stub files for the upcoming
get_objects, get_table_schema, and get_table_types implementations:
- mod.rs: module exports
- sql.rs: SqlCommandBuilder stub for SHOW SQL commands
- type_mapping.rs: stub for Databricks-to-Arrow/XDBC type mapping
- parse.rs: stub for ExecuteResult parsing into intermediate structs
- builder.rs: stub for nested Arrow struct construction

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## What's Changed

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
