### PR TITLE
feat(csharp): sEA connection metadata — GetObjects, GetTableSchema, GetTableTypes, GetInfo, SQL commands

### DIFF
--- a/csharp/doc/sea-metadata-design.md
+++ b/csharp/doc/sea-metadata-design.md
@@ -1,0 +1,131 @@
+# SEA Metadata Architecture
+
+## Overview
+
+The Databricks ADBC driver supports two protocols for metadata retrieval:
+- **Thrift** (HiveServer2): Uses Thrift RPC calls to fetch metadata from the server
+- **SEA** (Statement Execution API): Uses SQL commands (`SHOW CATALOGS`, `SHOW SCHEMAS`, etc.) via the REST API
+
+Both protocols share the same Arrow result structure for `GetObjects`, `GetColumns`, `GetPrimaryKeys`, and other metadata operations. This document describes how shared code is structured to avoid duplication while allowing each protocol to fetch data from its respective backend.
+
+## Shared Interface: IGetObjectsDataProvider
+
+```
+AdbcConnection.GetObjects()  [sync ADBC API]
+         │
+         ▼
+GetObjectsResultBuilder.BuildGetObjectsResultAsync()  [async orchestrator]
+         │
+         ├─ provider.GetCatalogsAsync()
+         ├─ provider.GetSchemasAsync()
+         ├─ provider.GetTablesAsync()
+         └─ provider.PopulateColumnInfoAsync()
+         │
+         ▼
+    BuildResult() → HiveInfoArrowStream  [Arrow structure construction]
+```
+
+`IGetObjectsDataProvider` is the abstraction between "how to fetch metadata" and "how to build Arrow results":
+
+- **GetObjectsResultBuilder** knows how to construct the nested Arrow structures (catalog → schema → table → column) required by the ADBC GetObjects spec.
+- **IGetObjectsDataProvider** implementations know how to retrieve the raw data from their protocol.
+
+### Thrift Implementation (HiveServer2Connection)
+- Calls Thrift RPCs: `GetCatalogsAsync()`, `GetSchemasAsync()`, `GetTablesAsync()`, `GetColumnsAsync()`
+- Server returns typed result sets with precision, scale, column size
+- `SetPrecisionScaleAndTypeName` override handles per-connection type mapping
+
+### SEA Implementation (StatementExecutionConnection)
+- Executes SQL: `SHOW CATALOGS`, `SHOW SCHEMAS IN ...`, `SHOW TABLES IN ...`, `SHOW COLUMNS IN ...`
+- Server returns type name strings only — metadata is computed locally via `ColumnMetadataHelper`
+- `ColumnMetadataHelper.PopulateTableInfoFromTypeName` derives data type codes, column sizes, decimal digits from type names
+
+## Async Design
+
+The ADBC base class defines `GetObjects()` as synchronous:
+```csharp
+public abstract IArrowArrayStream GetObjects(GetObjectsDepth depth, ...);
+```
+
+Internally, the interface and builder are async:
+```csharp
+interface IGetObjectsDataProvider {
+    Task<IReadOnlyList<string>> GetCatalogsAsync(...);
+    // ...
+}
+
+static async Task<HiveInfoArrowStream> BuildGetObjectsResultAsync(
+    IGetObjectsDataProvider provider, ...) { ... }
+```
+
+The sync ADBC boundary blocks once at the top level:
+```csharp
+public override IArrowArrayStream GetObjects(...) {
+    return BuildGetObjectsResultAsync(this, ...).GetAwaiter().GetResult();
+}
+```
+
+This avoids nested `.Result` blocking calls on every Thrift RPC while maintaining the sync ADBC API contract.
+
+## Shared Schema Factories
+
+`MetadataSchemaFactory` (in hiveserver2) provides schema definitions used by both protocols:
+
+| Factory Method | Used By |
+|---|---|
+| `CreateCatalogsSchema()` | DatabricksStatement, StatementExecutionStatement |
+| `CreateSchemasSchema()` | DatabricksStatement, StatementExecutionStatement |
+| `CreateTablesSchema()` | DatabricksStatement, StatementExecutionStatement |
+| `CreateColumnMetadataSchema()` | DatabricksStatement, FlatColumnsResultBuilder |
+| `CreatePrimaryKeysSchema()` | MetadataSchemaFactory builders |
+| `CreateCrossReferenceSchema()` | MetadataSchemaFactory builders |
+| `BuildGetInfoResult()` | HiveServer2Connection, StatementExecutionConnection |
+
+## Type Mapping
+
+### Thrift Path
+```
+Server result → SetPrecisionScaleAndTypeName (per-connection override)
+    ├─ SparkConnection: parses DECIMAL/CHAR precision from type name
+    └─ HiveServer2ExtendedConnection: uses server-provided values
+
+For flat GetColumns, EnhanceGetColumnsResult (on HiveServer2Statement) adds
+a BASE_TYPE_NAME column and optionally overrides precision/scale by calling
+SetPrecisionScaleAndTypeName per row. This is Thrift-only — SEA builds the
+complete result from scratch via FlatColumnsResultBuilder.
+```
+
+### SEA Path
+```
+SHOW COLUMNS response → ColumnMetadataHelper.PopulateTableInfoFromTypeName
+    └─ Computes: data type code, column size, decimal digits, base type name
+```
+
+### Shared GetArrowType
+`HiveServer2Connection.GetArrowType()` (internal static) converts a column type ID to an Apache Arrow type. Both Thrift and SEA use this — SEA derives the type ID via `ColumnMetadataHelper.GetDataTypeCode()` first.
+
+## SQL Command Builders
+
+SEA metadata uses `MetadataCommandBase` with command subclasses:
+
+| Command | SQL Generated |
+|---|---|
+| `ShowCatalogsCommand` | `SHOW CATALOGS [LIKE 'pattern']` |
+| `ShowSchemasCommand` | `SHOW SCHEMAS IN \`catalog\` [LIKE 'pattern']` |
+| `ShowTablesCommand` | `SHOW TABLES IN CATALOG \`catalog\` [SCHEMA LIKE ...] [LIKE ...]` |
+| `ShowColumnsCommand` | `SHOW COLUMNS IN CATALOG \`catalog\` [SCHEMA LIKE ...] [TABLE LIKE ...] [LIKE ...]` |
+| `ShowKeysCommand` | `SHOW KEYS IN CATALOG ... IN SCHEMA ... IN TABLE ...` |
+| `ShowForeignKeysCommand` | `SHOW FOREIGN KEYS IN CATALOG ... IN SCHEMA ... IN TABLE ...` |
+
+Pattern conversion: ADBC `%` → Databricks `*`, ADBC `_` → Databricks `.`
+
+## GetObjects RPC Count
+
+Each IGetObjectsDataProvider method makes one server call. Total RPCs by depth:
+
+| Depth | Methods Called | RPCs |
+|---|---|---|
+| Catalogs | GetCatalogsAsync | 1 |
+| DbSchemas | + GetSchemasAsync | 2 |
+| Tables | + GetTablesAsync | 3 |
+| All | + PopulateColumnInfoAsync | 4 |

--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -380,20 +380,14 @@ namespace AdbcDrivers.Databricks
                         new("reason", "Multiple catalog support disabled")
                     ]);
 
