### PR TITLE
ci(rust): fix coverage report failing on fork PRs

### DIFF
--- a/.github/workflows/rust_coverage_report.yaml
+++ b/.github/workflows/rust_coverage_report.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) 2025-2026 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow runs in the context of the base repository after the
+# "Rust Test" workflow completes. It downloads the coverage artifact
+# and posts the coverage report as a PR comment. This two-workflow
+# approach is necessary because fork PRs do not receive write
+# permissions on the GITHUB_TOKEN.
+
+name: Rust Coverage Report
+
+on:
+  workflow_run:
+    workflows: ["Rust Test"]
+    types:
+      - completed
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  report:
+    name: "Post Coverage Report"
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+      actions: read
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          name: rust-coverage
+          path: coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Coverage report
+        uses: getsentry/codecov-action@bee8d919178e87c35ada22280d7da8b77dda2cbb  # main (2025-02-10)
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: coverage/lcov.info
+          coverage-format: lcov
+          post-pr-comment: true
+          commit-sha: ${{ github.event.workflow_run.head_sha }}
+          target-project: auto
+          threshold-project: 1
+          target-patch: 80
+          fail-on-error: false

--- a/.github/workflows/rust_test.yaml
+++ b/.github/workflows/rust_test.yaml
@@ -445,8 +445,6 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-      pull-requests: write
-      actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -467,14 +465,9 @@ jobs:
             --ignore-filename-regex "tests/" \
             --lcov --output-path lcov.info
 
-      - name: Coverage report
-        uses: getsentry/codecov-action@bee8d919178e87c35ada22280d7da8b77dda2cbb  # main (2025-02-10)
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: rust/lcov.info
-          coverage-format: lcov
-          post-pr-comment: true
-          target-project: auto
-          threshold-project: 1
-          target-patch: 80
-          fail-on-error: false
+          name: rust-coverage
+          path: rust/lcov.info
+          retention-days: 1


### PR DESCRIPTION
## Summary
- Split the coverage job into a two-workflow approach to fix `GITHUB_TOKEN` permission errors on fork PRs
- The `coverage` job in `rust_test.yaml` now generates `lcov.info` and uploads it as an artifact (read-only permissions)
- A new `rust_coverage_report.yaml` workflow triggers via `workflow_run` after "Rust Test" completes, downloads the artifact, and posts the coverage PR comment with full write permissions (runs in base repo context)

## Context
PR #240 showed that the coverage check fails on fork PRs because GitHub downgrades `GITHUB_TOKEN` to read-only for fork-based pull requests. The `getsentry/codecov-action` then fails when trying to post PR comments and create commit statuses, even with `fail-on-error: false`.

## Test plan
- [ ] Verify the `Coverage` job in `Rust Test` passes (generates coverage + uploads artifact)
- [ ] Verify `Rust Coverage Report` triggers automatically after `Rust Test` completes
- [ ] Verify coverage comment is posted on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)