### PR TITLE
feat(csharp): add ColumnMetadataHelper, FlatColumnsResultBuilder, and statement-level metadata routing

### DIFF
--- a/csharp/src/ColumnMetadataHelper.cs
+++ b/csharp/src/ColumnMetadataHelper.cs
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using AdbcDrivers.HiveServer2.Hive2;
+using static AdbcDrivers.HiveServer2.Hive2.HiveServer2Connection;
+
+namespace AdbcDrivers.Databricks
+{
+    /// <summary>
+    /// Computes column metadata (data type codes, column sizes, decimal digits,
+    /// buffer lengths, etc.) from SQL type name strings. Provides defaults for
+    /// metadata fields that are not returned directly by the server.
+    /// </summary>
+    internal static class ColumnMetadataHelper
+    {
+        private static readonly Dictionary<string, short> s_baseTypeToCodeMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "BOOLEAN", (short)ColumnTypeId.BOOLEAN },
+            { "TINYINT", (short)ColumnTypeId.TINYINT },
+            { "SMALLINT", (short)ColumnTypeId.SMALLINT },
+            { "INTEGER", (short)ColumnTypeId.INTEGER },
+            { "BIGINT", (short)ColumnTypeId.BIGINT },
+            { "FLOAT", (short)ColumnTypeId.FLOAT },
+            { "REAL", (short)ColumnTypeId.FLOAT },
+            { "DOUBLE", (short)ColumnTypeId.DOUBLE },
+            { "DECIMAL", (short)ColumnTypeId.DECIMAL },
+            { "NUMERIC", (short)ColumnTypeId.NUMERIC },
+            { "CHAR", (short)ColumnTypeId.CHAR },
+            { "NCHAR", (short)ColumnTypeId.NCHAR },
+            { "STRING", (short)ColumnTypeId.VARCHAR },
+            { "VARCHAR", (short)ColumnTypeId.VARCHAR },
+            { "NVARCHAR", (short)ColumnTypeId.NVARCHAR },
+            { "LONGVARCHAR", (short)ColumnTypeId.LONGVARCHAR },
+            { "LONGNVARCHAR", (short)ColumnTypeId.LONGNVARCHAR },
+            { "BINARY", (short)ColumnTypeId.BINARY },
+            { "VARBINARY", (short)ColumnTypeId.VARBINARY },
+            { "LONGVARBINARY", (short)ColumnTypeId.LONGVARBINARY },
+            { "DATE", (short)ColumnTypeId.DATE },
+            { "TIMESTAMP", (short)ColumnTypeId.TIMESTAMP },
+            { "ARRAY", (short)ColumnTypeId.ARRAY },
+            { "MAP", (short)ColumnTypeId.JAVA_OBJECT },
+            { "STRUCT", (short)ColumnTypeId.STRUCT },
+            { "NULL", (short)ColumnTypeId.NULL },
+            { "VOID", (short)ColumnTypeId.NULL },
+            { "INTERVAL", (short)ColumnTypeId.OTHER },
+            { "VARIANT", (short)ColumnTypeId.OTHER },
+            { "OTHER", (short)ColumnTypeId.OTHER },
+        };
+
+        private static readonly Dictionary<string, string> s_aliasToBaseType = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "BYTE", "TINYINT" },
+            { "SHORT", "SMALLINT" },
+            { "LONG", "BIGINT" },
+        };
+
+        private static readonly HashSet<string> s_numericBaseTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "TINYINT", "SMALLINT", "INTEGER", "BIGINT",
+            "FLOAT", "REAL", "DOUBLE", "DECIMAL", "NUMERIC"
+        };
+
+        private static readonly HashSet<string> s_charBaseTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "STRING", "VARCHAR", "CHAR", "NCHAR", "NVARCHAR",
+            "LONGVARCHAR", "LONGNVARCHAR"
+        };
+
+        internal static short GetDataTypeCode(string typeName)
+        {
+            string baseName = GetBaseTypeName(typeName);
+            if (s_baseTypeToCodeMap.TryGetValue(baseName, out short code))
+                return code;
+            return (short)ColumnTypeId.OTHER;
+        }
+
+        internal static string GetBaseTypeName(string typeName)
+        {
+            if (SqlTypeNameParser<SqlTypeNameParserResult>.TryParse(typeName, out SqlTypeNameParserResult? result))
+            {
+                return result!.BaseTypeName;
+            }
+            string upper = typeName.Trim().ToUpperInvariant();
+            if (s_aliasToBaseType.TryGetValue(upper, out string? canonical))
+                return canonical;
+            return upper;
+        }
+
+        internal static int? GetColumnSizeDefault(string typeName)
+        {
+            string baseName = GetBaseTypeName(typeName);
+            switch (baseName)
+            {
+                case "BOOLEAN":
+                case "TINYINT":
+                    return 1;
+                case "SMALLINT":
+                    return 2;
+                case "INTEGER":
+                case "FLOAT":
+                case "REAL":
+                case "DATE":
+                    return 4;
+                case "BIGINT":
+                case "DOUBLE":
+                case "TIMESTAMP":
+                    return 8;
+                case "DECIMAL":
+                case "NUMERIC":
+                    return GetParsedPrecision(typeName) ?? SqlDecimalTypeParser.DecimalPrecisionDefault;
+                case "VARCHAR":
+                case "LONGVARCHAR":
+                case "LONGNVARCHAR":
+                case "NVARCHAR":
+                    return GetParsedColumnSize(typeName) ?? SqlVarcharTypeParser.VarcharColumnSizeDefault;
+                case "STRING":
+                    return int.MaxValue;
+                case "CHAR":
+                case "NCHAR":
+                    return GetParsedColumnSize(typeName) ?? 255;
+                case "BINARY":
+                case "VARBINARY":
+                case "LONGVARBINARY":
+                    return 0;
+                case "NULL":
+                case "VOID":
+                    return 1;
+                case "INTERVAL":
+                    return GetIntervalSize(typeName);
+                default:
+                    return 0;
+            }
+        }
+
+        internal static int? GetDecimalDigitsDefault(string typeName)
+        {
+            string baseName = GetBaseTypeName(typeName);
+            return baseName switch
+            {
+                "DECIMAL" or "NUMERIC" => GetParsedScale(typeName) ?? SqlDecimalTypeParser.DecimalScaleDefault,
+                "FLOAT" or "REAL" => 7,
+                "DOUBLE" => 15,
+                "TIMESTAMP" => 6,
+                _ => 0
+            };
+        }
+
+        internal static int? GetBufferLength(string typeName)
+        {
+            string baseName = GetBaseTypeName(typeName);
+            switch (baseName)
+            {
+                case "BOOLEAN":
+                case "TINYINT":
+                    return 1;
+                case "SMALLINT":
+                    return 2;
+                case "INTEGER":
+                case "FLOAT":
+                case "REAL":
+                    return 4;
+                case "BIGINT":
+                case "DOUBLE":
+                case "TIMESTAMP":
+                case "DATE":
+                    return 8;
+                case "DECIMAL":
+                case "NUMERIC":
+                    int precision = GetParsedPrecision(typeName) ?? SqlDecimalTypeParser.DecimalPrecisionDefault;
+                    return ((precision + 8) / 9) * 5 + 1;
+                default:
+                    return null;
+            }
+        }
+
+        internal static short? GetNumPrecRadix(string typeName)
+        {
+            string baseName = GetBaseTypeName(typeName);
+            return s_numericBaseTypes.Contains(baseName) ? (short)10 : null;
+        }
+
+        internal static int? GetCharOctetLength(string typeName)
+        {
+            string baseName = GetBaseTypeName(typeName);
+            return s_charBaseTypes.Contains(baseName) ? GetColumnSizeDefault(typeName) : null;
+        }
+
+        internal static short? GetSqlDatetimeSub(string typeName)
+        {
+            string baseName = GetBaseTypeName(typeName);
+            return baseName switch
+            {
+                "DATE" => 1,
+                "TIMESTAMP" => 3,
+                _ => null
+            };
+        }
+
+        internal static void PopulateTableInfoFromTypeName(
+            TableInfo tableInfo,
+            string columnName,
+            string typeName,
+            int ordinalPosition,
+            bool isNullable = true,
+            string? comment = null,
+            string? columnDefault = null)
+        {
+            tableInfo.ColumnName.Add(columnName);
+            tableInfo.TypeName.Add(typeName);
+            tableInfo.ColType.Add(GetDataTypeCode(typeName));
+            tableInfo.BaseTypeName.Add(GetBaseTypeName(typeName));
+            tableInfo.Precision.Add(GetColumnSizeDefault(typeName));
+            int? scale = GetDecimalDigitsDefault(typeName);
+            tableInfo.Scale.Add(scale.HasValue ? (short)scale.Value : null);
+            tableInfo.OrdinalPosition.Add(ordinalPosition);
+            tableInfo.Nullable.Add(isNullable ? (short)1 : (short)0);
+            tableInfo.IsNullable.Add(isNullable ? "YES" : "NO");
+            tableInfo.IsAutoIncrement.Add(false);
+            tableInfo.ColumnDefault.Add(columnDefault ?? "");
+        }
+
+        private static int? GetParsedPrecision(string typeName)
+        {
+            if (SqlTypeNameParser<SqlDecimalParserResult>.TryParse(typeName, out SqlTypeNameParserResult? result)
+                && result is SqlDecimalParserResult decimalResult)
+                return decimalResult.Precision;
+            return null;
+        }
+
+        private static int? GetParsedScale(string typeName)
+        {
+            if (SqlTypeNameParser<SqlDecimalParserResult>.TryParse(typeName, out SqlTypeNameParserResult? result)
+                && result is SqlDecimalParserResult decimalResult)
+                return decimalResult.Scale;
+            return null;
+        }
+
+        private static int? GetParsedColumnSize(string typeName)
+        {
+            if (SqlTypeNameParser<SqlCharVarcharParserResult>.TryParse(typeName, out SqlTypeNameParserResult? result)
+                && result is SqlCharVarcharParserResult charResult)
+                return charResult.ColumnSize;
+            return null;
+        }
+
+        private static int GetIntervalSize(string typeName)
+        {
+            string upper = typeName.Trim().ToUpperInvariant();
+            if (upper.Contains("YEAR") || upper.Contains("MONTH"))
+                return 4;
+            if (upper.Contains("DAY") || upper.Contains("HOUR") || upper.Contains("MINUTE") || upper.Contains("SECOND"))
+                return 8;
+            return 4;
+        }
+    }
+}