-                    // Create a schema with a single column TABLE_CAT
-                    var field = new Field("TABLE_CAT", StringType.Default, true);
-                    var schema = new Schema(new[] { field }, null);
-
-                    // Create a single row with value "SPARK"
+                    var schema = MetadataSchemaFactory.CreateCatalogsSchema();
                     var builder = new StringArray.Builder();
                     builder.Append("SPARK");
-                    var array = builder.Build();
 
                     activity?.SetTag(SemanticConventions.Db.Response.ReturnedRows, 1);
                     activity?.AddEvent("statement.get_catalogs.complete");
 
-                    // Return the result without making an RPC call
-                    return new QueryResult(1, new HiveServer2Connection.HiveInfoArrowStream(schema, new[] { array }));
+                    return new QueryResult(1, new HiveInfoArrowStream(schema, new IArrowArray[] { builder.Build() }));
                 }
 
                 // If EnableMultipleCatalogSupport is true, delegate to base class implementation
@@ -433,23 +427,10 @@ namespace AdbcDrivers.Databricks
                         new("reason", "Multiple catalog support disabled and catalog is not null")
                     ]);
 
-                    // Create a schema with TABLE_SCHEM and TABLE_CATALOG columns
-                    var fields = new[]
-                    {
-                        new Field("TABLE_SCHEM", StringType.Default, true),
-                        new Field("TABLE_CATALOG", StringType.Default, true)
-                    };
-                    var schema = new Schema(fields, null);
-
-                    // Create empty arrays for both columns
-                    var catalogArray = new StringArray.Builder().Build();
-                    var schemaArray = new StringArray.Builder().Build();
-
                     activity?.SetTag(SemanticConventions.Db.Response.ReturnedRows, 0);
                     activity?.AddEvent("statement.get_schemas.complete");
 
-                    // Return empty result
-                    return new QueryResult(0, new HiveServer2Connection.HiveInfoArrowStream(schema, new[] { catalogArray, schemaArray }));
+                    return MetadataSchemaFactory.CreateEmptySchemasResult();
                 }
 
                 // Call the base implementation with the potentially modified catalog name
@@ -492,42 +473,10 @@ namespace AdbcDrivers.Databricks
                         new("reason", "Multiple catalog support disabled and catalog is not null")
                     ]);
 
-                    // Correct schema for GetTables
-                    var fields = new[]
-                    {
-                        new Field("TABLE_CAT", StringType.Default, true),
-                        new Field("TABLE_SCHEM", StringType.Default, true),
-                        new Field("TABLE_NAME", StringType.Default, true),
-                        new Field("TABLE_TYPE", StringType.Default, true),
-                        new Field("REMARKS", StringType.Default, true),
-                        new Field("TYPE_CAT", StringType.Default, true),
-                        new Field("TYPE_SCHEM", StringType.Default, true),
-                        new Field("TYPE_NAME", StringType.Default, true),
-                        new Field("SELF_REFERENCING_COL_NAME", StringType.Default, true),
-                        new Field("REF_GENERATION", StringType.Default, true)
-                    };
-                    var schema = new Schema(fields, null);
-
-                    // Create empty arrays for all columns
-                    var arrays = new IArrowArray[]
-                    {
-                        new StringArray.Builder().Build(), // TABLE_CAT
-                        new StringArray.Builder().Build(), // TABLE_SCHEM
-                        new StringArray.Builder().Build(), // TABLE_NAME
-                        new StringArray.Builder().Build(), // TABLE_TYPE
-                        new StringArray.Builder().Build(), // REMARKS
-                        new StringArray.Builder().Build(), // TYPE_CAT
-                        new StringArray.Builder().Build(), // TYPE_SCHEM
-                        new StringArray.Builder().Build(), // TYPE_NAME
-                        new StringArray.Builder().Build(), // SELF_REFERENCING_COL_NAME
-                        new StringArray.Builder().Build()  // REF_GENERATION
-                    };
-
                     activity?.SetTag(SemanticConventions.Db.Response.ReturnedRows, 0);
                     activity?.AddEvent("statement.get_tables.complete");
 
-                    // Return empty result
-                    return new QueryResult(0, new HiveServer2Connection.HiveInfoArrowStream(schema, arrays));
+                    return MetadataSchemaFactory.CreateEmptyTablesResult();
                 }
 
                 // Call the base implementation with the potentially modified catalog name
@@ -571,7 +520,7 @@ namespace AdbcDrivers.Databricks
                     ]);
 
                     // Correct schema for GetColumns
-                    var schema = CreateColumnMetadataSchema();
+                    var schema = MetadataSchemaFactory.CreateColumnMetadataSchema();
 
                     // Create empty arrays for all columns
                     var arrays = CreateColumnMetadataEmptyArray();
@@ -580,7 +529,7 @@ namespace AdbcDrivers.Databricks
                     activity?.AddEvent("statement.get_columns.complete");
 
                     // Return empty result
-                    return new QueryResult(0, new HiveServer2Connection.HiveInfoArrowStream(schema, arrays));
+                    return new QueryResult(0, new HiveInfoArrowStream(schema, arrays));
                 }
 
                 // Call the base implementation with the potentially modified catalog name
