### PR TITLE
ci: dispatch per-driver integration tests based on changed paths

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -189,7 +189,7 @@ jobs:
             await github.rest.checks.create({
               owner: 'adbc-drivers',
               repo: 'databricks',
-              name: 'Integration Tests',
+              name: 'C# Integration Tests',
               head_sha: context.payload.pull_request.head.sha,
               status: 'completed',
               conclusion: 'success',
@@ -335,7 +335,7 @@ jobs:
             });
             console.log(`PR #${prNumber} head SHA: ${pr.head.sha}`);
             // Check both required checks passed on current PR head SHA
-            const checkNames = ['Integration Tests', 'Rust Integration Tests'];
+            const checkNames = ['C# Integration Tests', 'Rust Integration Tests'];
             const results = await Promise.all(checkNames.map(name =>
               github.rest.checks.listForRef({
                 owner: context.repo.owner,
@@ -419,7 +419,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const headSha = '${{ github.event.merge_group.head_sha }}';
-            for (const name of ['Integration Tests', 'Rust Integration Tests']) {
+            for (const name of ['C# Integration Tests', 'Rust Integration Tests']) {
               await github.rest.checks.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -453,7 +453,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const headSha = '${{ github.event.merge_group.head_sha }}';
-            for (const name of ['Integration Tests', 'Rust Integration Tests']) {
+            for (const name of ['C# Integration Tests', 'Rust Integration Tests']) {
               await github.rest.checks.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- Rename `adbc-pr-test` → `adbc-csharp-pr-test` to match the test repo's workflow trigger
- Add `adbc-rust-pr-test` dispatch for Rust integration tests
- PR label flow: detect changed paths via GitHub API, only dispatch tests for the driver that changed
- Merge queue flow: output separate `csharp-changed` / `rust-changed` flags, dispatch conditionally

## Test plan

- [ ] PR touching only `csharp/` → only C# tests triggered
- [ ] PR touching only `rust/` → only Rust tests triggered
- [ ] PR touching both → both triggered
- [ ] PR touching neither → no dispatch; merge queue's `auto-approve-no-relevant-changes` handles it

🤖 Generated with [Claude Code](https://claude.com/claude-code)