### PR TITLE
test(csharp): unit tests for ShowCommands and MetadataUtilities

### DIFF
--- a/csharp/test/Unit/MetadataUtilitiesTests.cs
+++ b/csharp/test/Unit/MetadataUtilitiesTests.cs
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit
+{
+    public class MetadataUtilitiesTests
+    {
+        // NormalizeSparkCatalog
+
+        [Fact]
+        public void NormalizeSparkCatalog_Spark_ReturnsNull()
+        {
+            Assert.Null(MetadataUtilities.NormalizeSparkCatalog("SPARK"));
+        }
+
+        [Fact]
+        public void NormalizeSparkCatalog_SparkLowerCase_ReturnsNull()
+        {
+            Assert.Null(MetadataUtilities.NormalizeSparkCatalog("spark"));
+        }
+
+        [Fact]
+        public void NormalizeSparkCatalog_SparkMixedCase_ReturnsNull()
+        {
+            Assert.Null(MetadataUtilities.NormalizeSparkCatalog("Spark"));
+        }
+
+        [Fact]
+        public void NormalizeSparkCatalog_Null_ReturnsNull()
+        {
+            Assert.Null(MetadataUtilities.NormalizeSparkCatalog(null));
+        }
+
+        [Fact]
+        public void NormalizeSparkCatalog_Empty_ReturnsEmpty()
+        {
+            Assert.Equal("", MetadataUtilities.NormalizeSparkCatalog(""));
+        }
+
+        [Fact]
+        public void NormalizeSparkCatalog_Main_ReturnsMain()
+        {
+            Assert.Equal("main", MetadataUtilities.NormalizeSparkCatalog("main"));
+        }
+
+        // IsInvalidPKFKCatalog
+
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        [InlineData("SPARK", true)]
+        [InlineData("spark", true)]
+        [InlineData("hive_metastore", true)]
+        [InlineData("main", false)]
+        [InlineData("samples", false)]
+        public void IsInvalidPKFKCatalog(string? catalog, bool expected)
+        {
+            Assert.Equal(expected, MetadataUtilities.IsInvalidPKFKCatalog(catalog));
+        }
+
+        // ShouldReturnEmptyPKFKResult
+
+        [Fact]
+        public void ShouldReturnEmptyPKFKResult_PKFKDisabled_ReturnsTrue()
+        {
+            Assert.True(MetadataUtilities.ShouldReturnEmptyPKFKResult("main", "main", enablePKFK: false));
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyPKFKResult_BothInvalid_ReturnsTrue()
+        {
+            Assert.True(MetadataUtilities.ShouldReturnEmptyPKFKResult("SPARK", "hive_metastore", enablePKFK: true));
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyPKFKResult_OneValid_ReturnsFalse()
+        {
+            Assert.False(MetadataUtilities.ShouldReturnEmptyPKFKResult("main", "SPARK", enablePKFK: true));
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyPKFKResult_BothValid_ReturnsFalse()
+        {
+            Assert.False(MetadataUtilities.ShouldReturnEmptyPKFKResult("main", "main", enablePKFK: true));
+        }
+
+        // BuildQualifiedTableName
+
+        [Fact]
+        public void BuildQualifiedTableName_AllParts()
+        {
+            Assert.Equal("`main`.`default`.`users`", MetadataUtilities.BuildQualifiedTableName("main", "default", "users"));
+        }
+
+        [Fact]
+        public void BuildQualifiedTableName_NoSchema()
+        {
+            Assert.Equal("`users`", MetadataUtilities.BuildQualifiedTableName("main", null, "users"));
+        }
+
+        [Fact]
+        public void BuildQualifiedTableName_SparkCatalog_OmitsCatalog()
+        {
+            Assert.Equal("`default`.`users`", MetadataUtilities.BuildQualifiedTableName("SPARK", "default", "users"));
+        }
+
+        [Fact]
+        public void BuildQualifiedTableName_NullTable_ReturnsNull()
+        {
+            Assert.Null(MetadataUtilities.BuildQualifiedTableName("main", "default", null));
+        }
+
+        [Fact]
+        public void BuildQualifiedTableName_EmptyTable_ReturnsEmpty()
+        {
+            Assert.Equal("", MetadataUtilities.BuildQualifiedTableName("main", "default", ""));
+        }
+
+        [Fact]
+        public void BuildQualifiedTableName_BackticksEscaped()
+        {
+            Assert.Equal("`main`.`my``schema`.`my``table`", MetadataUtilities.BuildQualifiedTableName("main", "my`schema", "my`table"));
+        }
+    }
+}

--- a/csharp/test/Unit/StatementExecution/ShowCommandTests.cs
+++ b/csharp/test/Unit/StatementExecution/ShowCommandTests.cs
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using AdbcDrivers.Databricks.StatementExecution;
+using AdbcDrivers.Databricks.StatementExecution.MetadataCommands;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
+{
+    public class ShowCommandTests
+    {
+        // ShowCatalogsCommand
+
+        [Fact]
+        public void ShowCatalogs_NoPattern()
+        {
+            Assert.Equal("SHOW CATALOGS", new ShowCatalogsCommand().Build());
+        }
+
+        [Fact]
+        public void ShowCatalogs_WithPattern()
+        {
+            Assert.Equal("SHOW CATALOGS LIKE 'ma*'", new ShowCatalogsCommand("ma%").Build());
+        }
+
+        [Fact]
+        public void ShowCatalogs_WithUnderscorePattern()
+        {
+            Assert.Equal("SHOW CATALOGS LIKE 'm.in'", new ShowCatalogsCommand("m_in").Build());
+        }
+
+        // ShowSchemasCommand
+
+        [Fact]
+        public void ShowSchemas_NullCatalog_UsesAllCatalogs()
+        {
+            Assert.Equal("SHOW SCHEMAS IN ALL CATALOGS", new ShowSchemasCommand(null).Build());
+        }
+
+        [Fact]
+        public void ShowSchemas_WithCatalog()
+        {
+            Assert.Equal("SHOW SCHEMAS IN `main`", new ShowSchemasCommand("main").Build());
+        }
+
+        [Fact]
+        public void ShowSchemas_WithCatalogAndPattern()
+        {
+            Assert.Equal("SHOW SCHEMAS IN `main` LIKE 'def*'", new ShowSchemasCommand("main", "def%").Build());
+        }
+
+        [Fact]
+        public void ShowSchemas_CatalogWithBacktick()
+        {
+            Assert.Equal("SHOW SCHEMAS IN `my``catalog`", new ShowSchemasCommand("my`catalog").Build());
+        }
+
+        // ShowTablesCommand
+
+        [Fact]
+        public void ShowTables_NullCatalog_UsesAllCatalogs()
+        {
+            Assert.Equal("SHOW TABLES IN ALL CATALOGS", new ShowTablesCommand(null).Build());
+        }
+
+        [Fact]
+        public void ShowTables_WithCatalog()
+        {
+            Assert.Equal("SHOW TABLES IN CATALOG `main`", new ShowTablesCommand("main").Build());
+        }
+
+        [Fact]
+        public void ShowTables_WithCatalogAndSchema()
+        {
+            Assert.Equal(
+                "SHOW TABLES IN CATALOG `main` SCHEMA LIKE 'default'",
+                new ShowTablesCommand("main", "default").Build());
+        }
+
+        [Fact]
+        public void ShowTables_WithAllPatterns()
+        {
+            Assert.Equal(
+                "SHOW TABLES IN CATALOG `main` SCHEMA LIKE 'def*' LIKE 'test*'",
+                new ShowTablesCommand("main", "def%", "test%").Build());
+        }
+
+        // ShowColumnsCommand
+
+        [Fact]
+        public void ShowColumns_NullCatalog_UsesAllCatalogs()
+        {
+            Assert.Equal("SHOW COLUMNS IN ALL CATALOGS", new ShowColumnsCommand(null).Build());
+        }
+
+        [Fact]
+        public void ShowColumns_WithCatalog()
+        {
+            Assert.Equal("SHOW COLUMNS IN CATALOG `main`", new ShowColumnsCommand("main").Build());
+        }
+
+        [Fact]
+        public void ShowColumns_WithAllPatterns()
+        {
+            Assert.Equal(
+                "SHOW COLUMNS IN CATALOG `main` SCHEMA LIKE 'default' TABLE LIKE 'users' LIKE 'col*'",
+                new ShowColumnsCommand("main", "default", "users", "col%").Build());
+        }
+
+        [Fact]
+        public void ShowColumns_WildcardColumnPattern_Omitted()
+        {
+            Assert.Equal(
+                "SHOW COLUMNS IN CATALOG `main`",
+                new ShowColumnsCommand("main", null, null, "%").Build());
+        }
+
+        // ShowKeysCommand
+
+        [Fact]
+        public void ShowKeys_BuildsCorrectly()
+        {
+            Assert.Equal(
+                "SHOW KEYS IN CATALOG `main` IN SCHEMA `default` IN TABLE `users`",
+                new ShowKeysCommand("main", "default", "users").Build());
+        }
+
+        [Fact]
+        public void ShowKeys_NullCatalog_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ShowKeysCommand(null!, "default", "users"));
+        }
+
+        [Fact]
+        public void ShowKeys_NullSchema_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ShowKeysCommand("main", null!, "users"));
+        }
+
+        [Fact]
+        public void ShowKeys_NullTable_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ShowKeysCommand("main", "default", null!));
+        }
+
+        // ShowForeignKeysCommand
+
+        [Fact]
+        public void ShowForeignKeys_BuildsCorrectly()
+        {
+            Assert.Equal(
+                "SHOW FOREIGN KEYS IN CATALOG `main` IN SCHEMA `default` IN TABLE `orders`",
+                new ShowForeignKeysCommand("main", "default", "orders").Build());
+        }
+
+        [Fact]
+        public void ShowForeignKeys_SpecialCharsInIdentifiers()
+        {
+            Assert.Equal(
+                "SHOW FOREIGN KEYS IN CATALOG `my``cat` IN SCHEMA `my``schema` IN TABLE `my``table`",
+                new ShowForeignKeysCommand("my`cat", "my`schema", "my`table").Build());
+        }
+
+        // Pattern conversion edge cases
+
+        [Fact]
+        public void ShowCatalogs_SingleQuoteEscaped()
+        {
+            Assert.Equal("SHOW CATALOGS LIKE 'it''s'", new ShowCatalogsCommand("it's").Build());
+        }
+
+        [Fact]
+        public void ShowCatalogs_EmptyPattern()
+        {
+            Assert.Equal("SHOW CATALOGS LIKE '*'", new ShowCatalogsCommand("").Build());
+        }
+    }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/259/files/4b3f22b..3e07fa0) to review incremental changes only.

