### PR TITLE
refactor(ci): replace merge queue job chain with parallel per-driver jobs

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -280,7 +280,12 @@ jobs:
         id: extract-pr
         run: |
           REF="${{ github.event.merge_group.head_ref }}"
-          [[ $REF =~ pr-([0-9]+) ]] && echo "pr_number=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT || echo "pr_number=0" >> $GITHUB_OUTPUT
+          if [[ $REF =~ pr-([0-9]+) ]]; then
+            echo "pr_number=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          else
+            echo "Error: failed to extract PR number from merge group ref: '$REF'" >&2
+            exit 1
+          fi
 
       - name: Generate GitHub App Token (internal repo)
         if: steps.changed.outputs.changed == 'true'
@@ -368,7 +373,12 @@ jobs:
         id: extract-pr
         run: |
           REF="${{ github.event.merge_group.head_ref }}"
-          [[ $REF =~ pr-([0-9]+) ]] && echo "pr_number=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT || echo "pr_number=0" >> $GITHUB_OUTPUT
+          if [[ $REF =~ pr-([0-9]+) ]]; then
+            echo "pr_number=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          else
+            echo "Error: failed to extract PR number from merge group ref: '$REF'" >&2
+            exit 1
+          fi
 
       - name: Generate GitHub App Token (internal repo)
         if: steps.changed.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

- **Root cause**: The previous merge queue flow used a 5-job dependency chain where two bugs caused C#-only PRs to get permanently stuck:
  1. `check-previous-run` used `steps.check-pr.outputs.passed` but `github-script` maps `return` to `outputs.result` — so `auto-approve-already-passed` never ran and `trigger-tests-merge` always ran instead.
  2. `trigger-tests-merge` dispatched C# tests when C# files changed, but had no equivalent step to create a synthetic passing `Rust Integration Tests` check when Rust files _didn't_ change — leaving the required branch protection check permanently unset on the merge queue SHA.

- **Fix**: Replace the 5-job chain with two independent parallel jobs (`merge-queue-csharp`, `merge-queue-rust`). Each job:
  1. Checks if its driver's files changed
  2. If not changed → auto-pass the required check
  3. If changed → dispatch tests to the internal repo
  4. If dispatch fails → create an explicit failing check (so the merge queue fails fast rather than hanging)

## Test plan

- [ ] Add a C#-only PR to the merge queue — verify `Rust Integration Tests` auto-passes on the merge queue SHA and the PR merges successfully
- [ ] Add a Rust-only PR to the merge queue — verify `C# Integration Tests` auto-passes on the merge queue SHA and the PR merges successfully
- [ ] Add a PR with both C# and Rust changes — verify both test jobs are dispatched
- [ ] Add a PR with no driver changes — verify both checks auto-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)