@@ -608,25 +557,7 @@ namespace AdbcDrivers.Databricks
         /// </summary>
         internal bool ShouldReturnEmptyPkFkResult()
         {
-            if (!enablePKFK)
-                return true;
-
-            var catalogInvalid = string.IsNullOrEmpty(CatalogName) ||
-                string.Equals(CatalogName, "SPARK", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(CatalogName, "hive_metastore", StringComparison.OrdinalIgnoreCase);
-
-            var foreignCatalogInvalid = string.IsNullOrEmpty(ForeignCatalogName) ||
-                string.Equals(ForeignCatalogName, "SPARK", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(ForeignCatalogName, "hive_metastore", StringComparison.OrdinalIgnoreCase);
-
-            // Handle special catalog cases
-            // Only when both catalog and foreignCatalog is Invalid, we return empty results
-            if (catalogInvalid && foreignCatalogInvalid)
-            {
-                return true;
-            }
-
-            return false;
+            return MetadataUtilities.ShouldReturnEmptyPKFKResult(CatalogName, ForeignCatalogName, enablePKFK);
         }
 
         protected override async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken = default)
@@ -660,28 +591,7 @@ namespace AdbcDrivers.Databricks
 
         private QueryResult EmptyPrimaryKeysResult()
         {
-            var fields = new[]
-            {
-                new Field("TABLE_CAT", StringType.Default, true),
-                new Field("TABLE_SCHEM", StringType.Default, true),
-                new Field("TABLE_NAME", StringType.Default, true),
-                new Field("COLUMN_NAME", StringType.Default, true),
-                new Field("KEQ_SEQ", Int32Type.Default, true),
-                new Field("PK_NAME", StringType.Default, true)
-            };
-            var schema = new Schema(fields, null);
-
-            var arrays = new IArrowArray[]
-            {
-                new StringArray.Builder().Build(), // TABLE_CAT
-                new StringArray.Builder().Build(), // TABLE_SCHEM
-                new StringArray.Builder().Build(), // TABLE_NAME
-                new StringArray.Builder().Build(), // COLUMN_NAME
-                new Int32Array.Builder().Build(),  // KEQ_SEQ
-                new StringArray.Builder().Build()  // PK_NAME
-            };
-
-            return new QueryResult(0, new HiveServer2Connection.HiveInfoArrowStream(schema, arrays));
+            return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
         }
 
         protected override async Task<QueryResult> GetCrossReferenceAsync(CancellationToken cancellationToken = default)
@@ -744,44 +654,7 @@ namespace AdbcDrivers.Databricks
 
         private QueryResult EmptyCrossReferenceResult()
         {
-            var fields = new[]
-            {
-                new Field("PKTABLE_CAT", StringType.Default, true),
-                new Field("PKTABLE_SCHEM", StringType.Default, true),
-                new Field("PKTABLE_NAME", StringType.Default, true),
-                new Field("PKCOLUMN_NAME", StringType.Default, true),
-                new Field("FKTABLE_CAT", StringType.Default, true),
-                new Field("FKTABLE_SCHEM", StringType.Default, true),
-                new Field("FKTABLE_NAME", StringType.Default, true),
-                new Field("FKCOLUMN_NAME", StringType.Default, true),
-                new Field("KEQ_SEQ", Int32Type.Default, true),
-                new Field("UPDATE_RULE", Int32Type.Default, true),
-                new Field("DELETE_RULE", Int32Type.Default, true),
-                new Field("FK_NAME", StringType.Default, true),
-                new Field("PK_NAME", StringType.Default, true),
-                new Field("DEFERRABILITY", Int32Type.Default, true)
-            };
-            var schema = new Schema(fields, null);
-
-            var arrays = new IArrowArray[]
-            {
-                new StringArray.Builder().Build(), // PKTABLE_CAT
-                new StringArray.Builder().Build(), // PKTABLE_SCHEM
-                new StringArray.Builder().Build(), // PKTABLE_NAME
-                new StringArray.Builder().Build(), // PKCOLUMN_NAME
-                new StringArray.Builder().Build(), // FKTABLE_CAT
-                new StringArray.Builder().Build(), // FKTABLE_SCHEM
-                new StringArray.Builder().Build(), // FKTABLE_NAME
-                new StringArray.Builder().Build(), // FKCOLUMN_NAME
-                new Int32Array.Builder().Build(),  // KEQ_SEQ
-                new Int32Array.Builder().Build(),  // UPDATE_RULE
-                new Int32Array.Builder().Build(),  // DELETE_RULE
-                new StringArray.Builder().Build(), // FK_NAME
-                new StringArray.Builder().Build(), // PK_NAME
-                new Int32Array.Builder().Build()   // DEFERRABILITY
-            };
-
-            return new QueryResult(0, new HiveServer2Connection.HiveInfoArrowStream(schema, arrays));
+            return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
         }
 
         protected override async Task<QueryResult> GetColumnsExtendedAsync(CancellationToken cancellationToken = default)
@@ -840,7 +713,7 @@ namespace AdbcDrivers.Databricks
                     return baseResult;
                 }
 
-                var columnMetadataSchema = CreateColumnMetadataSchema();
+                var columnMetadataSchema = MetadataSchemaFactory.CreateColumnMetadataSchema();
 
                 if (descResult.Stream == null)
                 {
@@ -894,41 +767,6 @@ namespace AdbcDrivers.Databricks
 
         public override string AssemblyVersion => DatabricksConnection.s_assemblyVersion;
 
-        /// <summary>
-        /// Creates the schema for the column metadata result set.
-        /// This schema is used for the GetColumns metadata query.
-        /// </summary>
-        private static Schema CreateColumnMetadataSchema()
-        {
-            var fields = new[]
-            {
-                new Field("TABLE_CAT", StringType.Default, true),
-                new Field("TABLE_SCHEM", StringType.Default, true),
-                new Field("TABLE_NAME", StringType.Default, true),
-                new Field("COLUMN_NAME", StringType.Default, true),
-                new Field("DATA_TYPE", Int32Type.Default, true),
-                new Field("TYPE_NAME", StringType.Default, true),
-                new Field("COLUMN_SIZE", Int32Type.Default, true),
-                new Field("BUFFER_LENGTH", Int8Type.Default, true),
-                new Field("DECIMAL_DIGITS", Int32Type.Default, true),
-                new Field("NUM_PREC_RADIX", Int32Type.Default, true),
-                new Field("NULLABLE", Int32Type.Default, true),
-                new Field("REMARKS", StringType.Default, true),
-                new Field("COLUMN_DEF", StringType.Default, true),
-                new Field("SQL_DATA_TYPE", Int32Type.Default, true),
-                new Field("SQL_DATETIME_SUB", Int32Type.Default, true),
-                new Field("CHAR_OCTET_LENGTH", Int32Type.Default, true),
-                new Field("ORDINAL_POSITION", Int32Type.Default, true),
-                new Field("IS_NULLABLE", StringType.Default, true),
-                new Field("SCOPE_CATALOG", StringType.Default, true),
-                new Field("SCOPE_SCHEMA", StringType.Default, true),
-                new Field("SCOPE_TABLE", StringType.Default, true),
-                new Field("SOURCE_DATA_TYPE", Int16Type.Default, true),
-                new Field("IS_AUTO_INCREMENT", StringType.Default, true),
-                new Field("BASE_TYPE_NAME", StringType.Default, true)
-            };
-            return new Schema(fields, null);
-        }
 
         /// <summary>
         /// Creates an empty array for each column in the column metadata schema.
@@ -944,7 +782,7 @@ namespace AdbcDrivers.Databricks
                 new Int32Array.Builder().Build(),  // DATA_TYPE
                 new StringArray.Builder().Build(), // TYPE_NAME
                 new Int32Array.Builder().Build(),  // COLUMN_SIZE
-                new Int8Array.Builder().Build(),   // BUFFER_LENGTH
+                new Int32Array.Builder().Build(),  // BUFFER_LENGTH
                 new Int32Array.Builder().Build(),  // DECIMAL_DIGITS
                 new Int32Array.Builder().Build(),  // NUM_PREC_RADIX
                 new Int32Array.Builder().Build(),  // NULLABLE
@@ -964,7 +802,7 @@ namespace AdbcDrivers.Databricks
             ];
         }
 
-        private QueryResult CreateExtendedColumnsResult(Schema columnMetadataSchema, DescTableExtendedResult descResult)
+        internal static QueryResult CreateExtendedColumnsResult(Schema columnMetadataSchema, DescTableExtendedResult descResult)
         {
             var allFields = new List<Field>(columnMetadataSchema.FieldsList);
             foreach (var field in PrimaryKeyFields)
@@ -1140,7 +978,7 @@ namespace AdbcDrivers.Databricks
                 fkColumnKeySeqBuilder.Build()
             };
 
-            return new QueryResult(descResult.Columns.Count, new HiveServer2Connection.HiveInfoArrowStream(combinedSchema, combinedData));
+            return new QueryResult(descResult.Columns.Count, new HiveInfoArrowStream(combinedSchema, combinedData));
         }
     }
 }