- [feat/sea-metadata-part1](https://github.com/adbc-drivers/databricks/pull/257) [[Files changed](https://github.com/adbc-drivers/databricks/pull/257/files)]
  - [feat/sea-metadata-part2](https://github.com/adbc-drivers/databricks/pull/258) [[Files changed](https://github.com/adbc-drivers/databricks/pull/258/files/3c9e2bf..4b3f22b)]
    - [feat/sea-metadata-part3](https://github.com/adbc-drivers/databricks/pull/259) [[Files changed](https://github.com/adbc-drivers/databricks/pull/259/files/4b3f22b..3e07fa0)]
      - [feat/sea-metadata-part4](https://github.com/adbc-drivers/databricks/pull/260) [[Files changed](https://github.com/adbc-drivers/databricks/pull/260/files/3e07fa0..cd97cce)]
        - [feat/sea-metadata-part5](https://github.com/adbc-drivers/databricks/pull/261) [[Files changed](https://github.com/adbc-drivers/databricks/pull/261/files/cd97cce..6c4819e)]
          - [feat/sea-metadata-part6](https://github.com/adbc-drivers/databricks/pull/282) [[Files changed](https://github.com/adbc-drivers/databricks/pull/282/files/6c4819e..d30c12b)]

## Summary

- **ShowCommandTests** (22 tests): all 6 Show*Command classes — pattern conversion, backtick escaping, null catalog, IN ALL CATALOGS, argument validation
- **MetadataUtilitiesTests** (24 tests): NormalizeSparkCatalog, IsInvalidPKFKCatalog, ShouldReturnEmptyPKFKResult, BuildQualifiedTableName

🤖 Generated with [Claude Code](https://claude.com/claude-code)