### PR TITLE
ci: skip integration tests on PRs, gate on merge queue instead

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -100,12 +100,20 @@ jobs:
   skip-integration-tests-pr:
     if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
+      - name: Generate GitHub App Token
+        id: adbc-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+          owner: adbc-drivers
+          repositories: databricks
+
       - name: Skip C# Integration Tests
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.adbc-token.outputs.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',
@@ -124,6 +132,7 @@ jobs:
       - name: Skip Rust Integration Tests
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.adbc-token.outputs.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',


### PR DESCRIPTION
## Summary

- Add `skip-integration-tests-pr` job that immediately auto-passes `Rust Integration Tests` and `C# Integration Tests` on all PR events (opened, synchronize, reopened)
- Preserve the `integration-test` label flow for optional pre-merge verification (dispatches real tests whose result overrides the auto-skip)
- Merge queue jobs (`merge-queue-rust`, `merge-queue-csharp`) unchanged — real tests still run there

## Why

Once `Rust Integration Tests` and `C# Integration Tests` are added as **required checks** in branch protection:
- PRs can **enter the merge queue freely** (required checks are immediately satisfied by the auto-skip)
- The merge queue **blocks the merge** if real tests fail (external check posted by internal repo)

## Behavior

| Event | `skip-integration-tests-pr` | `trigger-tests-pr` |
|---|---|---|
| PR opened / sync / reopen | Posts both checks as ✅ success | Skipped |
| `integration-test` label added | Skipped | Dispatches real tests |
| New commit pushed | Resets both checks to ✅ success | Skipped (label removed by security job) |
| Merge queue | — | — (handled by `merge-queue-rust` / `merge-queue-csharp`) |

## Required follow-up

Add `Rust Integration Tests` and `C# Integration Tests` (app_id: 2731531) as required status checks in branch protection settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)