--- a/csharp/src/MetadataUtilities.cs
+++ b/csharp/src/MetadataUtilities.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace AdbcDrivers.Databricks
+{
+    internal static class MetadataUtilities
+    {
+        internal static string? NormalizeSparkCatalog(string? catalogName)
+        {
+            if (string.IsNullOrEmpty(catalogName))
+                return catalogName;
+
+            if (string.Equals(catalogName, "SPARK", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return catalogName;
+        }
+
+        internal static bool IsInvalidPKFKCatalog(string? catalogName)
+        {
+            return string.IsNullOrEmpty(catalogName) ||
+                   string.Equals(catalogName, "SPARK", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(catalogName, "hive_metastore", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool ShouldReturnEmptyPKFKResult(string? catalogName, string? foreignCatalogName, bool enablePKFK)
+        {
+            if (!enablePKFK)
+                return true;
+
+            return IsInvalidPKFKCatalog(catalogName) && IsInvalidPKFKCatalog(foreignCatalogName);
+        }
+
+        internal static string? BuildQualifiedTableName(string? catalogName, string? schemaName, string? tableName)
+        {
+            if (string.IsNullOrEmpty(tableName))
+                return tableName;
+
+            var parts = new System.Collections.Generic.List<string>();
+
+            if (!string.IsNullOrEmpty(schemaName))
+            {
+                if (!string.IsNullOrEmpty(catalogName) && !catalogName!.Equals("SPARK", StringComparison.OrdinalIgnoreCase))
+                {
+                    parts.Add($"`{catalogName.Replace("`", "``")}`");
+                }
+                parts.Add($"`{schemaName!.Replace("`", "``")}`");
+            }
+
+            parts.Add($"`{tableName!.Replace("`", "``")}`");
+
+            return string.Join(".", parts);
+        }
+    }
+}

--- a/csharp/src/Result/DescTableExtendedResult.cs
+++ b/csharp/src/Result/DescTableExtendedResult.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using AdbcDrivers.HiveServer2.Hive2;
 using static AdbcDrivers.HiveServer2.Hive2.HiveServer2Connection;
 
 namespace AdbcDrivers.Databricks.Result
@@ -84,116 +85,34 @@ namespace AdbcDrivers.Databricks.Result
             /// See the list of type names from https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-datatypes
             /// </summary>
             [JsonIgnore]
-            public ColumnTypeId DataType
-            {
-                get
-                {
-                    string normalizedTypeName = Type.Name.Trim().ToUpper();
-
-                    return normalizedTypeName switch
-                    {
-                        "BOOLEAN" => ColumnTypeId.BOOLEAN,
-                        "TINYINT" or "BYTE" => ColumnTypeId.TINYINT,
-                        "SMALLINT" or "SHORT" => ColumnTypeId.SMALLINT,
-                        "INT" or "INTEGER" => ColumnTypeId.INTEGER,
-                        "BIGINT" or "LONG" => ColumnTypeId.BIGINT,
-                        "FLOAT" or "REAL" => ColumnTypeId.FLOAT,
-                        "DOUBLE" => ColumnTypeId.DOUBLE,
-                        "DECIMAL" or "NUMERIC" => ColumnTypeId.DECIMAL,
-
-                        "CHAR" => ColumnTypeId.CHAR,
-                        "STRING" or "VARCHAR" => ColumnTypeId.VARCHAR,
-                        "BINARY" => ColumnTypeId.BINARY,
-
-                        "TIMESTAMP" => ColumnTypeId.TIMESTAMP,
-                        "TIMESTAMP_LTZ" => ColumnTypeId.TIMESTAMP,
-                        "TIMESTAMP_NTZ" => ColumnTypeId.TIMESTAMP,
-                        "DATE" => ColumnTypeId.DATE,
-
-                        "ARRAY" => ColumnTypeId.ARRAY,
-                        "MAP" => ColumnTypeId.JAVA_OBJECT,
-                        "STRUCT" => ColumnTypeId.STRUCT,
-                        "INTERVAL" => ColumnTypeId.OTHER, // Intervals don't have a direct JDBC mapping
-                        "VOID" => ColumnTypeId.NULL,
-                        "VARIANT" => ColumnTypeId.OTHER,
-                        _ => ColumnTypeId.OTHER // Default fallback for unknown types
-                    };
-                }
-            }
+            public ColumnTypeId DataType => (ColumnTypeId)ColumnMetadataHelper.GetDataTypeCode(Type.Name);
 
             [JsonIgnore]
-            public bool IsNumber
-            {
-                get
-                {
-                    return DataType switch
-                    {
-                        ColumnTypeId.TINYINT or ColumnTypeId.SMALLINT or ColumnTypeId.INTEGER or
-                        ColumnTypeId.BIGINT or ColumnTypeId.FLOAT or ColumnTypeId.DOUBLE or
-                        ColumnTypeId.DECIMAL or ColumnTypeId.NUMERIC => true,
-                        _ => false
-                    };
-                }
-            }
+            public bool IsNumber => ColumnMetadataHelper.GetNumPrecRadix(Type.Name) != null;
 
             [JsonIgnore]
-            public int DecimalDigits
-            {
-                get
-                {
-                    return DataType switch
-                    {
-                        ColumnTypeId.DECIMAL or ColumnTypeId.NUMERIC => Type.Scale ?? 0,
-                        ColumnTypeId.DOUBLE => 15,
-                        ColumnTypeId.FLOAT or ColumnTypeId.REAL => 7,
-                        ColumnTypeId.TIMESTAMP => 6,
-                        _ => 0
-                    };
-                }
-            }
+            public int DecimalDigits => ColumnMetadataHelper.GetDecimalDigitsDefault(Type.FullTypeName) ?? 0;
 
-            /// <summary>
-            /// Get column size
-            ///
-            /// Currently the query `DESC TABLE EXTNEDED AS JSON` does not return the column size,
-            /// we can calculate it based on the data type and some type specific properties
-            /// </summary>
             [JsonIgnore]
             public int? ColumnSize
             {
                 get
                 {
-                    return DataType switch
+                    // For INTERVAL types, FullTypeName may not include the qualifier
+                    // when only StartUnit is set. Use StartUnit directly in that case.
+                    if (Type.Name.Trim().Equals("INTERVAL", StringComparison.OrdinalIgnoreCase)
+                        && !string.IsNullOrEmpty(Type.StartUnit)
+                        && Type.EndUnit == null)
                     {
-                        ColumnTypeId.TINYINT or ColumnTypeId.BOOLEAN => 1,
-                        ColumnTypeId.SMALLINT => 2,
-                        ColumnTypeId.INTEGER or ColumnTypeId.FLOAT or ColumnTypeId.DATE => 4,
-                        ColumnTypeId.BIGINT or ColumnTypeId.DOUBLE or ColumnTypeId.TIMESTAMP or ColumnTypeId.TIMESTAMP_WITH_TIMEZONE => 8,
-                        ColumnTypeId.CHAR => Type.Length,
-                        ColumnTypeId.VARCHAR => Type.Name.Trim().ToUpper() == "STRING" ? int.MaxValue : Type.Length,
-                        ColumnTypeId.DECIMAL => Type.Precision ?? 0,
-                        ColumnTypeId.NULL => 1,
-                        _ => Type.Name.Trim().ToUpper() == "INTERVAL" ? GetIntervalSize() : 0
-                    };
+                        return Type.StartUnit!.ToUpper() switch
+                        {
+                            "YEAR" or "MONTH" => 4,
+                            "DAY" or "HOUR" or "MINUTE" or "SECOND" => 8,
+                            _ => 4
+                        };
+                    }
+                    return ColumnMetadataHelper.GetColumnSizeDefault(Type.FullTypeName);
                 }
-            }
-
-            private int GetIntervalSize()
-            {
-                if (String.IsNullOrEmpty(Type.StartUnit))
-                {
-                    return 0;
-                }
-
-                // Check whether interval is yearMonthIntervalQualifier or dayTimeIntervalQualifier
-                // yearMonthIntervalQualifier size is 4, dayTimeIntervalQualifier size is 8
-                // see https://docs.databricks.com/aws/en/sql/language-manual/data-types/interval-type
-                return Type.StartUnit!.ToUpper() switch
-                {
-                    "YEAR" or "MONTH" => 4,
-                    "DAY" or "HOUR" or "MINUTE" or "SECOND" => 8,
-                    _ => 4
-                };
             }
         }
 

--- a/csharp/src/StatementExecution/MetadataCommands/MetadataCommandBase.cs
+++ b/csharp/src/StatementExecution/MetadataCommands/MetadataCommandBase.cs
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
+
+namespace AdbcDrivers.Databricks.StatementExecution.MetadataCommands
+{
+    internal abstract class MetadataCommandBase
+    {
+        protected const string InAllCatalogs = " IN ALL CATALOGS";
+        protected const string LikeFormat = " LIKE '{0}'";
+        protected const string SchemaLikeFormat = " SCHEMA LIKE '{0}'";
+        protected const string TableLikeFormat = " TABLE LIKE '{0}'";
+        protected const string InCatalogFormat = " IN CATALOG {0}";
+        protected const string InSchemaFormat = " IN SCHEMA {0}";
+        protected const string InTableFormat = " IN TABLE {0}";
+
+        public abstract string Build();
+
+        protected static string QuoteIdentifier(string identifier)
+        {
+            return $"`{identifier.Replace("`", "``")}`";
+        }
+
+        protected static string ConvertPattern(string? pattern)
+        {
+            if (string.IsNullOrEmpty(pattern))
+                return "*";
+
+            var result = new StringBuilder(pattern!.Length);
+            bool escapeNext = false;
+
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                char c = pattern[i];
+
+                if (c == '\\')
+                {
+                    if (i + 1 < pattern.Length && pattern[i + 1] == '\\')
+                    {
+                        result.Append("\\\\");
+                        i++;
+                    }
+                    else
+                    {
+                        escapeNext = !escapeNext;
+                        if (!escapeNext)
+                            result.Append('\\');
+                    }
+                }
+                else if (escapeNext)
+                {
+                    result.Append(c);
+                    escapeNext = false;
+                }
+                else if (c == '%')
+                {
+                    result.Append('*');
+                }
+                else if (c == '_')
+                {
+                    result.Append('.');
+                }
+                else if (c == '\'')
+                {
+                    result.Append("''");
+                }
+                else
+                {
+                    result.Append(c);
+                }
+            }
+
+            if (escapeNext)
+            {
+                result.Append('\\');
+            }
+
+            return result.ToString();
+        }
+
+        protected static void AppendCatalogScope(StringBuilder sql, string? catalog)
+        {
+            if (catalog == null)
+                sql.Append(InAllCatalogs);
+            else
+                sql.Append(string.Format(InCatalogFormat, QuoteIdentifier(catalog)));
+        }
+    }
+}

--- a/csharp/src/StatementExecution/MetadataCommands/ShowCatalogsCommand.cs
+++ b/csharp/src/StatementExecution/MetadataCommands/ShowCatalogsCommand.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
+
+namespace AdbcDrivers.Databricks.StatementExecution.MetadataCommands
+{
+    internal class ShowCatalogsCommand : MetadataCommandBase
+    {
+        private readonly string? _catalogPattern;
+
+        public ShowCatalogsCommand(string? catalogPattern = null)
+        {
+            _catalogPattern = catalogPattern;
+        }
+
+        public override string Build()
+        {
+            var sql = new StringBuilder("SHOW CATALOGS");
+            if (_catalogPattern != null)
+                sql.Append(string.Format(LikeFormat, ConvertPattern(_catalogPattern)));
+            return sql.ToString();
+        }
+    }
+}

--- a/csharp/src/StatementExecution/MetadataCommands/ShowColumnsCommand.cs
+++ b/csharp/src/StatementExecution/MetadataCommands/ShowColumnsCommand.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
+
+namespace AdbcDrivers.Databricks.StatementExecution.MetadataCommands
+{
+    internal class ShowColumnsCommand : MetadataCommandBase
+    {
+        private readonly string? _catalog;
+        private readonly string? _schemaPattern;
+        private readonly string? _tablePattern;
+        private readonly string? _columnPattern;
+
+        public ShowColumnsCommand(string? catalog, string? schemaPattern = null,
+            string? tablePattern = null, string? columnPattern = null)
+        {
+            _catalog = catalog;
+            _schemaPattern = schemaPattern;
+            _tablePattern = tablePattern;
+            _columnPattern = columnPattern;
+        }
+
+        public override string Build()
+        {
+            var sql = new StringBuilder("SHOW COLUMNS");
+            AppendCatalogScope(sql, _catalog);
+            if (_schemaPattern != null)
+                sql.Append(string.Format(SchemaLikeFormat, ConvertPattern(_schemaPattern)));
+            if (_tablePattern != null)
+                sql.Append(string.Format(TableLikeFormat, ConvertPattern(_tablePattern)));
+            if (_columnPattern != null && _columnPattern != "%")
+                sql.Append(string.Format(LikeFormat, ConvertPattern(_columnPattern)));
+            return sql.ToString();
+        }
+    }
+}

--- a/csharp/src/StatementExecution/MetadataCommands/ShowKeysCommand.cs
+++ b/csharp/src/StatementExecution/MetadataCommands/ShowKeysCommand.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Text;
+
+namespace AdbcDrivers.Databricks.StatementExecution.MetadataCommands
+{
+    internal class ShowKeysCommand : MetadataCommandBase
+    {
+        private readonly string _catalog;
+        private readonly string _schema;
+        private readonly string _table;
+
+        public ShowKeysCommand(string catalog, string schema, string table)
+        {
+            _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+        }
+
+        public override string Build()
+        {
+            var sql = new StringBuilder("SHOW KEYS");
+            sql.Append(string.Format(InCatalogFormat, QuoteIdentifier(_catalog)));
+            sql.Append(string.Format(InSchemaFormat, QuoteIdentifier(_schema)));
+            sql.Append(string.Format(InTableFormat, QuoteIdentifier(_table)));
+            return sql.ToString();
+        }
+    }
+
+    internal class ShowForeignKeysCommand : MetadataCommandBase
+    {
+        private readonly string _catalog;
+        private readonly string _schema;
+        private readonly string _table;
+
+        public ShowForeignKeysCommand(string catalog, string schema, string table)
+        {
+            _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+        }
+
+        public override string Build()
+        {
+            var sql = new StringBuilder("SHOW FOREIGN KEYS");
+            sql.Append(string.Format(InCatalogFormat, QuoteIdentifier(_catalog)));
+            sql.Append(string.Format(InSchemaFormat, QuoteIdentifier(_schema)));
+            sql.Append(string.Format(InTableFormat, QuoteIdentifier(_table)));
+            return sql.ToString();
+        }
+    }
+}

--- a/csharp/src/StatementExecution/MetadataCommands/ShowSchemasCommand.cs
+++ b/csharp/src/StatementExecution/MetadataCommands/ShowSchemasCommand.cs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
+
+namespace AdbcDrivers.Databricks.StatementExecution.MetadataCommands
+{
+    internal class ShowSchemasCommand : MetadataCommandBase
+    {
+        private readonly string? _catalog;
+        private readonly string? _schemaPattern;
+
+        public ShowSchemasCommand(string? catalog, string? schemaPattern = null)
+        {
+            _catalog = catalog;
+            _schemaPattern = schemaPattern;
+        }
+
+        public override string Build()
+        {
+            var sql = new StringBuilder("SHOW SCHEMAS");
+            if (_catalog == null)
+                sql.Append(InAllCatalogs);
+            else
+                sql.Append($" IN {QuoteIdentifier(_catalog)}");
+            if (_schemaPattern != null)
+                sql.Append(string.Format(LikeFormat, ConvertPattern(_schemaPattern)));
+            return sql.ToString();
+        }
+    }
+}

--- a/csharp/src/StatementExecution/MetadataCommands/ShowTablesCommand.cs
+++ b/csharp/src/StatementExecution/MetadataCommands/ShowTablesCommand.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Text;
+
+namespace AdbcDrivers.Databricks.StatementExecution.MetadataCommands
+{
+    internal class ShowTablesCommand : MetadataCommandBase
+    {
+        private readonly string? _catalog;
+        private readonly string? _schemaPattern;
+        private readonly string? _tablePattern;
+
+        public ShowTablesCommand(string? catalog, string? schemaPattern = null, string? tablePattern = null)
+        {
+            _catalog = catalog;
+            _schemaPattern = schemaPattern;
+            _tablePattern = tablePattern;
+        }
+
+        public override string Build()
+        {
+            var sql = new StringBuilder("SHOW TABLES");
+            AppendCatalogScope(sql, _catalog);
+            if (_schemaPattern != null)
+                sql.Append(string.Format(SchemaLikeFormat, ConvertPattern(_schemaPattern)));
+            if (_tablePattern != null)
+                sql.Append(string.Format(LikeFormat, ConvertPattern(_tablePattern)));
+            return sql.ToString();
+        }
+    }
+}

--- a/csharp/src/StatementExecution/StatementExecutionClient.cs
+++ b/csharp/src/StatementExecution/StatementExecutionClient.cs
@@ -220,6 +220,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 Content = content
             };
 
+            if (request.IsMetadata)
+            {
+                httpRequest.Headers.TryAddWithoutValidation("x-databricks-sea-can-run-fully-sync", "true");
+            }
+
             var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessStatusCodeAsync(response).ConfigureAwait(false);

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -16,15 +16,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Http;
+using AdbcDrivers.HiveServer2.Hive2;
+using AdbcDrivers.Databricks.StatementExecution.MetadataCommands;
+using AdbcDrivers.HiveServer2.Spark;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
-using AdbcDrivers.HiveServer2.Spark;
 using Apache.Arrow.Adbc.Tracing;
 using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using static Apache.Arrow.Adbc.AdbcConnection;
 
 namespace AdbcDrivers.Databricks.StatementExecution
 {
@@ -33,7 +38,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
     /// Manages session lifecycle and creates statements for query execution.
     /// Extends TracingConnection for consistent tracing support with Thrift protocol.
     /// </summary>
-    internal class StatementExecutionConnection : TracingConnection
+    internal class StatementExecutionConnection : TracingConnection, IGetObjectsDataProvider
     {
         private readonly IStatementExecutionClient _client;
         private readonly string _warehouseId;
@@ -378,31 +383,305 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 this); // Pass connection as TracingConnection for tracing support
         }
 
-        /// <summary>
-        /// Gets objects (metadata) from the database.
-        /// </summary>
         public override IArrowArrayStream GetObjects(GetObjectsDepth depth, string? catalogPattern, string? schemaPattern, string? tableNamePattern, IReadOnlyList<string>? tableTypes, string? columnNamePattern)
         {
-            // TODO (PECO-2792): Implement metadata operations via SQL queries
-            throw new NotImplementedException("Metadata operations are not yet implemented for Statement Execution API (PECO-2792)");
+            return this.TraceActivity(activity =>
+            {
+                activity?.SetTag("depth", depth.ToString());
+                activity?.SetTag("catalog_pattern", catalogPattern ?? "(none)");
+                activity?.SetTag("schema_pattern", schemaPattern ?? "(none)");
+                activity?.SetTag("table_pattern", tableNamePattern ?? "(none)");
+                activity?.SetTag("column_pattern", columnNamePattern ?? "(none)");
+
+                using var cts = CreateMetadataTimeoutCts();
+                return GetObjectsResultBuilder.BuildGetObjectsResultAsync(
+                    this, depth, catalogPattern, schemaPattern,
+                    tableNamePattern, tableTypes, columnNamePattern,
+                    cts.Token).GetAwaiter().GetResult();
+            }, nameof(GetObjects));
         }
 
-        /// <summary>
-        /// Gets table types from the database.
-        /// </summary>
+        public override IArrowArrayStream GetInfo(IReadOnlyList<AdbcInfoCode> codes)
+        {
+            return this.TraceActivity(activity =>
+            {
+                var supportedCodes = new AdbcInfoCode[]
+                {
+                    AdbcInfoCode.DriverName,
+                    AdbcInfoCode.DriverVersion,
+                    AdbcInfoCode.DriverArrowVersion,
+                    AdbcInfoCode.VendorName,
+                    AdbcInfoCode.VendorVersion,
+                    AdbcInfoCode.VendorSql,
+                };
+
+                if (codes == null || codes.Count == 0)
+                    codes = supportedCodes;
+
+                activity?.SetTag("requested_codes", string.Join(",", codes));
+
+                var values = new Dictionary<AdbcInfoCode, object>
+                {
+                    { AdbcInfoCode.DriverName, "ADBC Databricks Driver" },
+                    { AdbcInfoCode.DriverVersion, AssemblyVersion },
+                    { AdbcInfoCode.DriverArrowVersion, "1.0.0" },
+                    { AdbcInfoCode.VendorName, "Databricks" },
+                    { AdbcInfoCode.VendorVersion, AssemblyVersion },
+                    { AdbcInfoCode.VendorSql, true },
+                };
+
+                return MetadataSchemaFactory.BuildGetInfoResult(codes, values);
+            }, nameof(GetInfo));
+        }
+
         public override IArrowArrayStream GetTableTypes()
         {
-            // TODO (PECO-2792): Implement metadata operations via SQL queries
-            throw new NotImplementedException("Metadata operations are not yet implemented for Statement Execution API (PECO-2792)");
+            return this.TraceActivity(activity =>
+            {
+                var builder = new StringArray.Builder();
+                builder.Append("TABLE");
+                builder.Append("VIEW");
+                var schema = new Schema(new[] { new Field("table_type", StringType.Default, false) }, null);
+                return new HiveInfoArrowStream(schema, new IArrowArray[] { builder.Build() });
+            }, nameof(GetTableTypes));
         }
 
-        /// <summary>
-        /// Gets the schema for a specific table.
-        /// </summary>
         public override Schema GetTableSchema(string? catalog, string? dbSchema, string tableName)
         {
-            // TODO (PECO-2792): Implement metadata operations via SQL queries
-            throw new NotImplementedException("Metadata operations are not yet implemented for Statement Execution API (PECO-2792)");
+            return this.TraceActivity(activity =>
+            {
+                activity?.SetTag("catalog", catalog ?? "(none)");
+                activity?.SetTag("db_schema", dbSchema ?? "(none)");
+                activity?.SetTag("table_name", tableName);
+
+                using var cts = CreateMetadataTimeoutCts();
+                string sql = new ShowColumnsCommand(
+                    catalog ?? _catalog, dbSchema, tableName).Build();
+                activity?.SetTag("sql_query", sql);
+                var batches = ExecuteMetadataSql(sql, cts.Token);
+
+                var fields = new List<Field>();
+                foreach (var batch in batches)
+                {
+                    var colNameArray = TryGetColumn<StringArray>(batch, "col_name");
+                    var columnTypeArray = TryGetColumn<StringArray>(batch, "columnType");
+                    var isNullableArray = TryGetColumn<StringArray>(batch, "isNullable");
+
+                    if (colNameArray == null || columnTypeArray == null) continue;
+
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (colNameArray.IsNull(i) || columnTypeArray.IsNull(i)) continue;
+
+                        string colName = colNameArray.GetString(i);
+                        string colType = columnTypeArray.GetString(i);
+                        bool nullable = isNullableArray == null || isNullableArray.IsNull(i) ||
+                            !isNullableArray.GetString(i).Equals("false", StringComparison.OrdinalIgnoreCase);
+
+                        short typeCode = ColumnMetadataHelper.GetDataTypeCode(colType);
+                        IArrowType arrowType = HiveServer2Connection.GetArrowType(typeCode, colType, false, null, null);
+                        fields.Add(new Field(colName, arrowType, nullable));
+                    }
+                }
+
+                activity?.SetTag("result_fields", fields.Count);
+                return new Schema(fields, null);
+            }, nameof(GetTableSchema));
+        }
+
+        // IGetObjectsDataProvider implementation
+
+        async Task<IReadOnlyList<string>> IGetObjectsDataProvider.GetCatalogsAsync(string? catalogPattern, CancellationToken cancellationToken)
+        {
+            string sql = new ShowCatalogsCommand(catalogPattern).Build();
+            var batches = await ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+            var result = new List<string>();
+            foreach (var batch in batches)
+            {
+                var catalogArray = TryGetColumn<StringArray>(batch, "catalog");
+                if (catalogArray == null) continue;
+                for (int i = 0; i < batch.Length; i++)
+                {
+                    if (!catalogArray.IsNull(i))
+                        result.Add(catalogArray.GetString(i));
+                }
+            }
+            return result;
+        }
+
+        async Task<IReadOnlyList<(string catalog, string schema)>> IGetObjectsDataProvider.GetSchemasAsync(string? catalogPattern, string? schemaPattern, CancellationToken cancellationToken)
+        {
+            string sql = new ShowSchemasCommand(catalogPattern, schemaPattern).Build();
+            var batches = await ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+            var result = new List<(string, string)>();
+            foreach (var batch in batches)
+            {
+                var schemaArray = TryGetColumn<StringArray>(batch, "databaseName");
+                if (schemaArray == null) continue;
+
+                // SHOW SCHEMAS IN ALL CATALOGS has catalog_name column;
+                // SHOW SCHEMAS IN `catalog` does not — use the catalogPattern as the catalog.
+                var catalogArray = TryGetColumn<StringArray>(batch, "catalog_name");
+
+                for (int i = 0; i < batch.Length; i++)
+                {
+                    if (schemaArray.IsNull(i)) continue;
+                    string catalog = catalogArray != null && !catalogArray.IsNull(i)
+                        ? catalogArray.GetString(i)
+                        : catalogPattern ?? "";
+                    result.Add((catalog, schemaArray.GetString(i)));
+                }
+            }
+            return result;
+        }
+
+        async Task<IReadOnlyList<(string catalog, string schema, string table, string tableType)>> IGetObjectsDataProvider.GetTablesAsync(
+            string? catalogPattern, string? schemaPattern, string? tableNamePattern, IReadOnlyList<string>? tableTypes, CancellationToken cancellationToken)
+        {
+            string sql = new ShowTablesCommand(catalogPattern, schemaPattern, tableNamePattern).Build();
+            var batches = await ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+            var result = new List<(string, string, string, string)>();
+            foreach (var batch in batches)
+            {
+                var catalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                var schemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                var tableArray = TryGetColumn<StringArray>(batch, "tableName");
+                var tableTypeArray = TryGetColumn<StringArray>(batch, "tableType");
+
+                if (catalogArray == null || schemaArray == null || tableArray == null) continue;
+
+                for (int i = 0; i < batch.Length; i++)
+                {
+                    if (catalogArray.IsNull(i) || schemaArray.IsNull(i) || tableArray.IsNull(i)) continue;
+
+                    string tableType = "TABLE";
+                    if (tableTypeArray != null && !tableTypeArray.IsNull(i))
+                    {
+                        string serverType = tableTypeArray.GetString(i);
+                        if (!string.IsNullOrEmpty(serverType))
+                            tableType = serverType;
+                    }
+
+                    if (tableTypes != null && tableTypes.Count > 0 && !tableTypes.Contains(tableType))
+                        continue;
+
+                    result.Add((catalogArray.GetString(i), schemaArray.GetString(i),
+                        tableArray.GetString(i), tableType));
+                }
+            }
+            return result;
+        }
+
+        async Task IGetObjectsDataProvider.PopulateColumnInfoAsync(string? catalogPattern, string? schemaPattern,
+            string? tablePattern, string? columnPattern,
+            Dictionary<string, Dictionary<string, Dictionary<string, TableInfo>>> catalogMap,
+            CancellationToken cancellationToken)
+        {
+            string sql = new ShowColumnsCommand(catalogPattern, schemaPattern, tablePattern, columnPattern).Build();
+            var batches = await ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+
+            var tablePositions = new Dictionary<string, int>();
+
+            foreach (var batch in batches)
+            {
+                var catalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                var schemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                var tableNameArray = TryGetColumn<StringArray>(batch, "tableName");
+                var colNameArray = TryGetColumn<StringArray>(batch, "col_name");
+                var columnTypeArray = TryGetColumn<StringArray>(batch, "columnType");
+                var isNullableArray = TryGetColumn<StringArray>(batch, "isNullable");
+
+                if (catalogArray == null || schemaArray == null || tableNameArray == null ||
+                    colNameArray == null || columnTypeArray == null) continue;
+
+                for (int i = 0; i < batch.Length; i++)
+                {
+                    if (catalogArray.IsNull(i) || schemaArray.IsNull(i) || tableNameArray.IsNull(i) ||
+                        colNameArray.IsNull(i) || columnTypeArray.IsNull(i)) continue;
+
+                    string cat = catalogArray.GetString(i);
+                    string sch = schemaArray.GetString(i);
+                    string tbl = tableNameArray.GetString(i);
+                    string colName = colNameArray.GetString(i);
+                    string colType = columnTypeArray.GetString(i);
+
+                    if (string.IsNullOrEmpty(colName)) continue;
+
+                    string tableKey = $"{cat}.{sch}.{tbl}";
+                    if (!tablePositions.ContainsKey(tableKey))
+                        tablePositions[tableKey] = 1;
+                    int position = tablePositions[tableKey]++;
+
+                    bool nullable = isNullableArray == null || isNullableArray.IsNull(i) ||
+                        !isNullableArray.GetString(i).Equals("false", StringComparison.OrdinalIgnoreCase);
+
+                    if (catalogMap.TryGetValue(cat, out var schemaMap)
+                        && schemaMap.TryGetValue(sch, out var tableMap)
+                        && tableMap.TryGetValue(tbl, out var tableInfo))
+                    {
+                        ColumnMetadataHelper.PopulateTableInfoFromTypeName(
+                            tableInfo, colName, colType, position, nullable);
+
+                        // Match Thrift GetObjects behavior: SparkConnection.SetPrecisionScaleAndTypeName
+                        // sets Precision/Scale to null for non-DECIMAL/CHAR types in the nested path.
+                        int lastIdx = tableInfo.Precision.Count - 1;
+                        short typeCode = tableInfo.ColType[lastIdx];
+                        if (typeCode != (short)HiveServer2Connection.ColumnTypeId.DECIMAL
+                            && typeCode != (short)HiveServer2Connection.ColumnTypeId.NUMERIC
+                            && typeCode != (short)HiveServer2Connection.ColumnTypeId.CHAR
+                            && typeCode != (short)HiveServer2Connection.ColumnTypeId.NCHAR
+                            && typeCode != (short)HiveServer2Connection.ColumnTypeId.VARCHAR
+                            && typeCode != (short)HiveServer2Connection.ColumnTypeId.NVARCHAR
+                            && typeCode != (short)HiveServer2Connection.ColumnTypeId.LONGVARCHAR
+                            && typeCode != (short)HiveServer2Connection.ColumnTypeId.LONGNVARCHAR)
+                        {
+                            tableInfo.Precision[lastIdx] = null;
+                            tableInfo.Scale[lastIdx] = null;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static T? TryGetColumn<T>(RecordBatch batch, string name) where T : class, IArrowArray
+        {
+            try
+            {
+                return batch.Column(name) as T;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return null;
+            }
+        }
+
+        internal async Task<List<RecordBatch>> ExecuteMetadataSqlAsync(string sql, CancellationToken cancellationToken = default)
+        {
+            var batches = new List<RecordBatch>();
+            using var stmt = (StatementExecutionStatement)CreateStatement();
+            stmt.SqlQuery = sql;
+            stmt.IsMetadataExecution = true;
+            var result = await stmt.ExecuteQueryAsync(cancellationToken).ConfigureAwait(false);
+            using var stream = result.Stream;
+            if (stream == null) return batches;
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var batch = await stream.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false);
+                if (batch == null) break;
+                batches.Add(batch);
+            }
+            return batches;
+        }
+
+        internal List<RecordBatch> ExecuteMetadataSql(string sql, CancellationToken cancellationToken = default)
+        {
+            return ExecuteMetadataSqlAsync(sql, cancellationToken).GetAwaiter().GetResult();
+        }
+
+        internal CancellationTokenSource CreateMetadataTimeoutCts()
+        {
+            return new CancellationTokenSource(TimeSpan.FromSeconds(_waitTimeoutSeconds));
         }
 
         /// <summary>

--- a/csharp/src/StatementExecution/StatementExecutionModels.cs
+++ b/csharp/src/StatementExecution/StatementExecutionModels.cs
@@ -167,6 +167,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
         public string? OnWaitTimeout { get; set; }
 
         /// <summary>
+        /// Client-side flag indicating this is a metadata operation.
+        /// Not serialized to JSON — used to add the x-databricks-sea-can-run-fully-sync header.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsMetadata { get; set; }
+
+        /// <summary>
         /// Maximum number of rows to return.
         /// </summary>
         [JsonPropertyName("row_limit")]

--- a/csharp/test/Unit/Result/DescTableExtendedResultTest.cs
+++ b/csharp/test/Unit/Result/DescTableExtendedResultTest.cs
@@ -351,7 +351,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Result
         [InlineData("CHAR", ColumnTypeId.CHAR, false, 20)]
         [InlineData("VARCHAR", ColumnTypeId.VARCHAR, false, 20)]
         [InlineData("STRING", ColumnTypeId.VARCHAR, false, int.MaxValue)]
-        [InlineData("BINARY", ColumnTypeId.BINARY, false, 0)]
+        [InlineData("BINARY", ColumnTypeId.BINARY, false, int.MaxValue)]
         [InlineData("DATE", ColumnTypeId.DATE, false, 4)]
         [InlineData("TIMESTAMP", ColumnTypeId.TIMESTAMP, false, 8)]
         [InlineData("TIMESTAMP_LTZ", ColumnTypeId.TIMESTAMP, false, 8)]


### PR DESCRIPTION
## 🥞 Stacked PR

- [feat/sea-metadata-part1](https://github.com/adbc-drivers/databricks/pull/257) [[Files changed](https://github.com/adbc-drivers/databricks/pull/257/files)]
  - [feat/sea-metadata-part2](https://github.com/adbc-drivers/databricks/pull/258) [[Files changed](https://github.com/adbc-drivers/databricks/pull/258/files/3c9e2bf..4b3f22b)]
    - [feat/sea-metadata-part3](https://github.com/adbc-drivers/databricks/pull/259) [[Files changed](https://github.com/adbc-drivers/databricks/pull/259/files/4b3f22b..3e07fa0)]
      - [feat/sea-metadata-part4](https://github.com/adbc-drivers/databricks/pull/260) [[Files changed](https://github.com/adbc-drivers/databricks/pull/260/files/3e07fa0..cd97cce)]
        - [feat/sea-metadata-part5](https://github.com/adbc-drivers/databricks/pull/261) [[Files changed](https://github.com/adbc-drivers/databricks/pull/261/files/cd97cce..6c4819e)]
          - [feat/sea-metadata-part6](https://github.com/adbc-drivers/databricks/pull/282) [[Files changed](https://github.com/adbc-drivers/databricks/pull/282/files/6c4819e..d30c12b)]

## Summary

Core SEA metadata infrastructure and connection-level operations.

### Connection-level metadata
- **GetObjects**: async `IGetObjectsDataProvider` with shared `CancellationToken` per operation
- **GetTableSchema**: via SHOW COLUMNS + shared `HiveServer2Connection.GetArrowType`
- **GetTableTypes**: returns TABLE, VIEW
- **GetInfo**: via shared `MetadataSchemaFactory.BuildGetInfoResult`
- **GetObjects xdbc_column_size/xdbc_decimal_digits**: nulled for non-DECIMAL/CHAR to match Thrift

### SQL command builders (`MetadataCommands/`)
- `MetadataCommandBase` with `ConvertPattern`, `QuoteIdentifier`, `AppendCatalogScope`
- `ShowCatalogs`, `ShowSchemas`, `ShowTables`, `ShowColumns`, `ShowKeys`, `ShowForeignKeys`

### HTTP & protocol
- `x-databricks-sea-can-run-fully-sync` header on metadata requests via `IsMetadata` flag
- `ExecuteMetadataSqlAsync` — async SQL execution for metadata
- `CreateMetadataTimeoutCts` — disposable CTS with configurable timeout

### Utilities
- `MetadataUtilities`: `NormalizeSparkCatalog`, `IsInvalidPKFKCatalog`, `BuildQualifiedTableName`
- `DescTableExtendedResult`: REAL→FLOAT via `ColumnMetadataHelper.GetDataTypeCode` directly

### Also includes
- `DatabricksStatement` wired to shared `MetadataSchemaFactory`
- `sea-metadata-design.md` architecture documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)