--- a/csharp/src/FlatColumnsResultBuilder.cs
+++ b/csharp/src/FlatColumnsResultBuilder.cs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using AdbcDrivers.HiveServer2;
+using AdbcDrivers.HiveServer2.Hive2;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+
+namespace AdbcDrivers.Databricks
+{
+    /// <summary>
+    /// Builds a flat columns result set with all 24 standard metadata columns,
+    /// including computed fields like BUFFER_LENGTH, NUM_PREC_RADIX,
+    /// SQL_DATETIME_SUB, and CHAR_OCTET_LENGTH.
+    /// </summary>
+    internal static class FlatColumnsResultBuilder
+    {
+        internal static QueryResult BuildFlatColumnsResult(
+            IEnumerable<(string catalog, string schema, string table, TableInfo info)> tables)
+        {
+            var tableCatBuilder = new StringArray.Builder();
+            var tableSchemaBuilder = new StringArray.Builder();
+            var tableNameBuilder = new StringArray.Builder();
+            var columnNameBuilder = new StringArray.Builder();
+            var dataTypeBuilder = new Int32Array.Builder();
+            var typeNameBuilder = new StringArray.Builder();
+            var columnSizeBuilder = new Int32Array.Builder();
+            var bufferLengthBuilder = new Int32Array.Builder();
+            var decimalDigitsBuilder = new Int32Array.Builder();
+            var numPrecRadixBuilder = new Int32Array.Builder();
+            var nullableBuilder = new Int32Array.Builder();
+            var remarksBuilder = new StringArray.Builder();
+            var columnDefBuilder = new StringArray.Builder();
+            var sqlDataTypeBuilder = new Int32Array.Builder();
+            var sqlDatetimeSubBuilder = new Int32Array.Builder();
+            var charOctetLengthBuilder = new Int32Array.Builder();
+            var ordinalPositionBuilder = new Int32Array.Builder();
+            var isNullableBuilder = new StringArray.Builder();
+            var scopeCatalogBuilder = new StringArray.Builder();
+            var scopeSchemaBuilder = new StringArray.Builder();
+            var scopeTableBuilder = new StringArray.Builder();
+            var sourceDataTypeBuilder = new Int16Array.Builder();
+            var isAutoIncrementBuilder = new StringArray.Builder();
+            var baseTypeNameBuilder = new StringArray.Builder();
+            int totalRows = 0;
+
+            foreach (var (catalog, schema, table, info) in tables)
+            {
+                for (int i = 0; i < info.ColumnName.Count; i++)
+                {
+                    tableCatBuilder.Append(catalog);
+                    tableSchemaBuilder.Append(schema);
+                    tableNameBuilder.Append(table);
+                    columnNameBuilder.Append(info.ColumnName[i]);
+                    dataTypeBuilder.Append(info.ColType[i]);
+                    typeNameBuilder.Append(info.TypeName[i]);
+
+                    if (info.Precision[i].HasValue) columnSizeBuilder.Append(info.Precision[i]!.Value); else columnSizeBuilder.AppendNull();
+
+                    int? bufLen = ColumnMetadataHelper.GetBufferLength(info.TypeName[i]);
+                    if (bufLen.HasValue) bufferLengthBuilder.Append(bufLen.Value); else bufferLengthBuilder.AppendNull();
+
+                    if (info.Scale[i].HasValue) decimalDigitsBuilder.Append(info.Scale[i]!.Value); else decimalDigitsBuilder.AppendNull();
+
+                    short? radix = ColumnMetadataHelper.GetNumPrecRadix(info.TypeName[i]);
+                    if (radix.HasValue) numPrecRadixBuilder.Append(radix.Value); else numPrecRadixBuilder.AppendNull();
+
+                    nullableBuilder.Append(info.Nullable[i]);
+                    remarksBuilder.Append("");
+                    columnDefBuilder.AppendNull();
+
+                    sqlDataTypeBuilder.Append(info.ColType[i]);
+
+                    short? dtSub = ColumnMetadataHelper.GetSqlDatetimeSub(info.TypeName[i]);
+                    if (dtSub.HasValue) sqlDatetimeSubBuilder.Append(dtSub.Value); else sqlDatetimeSubBuilder.AppendNull();
+
+                    int? charOctet = ColumnMetadataHelper.GetCharOctetLength(info.TypeName[i]);
+                    if (charOctet.HasValue) charOctetLengthBuilder.Append(charOctet.Value); else charOctetLengthBuilder.AppendNull();
+
+                    ordinalPositionBuilder.Append(info.OrdinalPosition[i]);
+                    isNullableBuilder.Append(info.IsNullable[i]);
+                    scopeCatalogBuilder.AppendNull();
+                    scopeSchemaBuilder.AppendNull();
+                    scopeTableBuilder.AppendNull();
+                    sourceDataTypeBuilder.AppendNull();
+                    isAutoIncrementBuilder.Append(info.IsAutoIncrement[i] ? "YES" : "NO");
+                    baseTypeNameBuilder.Append(info.BaseTypeName[i]);
+                    totalRows++;
+                }
+            }
+
+            var resultSchema = MetadataSchemaFactory.CreateColumnMetadataSchema();
+
+            var dataArrays = new IArrowArray[]
+            {
+                tableCatBuilder.Build(),
+                tableSchemaBuilder.Build(),
+                tableNameBuilder.Build(),
+                columnNameBuilder.Build(),
+                dataTypeBuilder.Build(),
+                typeNameBuilder.Build(),
+                columnSizeBuilder.Build(),
+                bufferLengthBuilder.Build(),
+                decimalDigitsBuilder.Build(),
+                numPrecRadixBuilder.Build(),
+                nullableBuilder.Build(),
+                remarksBuilder.Build(),
+                columnDefBuilder.Build(),
+                sqlDataTypeBuilder.Build(),
+                sqlDatetimeSubBuilder.Build(),
+                charOctetLengthBuilder.Build(),
+                ordinalPositionBuilder.Build(),
+                isNullableBuilder.Build(),
+                scopeCatalogBuilder.Build(),
+                scopeSchemaBuilder.Build(),
+                scopeTableBuilder.Build(),
+                sourceDataTypeBuilder.Build(),
+                isAutoIncrementBuilder.Build(),
+                baseTypeNameBuilder.Build()
+            };
+
+            return new QueryResult(totalRows, new HiveInfoArrowStream(resultSchema, dataArrays));
+        }
+    }
+}

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -22,6 +22,10 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Reader.CloudFetch;
+using AdbcDrivers.Databricks.StatementExecution.MetadataCommands;
+using AdbcDrivers.Databricks.Result;
+using AdbcDrivers.HiveServer2;
+using AdbcDrivers.HiveServer2.Hive2;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tracing;
@@ -60,9 +64,25 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // HTTP client for CloudFetch downloads
         private readonly HttpClient _httpClient;
 
