### PR TITLE
fix(rust): enter ADBC tracing span before session creation

### DIFF
--- a/rust/src/database.rs
+++ b/rust/src/database.rs
@@ -29,7 +29,6 @@ use adbc_core::Optionable;
 use driverbase::error::ErrorHelper;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::debug;
 
 /// Represents a database instance that holds connection configuration.
 ///
@@ -390,11 +389,6 @@ impl adbc_core::Database for Database {
                 .message("access_token not set")
                 .to_adbc()
         })?;
-
-        debug!(
-            "Creating connection to {} with warehouse {}",
-            host, warehouse_id
-        );
 
         // Create auth provider
         let auth_provider = Arc::new(PersonalAccessToken::new(access_token.clone()));


### PR DESCRIPTION
## Summary

- Move the `info_span!("ADBC", ...)` creation to before the `create_session()` call so all log lines during connection setup are tagged with the `ADBC` span prefix
- Record `session_id` on the span after session creation, so post-connection logs still include it
- Move the "Creating connection to ..." log from `database.rs` into `connection.rs` so it falls within the span

**Before:**
```
DEBUG Creating connection to ...                              (no ADBC prefix)
DEBUG Creating session at ...                                 (no ADBC prefix)
DEBUG ADBC{session_id=...}: Closing session: ...
```

**After:**
```
DEBUG ADBC: Creating connection to ...
DEBUG ADBC: Creating session at ...
DEBUG ADBC{session_id="..."}: Closing session: ...
```

## Test plan

- [x] `cargo fmt` — no changes
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all pass
- [x] E2E verified with ODBC driver: all log lines now uniformly prefixed with `ADBC:` or `ADBC{session_id="..."}:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)