+        // Connection reference for metadata queries
+        private readonly StatementExecutionConnection _connection;
+
         // Statement state
         private string? _currentStatementId;
         private string? _sqlQuery;
+
+        // Metadata command support
+        private bool _isMetadataCommand;
+        private bool _isMetadataExecution;
+        private bool _escapePatternWildcards;
+        private string? _metadataCatalogName;
+        private string? _metadataSchemaName;
+        private string? _metadataTableName;
+        private string? _metadataColumnName;
+        private string? _metadataTableTypes;
+        private string? _metadataForeignCatalogName;
+        private string? _metadataForeignSchemaName;
+        private string? _metadataForeignTableName;
 
         public StatementExecutionStatement(
             IStatementExecutionClient client,
@@ -80,8 +100,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
             System.Buffers.ArrayPool<byte> lz4BufferPool,
             HttpClient httpClient,
             StatementExecutionConnection connection)
-            : base(connection) // Initialize TracingStatement base class with TracingConnection
+            : base(connection)
         {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _sessionId = sessionId;
             _warehouseId = warehouseId ?? throw new ArgumentNullException(nameof(warehouseId));
@@ -108,18 +129,75 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
-        /// Executes the query and returns a result set.
+        /// Marks this statement as a metadata operation so the HTTP request includes
+        /// the x-databricks-sea-can-run-fully-sync header for optimized server execution.
         /// </summary>
+        internal bool IsMetadataExecution
+        {
+            set => _isMetadataExecution = value;
+        }
+
+        public override void SetOption(string key, string value)
+        {
+            switch (key)
+            {
+                case ApacheParameters.IsMetadataCommand:
+                    _isMetadataCommand = bool.TryParse(value, out bool b) && b;
+                    break;
+                case ApacheParameters.CatalogName:
+                    _metadataCatalogName = value;
+                    break;
+                case ApacheParameters.SchemaName:
+                    _metadataSchemaName = value;
+                    break;
+                case ApacheParameters.TableName:
+                    _metadataTableName = value;
+                    break;
+                case ApacheParameters.ColumnName:
+                    _metadataColumnName = value;
+                    break;
+                case ApacheParameters.ForeignCatalogName:
+                    _metadataForeignCatalogName = value;
+                    break;
+                case ApacheParameters.ForeignSchemaName:
+                    _metadataForeignSchemaName = value;
+                    break;
+                case ApacheParameters.ForeignTableName:
+                    _metadataForeignTableName = value;
+                    break;
+                case ApacheParameters.TableTypes:
+                    _metadataTableTypes = value;
+                    break;
+                case ApacheParameters.EscapePatternWildcards:
+                    _escapePatternWildcards = bool.TryParse(value, out bool escape) && escape;
+                    break;
+
+                // These options are readonly in SEA (set at connection level).
+                // Accept but ignore them to avoid NotImplemented exceptions for compatibility.
+                case ApacheParameters.PollTimeMilliseconds:
+                case ApacheParameters.BatchSize:
+                case ApacheParameters.BatchSizeStopCondition:
+                case ApacheParameters.QueryTimeoutSeconds:
+                    break;
+
+                default:
+                    base.SetOption(key, value);
+                    break;
+            }
+        }
+
         public override QueryResult ExecuteQuery()
         {
             return ExecuteQueryAsync(CancellationToken.None).GetAwaiter().GetResult();
         }
 
-        /// <summary>
-        /// Executes the query asynchronously and returns a result set.
-        /// </summary>
         public async Task<QueryResult> ExecuteQueryAsync(CancellationToken cancellationToken = default)
         {
+            if (_isMetadataCommand)
+            {
+                return await ExecuteMetadataCommandAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             if (string.IsNullOrEmpty(_sqlQuery))
             {
                 throw new InvalidOperationException("SQL query is required");
@@ -139,7 +217,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 Format = _resultFormat,
                 ResultCompression = _resultCompression,
                 WaitTimeout = $"{_waitTimeoutSeconds}s",
-                OnWaitTimeout = "CONTINUE"
+                OnWaitTimeout = "CONTINUE",
+                IsMetadata = _isMetadataExecution
             };
 
             // Execute the statement
@@ -416,7 +495,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 Format = _resultFormat,
                 ResultCompression = _resultCompression,
                 WaitTimeout = $"{_waitTimeoutSeconds}s",
-                OnWaitTimeout = "CONTINUE"
+                OnWaitTimeout = "CONTINUE",
+                IsMetadata = _isMetadataExecution
             };
 
             // Execute the statement
@@ -611,6 +691,421 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
                 return result;
             }
+        }
+
+        // Metadata command routing
+
+        private string? EffectiveCatalog => MetadataUtilities.NormalizeSparkCatalog(_metadataCatalogName) ?? _catalog;
+
+        /// <summary>
+        /// Escapes wildcard characters (_ and %) in metadata name parameters when
+        /// EscapePatternWildcards is enabled. This prevents literal underscores or
+        /// percent signs in identifiers from being treated as pattern wildcards.
+        /// </summary>
+        private string? EscapePatternWildcardsInName(string? name)
+        {
+            if (!_escapePatternWildcards || name == null)
+                return name;
+            return name.Replace("_", "\\_").Replace("%", "\\%");
+        }
+
+        private Task<QueryResult> ExecuteMetadataCommandAsync(CancellationToken cancellationToken)
+        {
+            return _sqlQuery?.ToLowerInvariant() switch
+            {
+                "getcatalogs" => GetCatalogsAsync(cancellationToken),
+                "getschemas" => GetSchemasAsync(cancellationToken),
+                "gettables" => GetTablesAsync(cancellationToken),
+                "getcolumns" => GetColumnsAsync(cancellationToken),
+                "getcolumnsextended" => GetColumnsExtendedAsync(cancellationToken),
+                "getprimarykeys" => GetPrimaryKeysAsync(cancellationToken),
+                "getcrossreference" => GetCrossReferenceAsync(cancellationToken),
+                _ => throw new NotSupportedException($"Metadata command '{_sqlQuery}' is not supported"),
+            };
+        }
+
+        private async Task<QueryResult> GetCatalogsAsync(CancellationToken cancellationToken)
+        {
+            return await this.TraceActivityAsync(async activity =>
+            {
+                activity?.SetTag("catalog_pattern", _metadataCatalogName ?? "(none)");
+
+                string sql = new ShowCatalogsCommand(EscapePatternWildcardsInName(_metadataCatalogName)).Build();
+                activity?.SetTag("sql_query", sql);
+                var batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+
+                var tableCatBuilder = new StringArray.Builder();
+                int count = 0;
+                foreach (var batch in batches)
+                {
+                    var catalogArray = TryGetColumn<StringArray>(batch, "catalog");
+                    if (catalogArray == null) continue;
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (!catalogArray.IsNull(i))
+                        {
+                            tableCatBuilder.Append(catalogArray.GetString(i));
+                            count++;
+                        }
+                    }
+                }
+
+                activity?.SetTag("result_count", count);
+                var schema = MetadataSchemaFactory.CreateCatalogsSchema();
+                return new QueryResult(count, new HiveInfoArrowStream(schema, new IArrowArray[] { tableCatBuilder.Build() }));
+            }, "GetCatalogs").ConfigureAwait(false);
+        }
+
+        private async Task<QueryResult> GetSchemasAsync(CancellationToken cancellationToken)
+        {
+            return await this.TraceActivityAsync(async activity =>
+            {
+                activity?.SetTag("catalog", EffectiveCatalog ?? "(none)");
+                activity?.SetTag("schema_pattern", _metadataSchemaName ?? "(none)");
+
+                string sql = new ShowSchemasCommand(
+                    EffectiveCatalog,
+                    EscapePatternWildcardsInName(_metadataSchemaName)).Build();
+                activity?.SetTag("sql_query", sql);
+                var batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+
+                var tableSchemaBuilder = new StringArray.Builder();
+                var tableCatalogBuilder = new StringArray.Builder();
+                int count = 0;
+                foreach (var batch in batches)
+                {
+                    var schemaArray = TryGetColumn<StringArray>(batch, "databaseName");
+                    var catalogArray = TryGetColumn<StringArray>(batch, "catalog_name");
+                    if (schemaArray == null) continue;
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (schemaArray.IsNull(i)) continue;
+                        tableSchemaBuilder.Append(schemaArray.GetString(i));
+                        string catalog = catalogArray != null && !catalogArray.IsNull(i)
+                            ? catalogArray.GetString(i)
+                            : EffectiveCatalog ?? "";
+                        tableCatalogBuilder.Append(catalog);
+                        count++;
+                    }
+                }
+
+                activity?.SetTag("result_count", count);
+                var schema = MetadataSchemaFactory.CreateSchemasSchema();
+                return new QueryResult(count, new HiveInfoArrowStream(schema, new IArrowArray[]
+                {
+                    tableSchemaBuilder.Build(), tableCatalogBuilder.Build()
+                }));
+            }, "GetSchemas").ConfigureAwait(false);
+        }
+
+        private async Task<QueryResult> GetTablesAsync(CancellationToken cancellationToken)
+        {
+            return await this.TraceActivityAsync(async activity =>
+            {
+                activity?.SetTag("catalog", EffectiveCatalog ?? "(none)");
+                activity?.SetTag("schema_pattern", _metadataSchemaName ?? "(none)");
+                activity?.SetTag("table_pattern", _metadataTableName ?? "(none)");
+
+                string sql = new ShowTablesCommand(
+                    EffectiveCatalog,
+                    EscapePatternWildcardsInName(_metadataSchemaName),
+                    EscapePatternWildcardsInName(_metadataTableName)).Build();
+                activity?.SetTag("sql_query", sql);
+                var batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+
+                var tableCatBuilder = new StringArray.Builder();
+                var tableSchemaBuilder = new StringArray.Builder();
+                var tableNameBuilder = new StringArray.Builder();
+                var tableTypeBuilder = new StringArray.Builder();
+                var remarksBuilder = new StringArray.Builder();
+                var typeCatBuilder = new StringArray.Builder();
+                var typeSchemaBuilder = new StringArray.Builder();
+                var typeNameBuilder = new StringArray.Builder();
+                var selfRefColBuilder = new StringArray.Builder();
+                var refGenBuilder = new StringArray.Builder();
+                int count = 0;
+                foreach (var batch in batches)
+                {
+                    var catalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                    var schemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                    var tableArray = TryGetColumn<StringArray>(batch, "tableName");
+                    var tableTypeArray = TryGetColumn<StringArray>(batch, "tableType");
+                    var remarksArray = TryGetColumn<StringArray>(batch, "remarks");
+                    if (catalogArray == null || schemaArray == null || tableArray == null) continue;
+
+                    var tableTypeFilter = !string.IsNullOrEmpty(_metadataTableTypes)
+                        ? new HashSet<string>(_metadataTableTypes!.Split(','), StringComparer.OrdinalIgnoreCase)
+                        : null;
+
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (catalogArray.IsNull(i) || schemaArray.IsNull(i) || tableArray.IsNull(i)) continue;
+                        string tableType = tableTypeArray != null && !tableTypeArray.IsNull(i) ? tableTypeArray.GetString(i) : "TABLE";
+                        if (tableTypeFilter != null && !tableTypeFilter.Contains(tableType)) continue;
+                        tableCatBuilder.Append(catalogArray.GetString(i));
+                        tableSchemaBuilder.Append(schemaArray.GetString(i));
+                        tableNameBuilder.Append(tableArray.GetString(i));
+                        tableTypeBuilder.Append(tableType);
+                        remarksBuilder.Append(remarksArray != null && !remarksArray.IsNull(i) ? remarksArray.GetString(i) : "");
+                        typeCatBuilder.AppendNull();
+                        typeSchemaBuilder.AppendNull();
+                        typeNameBuilder.AppendNull();
+                        selfRefColBuilder.AppendNull();
+                        refGenBuilder.AppendNull();
+                        count++;
+                    }
+                }
+
+                activity?.SetTag("result_count", count);
+                var schema = MetadataSchemaFactory.CreateTablesSchema();
+                return new QueryResult(count, new HiveInfoArrowStream(schema, new IArrowArray[]
+                {
+                    tableCatBuilder.Build(), tableSchemaBuilder.Build(), tableNameBuilder.Build(),
+                    tableTypeBuilder.Build(), remarksBuilder.Build(), typeCatBuilder.Build(),
+                    typeSchemaBuilder.Build(), typeNameBuilder.Build(), selfRefColBuilder.Build(),
+                    refGenBuilder.Build()
+                }));
+            }, "GetTables").ConfigureAwait(false);
+        }
+
+        private async Task<QueryResult> GetColumnsAsync(CancellationToken cancellationToken)
+        {
+            return await this.TraceActivityAsync(async activity =>
+            {
+                activity?.SetTag("catalog", EffectiveCatalog ?? "(none)");
+                activity?.SetTag("schema_pattern", _metadataSchemaName ?? "(none)");
+                activity?.SetTag("table_pattern", _metadataTableName ?? "(none)");
+                activity?.SetTag("column_pattern", _metadataColumnName ?? "(none)");
+
+                string sql = new ShowColumnsCommand(
+                    EffectiveCatalog,
+                    EscapePatternWildcardsInName(_metadataSchemaName),
+                    EscapePatternWildcardsInName(_metadataTableName),
+                    EscapePatternWildcardsInName(_metadataColumnName)).Build();
+                activity?.SetTag("sql_query", sql);
+                var batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+
+                var tableInfos = new Dictionary<string, (string catalog, string schema, string table, TableInfo info)>();
+
+                foreach (var batch in batches)
+                {
+                    var catalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                    var schemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                    var tableArray = TryGetColumn<StringArray>(batch, "tableName");
+                    var colNameArray = TryGetColumn<StringArray>(batch, "col_name");
+                    var columnTypeArray = TryGetColumn<StringArray>(batch, "columnType");
+                    var isNullableArray = TryGetColumn<StringArray>(batch, "isNullable");
+
+                    if (catalogArray == null || schemaArray == null || tableArray == null ||
+                        colNameArray == null || columnTypeArray == null) continue;
+
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (catalogArray.IsNull(i) || schemaArray.IsNull(i) || tableArray.IsNull(i) ||
+                            colNameArray.IsNull(i) || columnTypeArray.IsNull(i)) continue;
+
+                        string cat = catalogArray.GetString(i);
+                        string sch = schemaArray.GetString(i);
+                        string tbl = tableArray.GetString(i);
+                        string key = $"{cat}.{sch}.{tbl}";
+
+                        if (!tableInfos.ContainsKey(key))
+                            tableInfos[key] = (cat, sch, tbl, new TableInfo("TABLE"));
+
+                        var entry = tableInfos[key];
+                        bool nullable = isNullableArray == null || isNullableArray.IsNull(i) ||
+                            !isNullableArray.GetString(i).Equals("false", StringComparison.OrdinalIgnoreCase);
+
+                        ColumnMetadataHelper.PopulateTableInfoFromTypeName(
+                            entry.info,
+                            colNameArray.GetString(i),
+                            columnTypeArray.GetString(i),
+                            entry.info.ColumnName.Count,
+                            nullable);
+                    }
+                }
+
+                activity?.SetTag("result_tables", tableInfos.Count);
+                return FlatColumnsResultBuilder.BuildFlatColumnsResult(tableInfos.Values);
+            }, "GetColumns").ConfigureAwait(false);
+        }
+
+        private async Task<QueryResult> GetColumnsExtendedAsync(CancellationToken cancellationToken)
+        {
+            return await this.TraceActivityAsync(async activity =>
+            {
+                activity?.SetTag("catalog", EffectiveCatalog ?? "(none)");
+                activity?.SetTag("schema", _metadataSchemaName ?? "(none)");
+                activity?.SetTag("table", _metadataTableName ?? "(none)");
+
+                string? fullTableName = MetadataUtilities.BuildQualifiedTableName(
+                    EffectiveCatalog, _metadataSchemaName, _metadataTableName);
+
+                if (string.IsNullOrEmpty(fullTableName))
+                    throw new ArgumentException("Catalog, schema, and table name are required for GetColumnsExtended");
+
+                string query = $"DESC TABLE EXTENDED {fullTableName} AS JSON";
+                activity?.SetTag("sql_query", query);
+                var batches = await _connection.ExecuteMetadataSqlAsync(query, cancellationToken).ConfigureAwait(false);
+
+                string? resultJson = null;
+                foreach (var batch in batches)
+                {
+                    if (batch.Length > 0)
+                    {
+                        resultJson = ((StringArray)batch.Column(0)).GetString(0);
+                        break;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(resultJson))
+                    throw new FormatException($"Empty result from {query}");
+
+                var descResult = System.Text.Json.JsonSerializer.Deserialize<DescTableExtendedResult>(resultJson!);
+                if (descResult == null)
+                    throw new FormatException($"Failed to parse JSON result from {query}");
+
+                activity?.SetTag("result_columns", descResult.Columns?.Count ?? 0);
+                activity?.SetTag("result_pk_count", descResult.PrimaryKeys?.Count ?? 0);
+                activity?.SetTag("result_fk_count", descResult.ForeignKeys?.Count ?? 0);
+
+                return DatabricksStatement.CreateExtendedColumnsResult(
+                    MetadataSchemaFactory.CreateColumnMetadataSchema(), descResult);
+            }, "GetColumnsExtended").ConfigureAwait(false);
+        }
+
+        private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
+        {
+            return await this.TraceActivityAsync(async activity =>
+            {
+                activity?.SetTag("catalog", _metadataCatalogName ?? "(none)");
+                activity?.SetTag("schema", _metadataSchemaName ?? "(none)");
+                activity?.SetTag("table", _metadataTableName ?? "(none)");
+
+                if (MetadataUtilities.IsInvalidPKFKCatalog(_metadataCatalogName))
+                    return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
+
+                if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName) ||
+                    string.IsNullOrEmpty(_metadataTableName))
+                    return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
+
+                List<RecordBatch> batches;
+                try
+                {
+                    string sql = new ShowKeysCommand(_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!).Build();
+                    activity?.SetTag("sql_query", sql);
+                    batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
+                }
+
+                var keys = new List<(string, string, string, string, int, string)>();
+                int seq = 0;
+                foreach (var batch in batches)
+                {
+                    var colNameArray = TryGetColumn<StringArray>(batch, "col_name");
+                    var keyNameArray = TryGetColumn<StringArray>(batch, "constraintName");
+                    var keySeqArray = TryGetColumn<Int32Array>(batch, "keySeq");
+                    if (colNameArray == null) continue;
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (colNameArray.IsNull(i)) continue;
+                        int keySeq = keySeqArray != null && !keySeqArray.IsNull(i) ? keySeqArray.GetValue(i)!.Value : ++seq;
+                        string pkName = keyNameArray != null && !keyNameArray.IsNull(i) ? keyNameArray.GetString(i) : "";
+                        keys.Add((_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!,
+                            colNameArray.GetString(i), keySeq, pkName));
+                    }
+                }
+
+                activity?.SetTag("result_count", keys.Count);
+                return MetadataSchemaFactory.BuildPrimaryKeysResult(keys);
+            }, "GetPrimaryKeys").ConfigureAwait(false);
+        }
+
+        private async Task<QueryResult> GetCrossReferenceAsync(CancellationToken cancellationToken)
+        {
+            return await this.TraceActivityAsync(async activity =>
+            {
+                activity?.SetTag("pk_catalog", _metadataCatalogName ?? "(none)");
+                activity?.SetTag("pk_schema", _metadataSchemaName ?? "(none)");
+                activity?.SetTag("pk_table", _metadataTableName ?? "(none)");
+                activity?.SetTag("fk_catalog", _metadataForeignCatalogName ?? "(none)");
+                activity?.SetTag("fk_schema", _metadataForeignSchemaName ?? "(none)");
+                activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
+
+                if (MetadataUtilities.IsInvalidPKFKCatalog(_metadataForeignCatalogName))
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
+
+                if (string.IsNullOrEmpty(_metadataForeignCatalogName) || string.IsNullOrEmpty(_metadataForeignSchemaName) ||
+                    string.IsNullOrEmpty(_metadataForeignTableName))
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
+
+                List<RecordBatch> batches;
+                try
+                {
+                    string sql = new ShowForeignKeysCommand(
+                        _metadataForeignCatalogName!, _metadataForeignSchemaName!, _metadataForeignTableName!).Build();
+                    activity?.SetTag("sql_query", sql);
+                    batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
+                }
+
+                var refs = new List<(string, string, string, string, string, string, string, string, int, int, int, string, string?, int)>();
+                int seq = 0;
+                foreach (var batch in batches)
+                {
+                    var pkCatalogArray = TryGetColumn<StringArray>(batch, "parentCatalogName");
+                    var pkSchemaArray = TryGetColumn<StringArray>(batch, "parentNamespace");
+                    var pkTableArray = TryGetColumn<StringArray>(batch, "parentTableName");
+                    var pkColArray = TryGetColumn<StringArray>(batch, "parentColName");
+                    var fkCatalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                    var fkSchemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                    var fkTableArray = TryGetColumn<StringArray>(batch, "tableName");
+                    var fkColArray = TryGetColumn<StringArray>(batch, "col_name");
+                    var fkNameArray = TryGetColumn<StringArray>(batch, "constraintName");
+                    var fkKeySeqArray = TryGetColumn<Int32Array>(batch, "keySeq");
+                    var fkUpdateRuleArray = TryGetColumn<Int32Array>(batch, "updateRule");
+                    var fkDeleteRuleArray = TryGetColumn<Int32Array>(batch, "deleteRule");
+                    var fkDeferrabilityArray = TryGetColumn<Int32Array>(batch, "deferrability");
+
+                    if (fkColArray == null) continue;
+
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (fkColArray.IsNull(i)) continue;
+                        refs.Add((
+                            pkCatalogArray != null && !pkCatalogArray.IsNull(i) ? pkCatalogArray.GetString(i) : _metadataCatalogName ?? "",
+                            pkSchemaArray != null && !pkSchemaArray.IsNull(i) ? pkSchemaArray.GetString(i) : _metadataSchemaName ?? "",
+                            pkTableArray != null && !pkTableArray.IsNull(i) ? pkTableArray.GetString(i) : _metadataTableName ?? "",
+                            pkColArray != null && !pkColArray.IsNull(i) ? pkColArray.GetString(i) : "",
+                            fkCatalogArray != null && !fkCatalogArray.IsNull(i) ? fkCatalogArray.GetString(i) : _metadataForeignCatalogName!,
+                            fkSchemaArray != null && !fkSchemaArray.IsNull(i) ? fkSchemaArray.GetString(i) : _metadataForeignSchemaName!,
+                            fkTableArray != null && !fkTableArray.IsNull(i) ? fkTableArray.GetString(i) : _metadataForeignTableName!,
+                            fkColArray.GetString(i),
+                            fkKeySeqArray != null && !fkKeySeqArray.IsNull(i) ? fkKeySeqArray.GetValue(i)!.Value : ++seq,
+                            fkUpdateRuleArray != null && !fkUpdateRuleArray.IsNull(i) ? fkUpdateRuleArray.GetValue(i)!.Value : 0,
+                            fkDeleteRuleArray != null && !fkDeleteRuleArray.IsNull(i) ? fkDeleteRuleArray.GetValue(i)!.Value : 0,
+                            fkNameArray != null && !fkNameArray.IsNull(i) ? fkNameArray.GetString(i) : "",
+                            (string?)null,
+                            fkDeferrabilityArray != null && !fkDeferrabilityArray.IsNull(i) ? fkDeferrabilityArray.GetValue(i)!.Value : 5
+                        ));
+                    }
+                }
+
+                activity?.SetTag("result_count", refs.Count);
+                return MetadataSchemaFactory.BuildCrossReferenceResult(refs);
+            }, "GetCrossReference").ConfigureAwait(false);
+        }
+
+        private static T? TryGetColumn<T>(RecordBatch batch, string name) where T : class, IArrowArray
+        {
+            try { return batch.Column(name) as T; }
+            catch (ArgumentOutOfRangeException) { return null; }
         }
 
         // TracingStatement implementation

--- a/csharp/test/ColumnMetadataHelperTests.cs
+++ b/csharp/test/ColumnMetadataHelperTests.cs
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using AdbcDrivers.Databricks;
+using Xunit;
+using static AdbcDrivers.HiveServer2.Hive2.HiveServer2Connection;
+
+namespace AdbcDrivers.Databricks.Tests
+{
+    public class ColumnMetadataHelperTests
+    {
+        [Theory]
+        [InlineData("BOOLEAN", (short)ColumnTypeId.BOOLEAN)]
+        [InlineData("TINYINT", (short)ColumnTypeId.TINYINT)]
+        [InlineData("BYTE", (short)ColumnTypeId.TINYINT)]
+        [InlineData("SMALLINT", (short)ColumnTypeId.SMALLINT)]
+        [InlineData("SHORT", (short)ColumnTypeId.SMALLINT)]
+        [InlineData("INT", (short)ColumnTypeId.INTEGER)]
+        [InlineData("INTEGER", (short)ColumnTypeId.INTEGER)]
+        [InlineData("BIGINT", (short)ColumnTypeId.BIGINT)]
+        [InlineData("LONG", (short)ColumnTypeId.BIGINT)]
+        [InlineData("FLOAT", (short)ColumnTypeId.FLOAT)]
+        [InlineData("DOUBLE", (short)ColumnTypeId.DOUBLE)]
+        [InlineData("DECIMAL", (short)ColumnTypeId.DECIMAL)]
+        [InlineData("DECIMAL(10,2)", (short)ColumnTypeId.DECIMAL)]
+        [InlineData("DEC", (short)ColumnTypeId.DECIMAL)]
+        [InlineData("NUMERIC", (short)ColumnTypeId.DECIMAL)] // SqlTypeNameParser normalizes NUMERIC → DECIMAL
+        [InlineData("STRING", (short)ColumnTypeId.VARCHAR)]
+        [InlineData("VARCHAR", (short)ColumnTypeId.VARCHAR)]
+        [InlineData("VARCHAR(255)", (short)ColumnTypeId.VARCHAR)]
+        [InlineData("CHAR", (short)ColumnTypeId.CHAR)]
+        [InlineData("BINARY", (short)ColumnTypeId.BINARY)]
+        [InlineData("DATE", (short)ColumnTypeId.DATE)]
+        [InlineData("TIMESTAMP", (short)ColumnTypeId.TIMESTAMP)]
+        [InlineData("TIMESTAMP_NTZ", (short)ColumnTypeId.TIMESTAMP)]
+        [InlineData("TIMESTAMP_LTZ", (short)ColumnTypeId.TIMESTAMP)]
+        [InlineData("ARRAY<INT>", (short)ColumnTypeId.ARRAY)]
+        [InlineData("MAP<STRING,INT>", (short)ColumnTypeId.JAVA_OBJECT)]
+        [InlineData("STRUCT<F1:INT>", (short)ColumnTypeId.STRUCT)]
+        [InlineData("VOID", (short)ColumnTypeId.NULL)]
+        [InlineData("INTERVAL YEAR TO MONTH", (short)ColumnTypeId.OTHER)]
+        [InlineData("UNKNOWN_TYPE", (short)ColumnTypeId.OTHER)]
+        public void GetDataTypeCode_ReturnsCorrectCode(string typeName, short expectedCode)
+        {
+            Assert.Equal(expectedCode, ColumnMetadataHelper.GetDataTypeCode(typeName));
+        }
+
+        [Theory]
+        [InlineData("DECIMAL(10,2)", "DECIMAL")]
+        [InlineData("VARCHAR(255)", "VARCHAR")]
+        [InlineData("ARRAY<INT>", "ARRAY")]
+        [InlineData("MAP<STRING,INT>", "MAP")]
+        [InlineData("STRUCT<F1:INT>", "STRUCT")]
+        [InlineData("INT", "INTEGER")]
+        [InlineData("INTEGER", "INTEGER")]
+        [InlineData("DEC", "DECIMAL")]
+        [InlineData("TIMESTAMP_NTZ", "TIMESTAMP")]
+        [InlineData("TIMESTAMP_LTZ", "TIMESTAMP")]
+        [InlineData("BYTE", "TINYINT")]
+        [InlineData("SHORT", "SMALLINT")]
+        [InlineData("LONG", "BIGINT")]
+        [InlineData("STRING", "STRING")]
+        [InlineData("BOOLEAN", "BOOLEAN")]
+        [InlineData("DOUBLE", "DOUBLE")]
+        public void GetBaseTypeName_ReturnsCorrectName(string typeName, string expectedBase)
+        {
+            Assert.Equal(expectedBase, ColumnMetadataHelper.GetBaseTypeName(typeName));
+        }
+
+        [Theory]
+        [InlineData("BOOLEAN", 1)]
+        [InlineData("TINYINT", 1)]
+        [InlineData("SMALLINT", 2)]
+        [InlineData("INT", 4)]
+        [InlineData("INTEGER", 4)]
+        [InlineData("BIGINT", 8)]
+        [InlineData("FLOAT", 4)]
+        [InlineData("DOUBLE", 8)]
+        [InlineData("TIMESTAMP", 8)]
+        [InlineData("DATE", 4)]
+        [InlineData("DECIMAL(10,2)", 10)]
+        [InlineData("DECIMAL", 10)]
+        [InlineData("VARCHAR(255)", 255)]
+        [InlineData("STRING", int.MaxValue)]
+        [InlineData("CHAR(50)", 50)]
+        public void GetColumnSizeDefault_ReturnsCorrectSize(string typeName, int expectedSize)
+        {
+            Assert.Equal(expectedSize, ColumnMetadataHelper.GetColumnSizeDefault(typeName));
+        }
+
+        [Theory]
+        [InlineData("DECIMAL(10,2)", 2)]
+        [InlineData("DECIMAL", 0)]
+        [InlineData("FLOAT", 7)]
+        [InlineData("DOUBLE", 15)]
+        [InlineData("TIMESTAMP", 6)]
+        [InlineData("INT", 0)]
+        [InlineData("STRING", 0)]
+        [InlineData("BOOLEAN", 0)]
+        public void GetDecimalDigitsDefault_ReturnsCorrectDigits(string typeName, int expectedDigits)
+        {
+            Assert.Equal(expectedDigits, ColumnMetadataHelper.GetDecimalDigitsDefault(typeName));
+        }
+
+        [Theory]
+        [InlineData("BOOLEAN", 1)]
+        [InlineData("TINYINT", 1)]
+        [InlineData("SMALLINT", 2)]
+        [InlineData("INT", 4)]
+        [InlineData("BIGINT", 8)]
+        [InlineData("FLOAT", 4)]
+        [InlineData("DOUBLE", 8)]
+        [InlineData("DECIMAL(10,2)", 11)]
+        public void GetBufferLength_ReturnsCorrectLength(string typeName, int expectedLength)
+        {
+            Assert.Equal(expectedLength, ColumnMetadataHelper.GetBufferLength(typeName));
+        }
+
+        [Fact]
+        public void GetBufferLength_ReturnsNullForNonNumeric()
+        {
+            Assert.Null(ColumnMetadataHelper.GetBufferLength("STRING"));
+            Assert.Null(ColumnMetadataHelper.GetBufferLength("ARRAY<INT>"));
+        }
+
+        [Theory]
+        [InlineData("INT", (short)10)]
+        [InlineData("DECIMAL", (short)10)]
+        [InlineData("FLOAT", (short)10)]
+        [InlineData("DOUBLE", (short)10)]
+        [InlineData("BIGINT", (short)10)]
+        public void GetNumPrecRadix_Returns10ForNumeric(string typeName, short expected)
+        {
+            Assert.Equal(expected, ColumnMetadataHelper.GetNumPrecRadix(typeName));
+        }
+
+        [Theory]
+        [InlineData("STRING")]
+        [InlineData("BOOLEAN")]
+        [InlineData("DATE")]
+        [InlineData("TIMESTAMP")]
+        [InlineData("ARRAY<INT>")]
+        public void GetNumPrecRadix_ReturnsNullForNonNumeric(string typeName)
+        {
+            Assert.Null(ColumnMetadataHelper.GetNumPrecRadix(typeName));
+        }
+
+        [Theory]
+        [InlineData("STRING", int.MaxValue)]
+        [InlineData("VARCHAR(255)", 255)]
+        [InlineData("CHAR(50)", 50)]
+        public void GetCharOctetLength_ReturnsForCharTypes(string typeName, int expectedLength)
+        {
+            Assert.Equal(expectedLength, ColumnMetadataHelper.GetCharOctetLength(typeName));
+        }
+
+        [Theory]
+        [InlineData("INT")]
+        [InlineData("DECIMAL(10,2)")]
+        [InlineData("BOOLEAN")]
+        public void GetCharOctetLength_ReturnsNullForNonCharTypes(string typeName)
+        {
+            Assert.Null(ColumnMetadataHelper.GetCharOctetLength(typeName));
+        }
+
+        [Theory]
+        [InlineData("INTERVAL YEAR TO MONTH", 4)]
+        [InlineData("INTERVAL DAY TO SECOND", 8)]
+        [InlineData("INTERVAL HOUR TO SECOND", 8)]
+        public void GetColumnSizeDefault_HandlesIntervalTypes(string typeName, int expectedSize)
+        {
+            Assert.Equal(expectedSize, ColumnMetadataHelper.GetColumnSizeDefault(typeName));
+        }
+
+        [Theory]
+        [InlineData("  DECIMAL(10,2)  ", (short)ColumnTypeId.DECIMAL)]
+        [InlineData("decimal", (short)ColumnTypeId.DECIMAL)]
+        [InlineData("  int  ", (short)ColumnTypeId.INTEGER)]
+        public void GetDataTypeCode_HandlesTrimAndCase(string typeName, short expectedCode)
+        {
+            Assert.Equal(expectedCode, ColumnMetadataHelper.GetDataTypeCode(typeName));
+        }
+    }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/258/files/3c9e2bf..4b3f22b) to review incremental changes only.

- [feat/sea-metadata-part1](https://github.com/adbc-drivers/databricks/pull/257) [[Files changed](https://github.com/adbc-drivers/databricks/pull/257/files)]
  - [feat/sea-metadata-part2](https://github.com/adbc-drivers/databricks/pull/258) [[Files changed](https://github.com/adbc-drivers/databricks/pull/258/files/3c9e2bf..4b3f22b)]
    - [feat/sea-metadata-part3](https://github.com/adbc-drivers/databricks/pull/259) [[Files changed](https://github.com/adbc-drivers/databricks/pull/259/files/4b3f22b..3e07fa0)]
      - [feat/sea-metadata-part4](https://github.com/adbc-drivers/databricks/pull/260) [[Files changed](https://github.com/adbc-drivers/databricks/pull/260/files/3e07fa0..cd97cce)]
        - [feat/sea-metadata-part5](https://github.com/adbc-drivers/databricks/pull/261) [[Files changed](https://github.com/adbc-drivers/databricks/pull/261/files/cd97cce..6c4819e)]
          - [feat/sea-metadata-part6](https://github.com/adbc-drivers/databricks/pull/282) [[Files changed](https://github.com/adbc-drivers/databricks/pull/282/files/6c4819e..d30c12b)]

## Summary

SEA-specific metadata computation and statement-level command routing.

### New files
- **ColumnMetadataHelper**: computes column metadata from type name strings. No duplicate GetArrowType — reuses `HiveServer2Connection.GetArrowType`. REAL→FLOAT in type map. BINARY column size = 0.
- **FlatColumnsResultBuilder**: builds flat 24-column GetColumns with computed fields. REMARKS = empty, COLUMN_DEF = null.

### StatementExecutionStatement
- Async `ExecuteMetadataCommandAsync` with CancellationToken propagation
- Commands: GetCatalogs, GetSchemas, GetTables, GetColumns, GetColumnsExtended (DESC TABLE EXTENDED AS JSON), GetPrimaryKeys, GetCrossReference
- `EscapePatternWildcards`: escapes _ and % in LIKE params (not backtick-quoted catalog)
- `TableTypes`: filters GetTables by comma-separated type list
- `NormalizeSparkCatalog`: SPARK→null→falls to connection default
- All methods wrapped in `TraceActivityAsync`
- 100 ColumnMetadataHelper unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)