### PR TITLE
feat(rust): update CloudFetchConfig with C# aligned defaults

### DIFF
--- a/rust/spec/cloudfetch-pipeline-redesign.md
+++ b/rust/spec/cloudfetch-pipeline-redesign.md
@@ -1,0 +1,358 @@
+# CloudFetch Pipeline Redesign: DashMap → Channel-Based Pipeline
+
+**Status:** Proposed
+**Scope:** `rust/src/reader/cloudfetch/streaming_provider.rs` and supporting types
+**Reference implementation:** `csharp/src/Reader/CloudFetch/`
+
+---
+
+## Problem Statement
+
+The current `StreamingCloudFetchProvider` uses a single `DashMap<i64, ChunkEntry>` as the
+central coordination point for three unrelated concerns:
+
+| Field on `ChunkEntry` | Role |
+|---|---|
+| `link: Option<CloudFetchLink>` | Presigned URL storage |
+| `state: ChunkState` | Download state machine |
+| `batches: Option<Vec<RecordBatch>>` | Result buffering (potentially 100 MB+) |
+
+Combining these into one shared concurrent map creates compounding problems:
+
+1. **Lock discipline burden.** DashMap shard locks must not be held across `.await` points or
+   the task deadlocks itself. Every read-then-write sequence requires an explicit drop-guard
+   pattern and careful review.
+
+2. **Unnatural indirection for URL refresh.** When a 401/403/404 occurs, the code cannot call
+   `refetch_link().await` while holding `get_mut()`. The workaround requires a two-`get_mut`
+   dance with explicit scope comments explaining why.
+
+3. **Large data in a concurrent map.** `ChunkEntry` derives `Clone` but holds
+   `Option<Vec<RecordBatch>>`. An accidental clone copies hundreds of megabytes. The map was
+   designed for fast keyed lookup, not result storage.
+
+4. **Poll-based consumer synchronisation.** `wait_for_chunk` loops on a `Notify`, checking
+   state on every wakeup. This is a workaround for the absence of a direct completion signal
+   from download task to consumer.
+
+The C# driver avoids all of these by giving each chunk its own self-contained object that flows
+through two channels. This document proposes the same structure for Rust.
+
+---
+
+## Proposed Design
+
+### Pipeline Overview
+
+```mermaid
+graph LR
+    LF[ChunkLinkFetcher] -->|CloudFetchLink| S[Scheduler]
+    S -->|ChunkDownloadTask| DQ[(download_channel)]
+    S -->|ChunkHandle| RQ[(result_channel)]
+    DQ --> W1[Worker]
+    DQ --> W2[Worker]
+    DQ --> Wn[Worker ...]
+    W1 -->|oneshot result| RQ
+    W2 -->|oneshot result| RQ
+    Wn -->|oneshot result| RQ
+    RQ --> C[Consumer / next_batch]
+```
+
+**Two channels replace the DashMap:**
+
+- **`download_channel`** — scheduler pushes `ChunkDownloadTask` items; download workers pull
+  from it. Unbounded (backpressure is applied via `result_channel`).
+- **`result_channel`** — scheduler pushes `ChunkHandle` items *in chunk-index order*, bounded
+  to `max_chunks_in_memory`. The consumer reads from it in order and awaits each handle.
+
+Items are enqueued to `result_channel` by the scheduler before the download starts, preserving
+sequential ordering even when downloads complete out of order. This matches the C# pattern in
+`CloudFetchDownloader.cs` (result enqueued before download task is awaited).
+
+---
+
+## Key Types
+
+### `ChunkDownloadTask`
+
+Sent through `download_channel`. Owned entirely by the download worker — no shared state.
+
+```rust
+struct ChunkDownloadTask {
+    chunk_index: i64,
+    link: CloudFetchLink,
+    result_tx: oneshot::Sender<Result<Vec<RecordBatch>>>,
+}
+```
+
+### `ChunkHandle`
+
+Sent through `result_channel` in scheduler (chunk-index) order. The consumer awaits the
+embedded receiver to get the downloaded batches.
+
+```rust
+struct ChunkHandle {
+    chunk_index: i64,
+    result_rx: oneshot::Receiver<Result<Vec<RecordBatch>>>,
+}
+```
+
+Mirrors C#'s `IDownloadResult` with its `DownloadCompletedTask` (`TaskCompletionSource`).
+
+---
+
+## Component Responsibilities
+
+### Scheduler (replaces `schedule_downloads`)
+
+```mermaid
+sequenceDiagram
+    participant LF as ChunkLinkFetcher
+    participant S as Scheduler
+    participant DQ as download_channel
+    participant RQ as result_channel
+
+    loop until has_more = false
+        S->>LF: fetch_links(next_chunk_index)
+        LF-->>S: Vec<CloudFetchLink> (batch)
+        loop for each link in batch
+            S->>S: create oneshot (tx, rx)
+            S->>DQ: send ChunkDownloadTask { link, tx }
+            S->>RQ: send ChunkHandle { rx }
+            Note over S,RQ: result_channel bounded — blocks here<br/>when max_chunks_in_memory reached
+        end
+    end
+```
+
+- `fetch_links()` returns a **batch** of `CloudFetchLink` values (`Vec<CloudFetchLink>`), not a
+  single link. The scheduler iterates the batch and creates one oneshot pair per link.
+- `SeaChunkLinkFetcher` caches and prefetches links internally; the scheduler simply consumes
+  what `fetch_links()` returns, advancing `next_chunk_index` after each batch.
+- Creates a `oneshot` channel pair per chunk.
+- Sends `ChunkDownloadTask` to `download_channel` and `ChunkHandle` to `result_channel`.
+- The bounded `result_channel` provides backpressure automatically — no manual
+  `chunks_in_memory` counter or `AtomicUsize` needed.
+
+### Download Worker (replaces `download_chunk_with_retry`)
+
+Each worker is a long-lived `tokio::spawn` task that loops over `download_channel`.
+
+```mermaid
+sequenceDiagram
+    participant DQ as download_channel
+    participant W as Worker
+    participant CS as Cloud Storage
+    participant LF as ChunkLinkFetcher
+
+    loop
+        W->>DQ: recv()
+        DQ-->>W: ChunkDownloadTask
+        W->>W: proactive expiry check (link.is_expired())
+        opt link expired or expiring within url_expiration_buffer_secs
+            W->>LF: refetch_link(chunk_index)
+            LF-->>W: fresh CloudFetchLink
+        end
+        W->>CS: GET presigned_url
+        alt success
+            CS-->>W: Arrow IPC bytes
+            W->>W: parse batches
+            W->>W: result_tx.send(Ok(batches))
+        else 401 / 403 / 404
+            W->>LF: refetch_link(chunk_index)
+            LF-->>W: fresh CloudFetchLink
+            W->>CS: GET fresh_url  (retry immediately, no sleep)
+        else other error
+            W->>W: sleep(retry_delay * (attempt + 1))
+            W->>CS: retry
+        end
+        alt max_retries exceeded
+            W->>W: result_tx.send(Err(...))
+        end
+    end
+```
+
+The worker owns `ChunkDownloadTask` outright. URL refresh mutates a local `link` variable —
+no map lookup, no lock, no guard. Mirrors C#'s `DownloadFileAsync` directly.
+
+**Proactive expiry check** (C# parity — `IsExpiredOrExpiringSoon`): before the first HTTP
+request for each chunk, the worker checks `link.is_expired()` using the
+`url_expiration_buffer_secs` buffer. If the link is already expired or will expire within that
+window, it is refetched immediately before the download attempt begins. This avoids a
+guaranteed 401/403 failure that would otherwise cost one retry.
+
+**Retry sleep** matches C#'s `Task.Delay(_retryDelayMs * (retry + 1))`: linear backoff
+(`retry_delay * (attempt + 1)`), not constant and not exponential.
+
+**Retry contract:**
+
+| Error type | Sleep before retry | Counts against `max_retries` | Counts against `max_refresh_retries` |
+|---|---|---|---|
+| Network / 5xx | Yes — `retry_delay * (attempt + 1)` | Yes | No |
+| 401 / 403 / 404 | No | Yes | Yes |
+| Link proactively expired | No | No | Yes |
+
+### Consumer (replaces `wait_for_chunk` + `next_batch`)
+
+```mermaid
+sequenceDiagram
+    participant RQ as result_channel
+    participant C as Consumer
+    participant App as Caller
+
+    loop
+        App->>C: next_batch()
+        C->>RQ: recv() → ChunkHandle
+        C->>C: handle.result_rx.await
+        C-->>App: Ok(Some(RecordBatch))
+    end
+    App->>C: next_batch()
+    C->>RQ: recv() → channel closed
+    C-->>App: Ok(None)
+```
+
+`wait_for_chunk` and its `Notify`-based polling loop are replaced by a single `.await` on
+the `oneshot::Receiver`. No state check, no timeout loop, no `chunk_state_changed` signal.
+
+---
+
+## Struct Changes
+
+### `StreamingCloudFetchProvider` (after)
+
+```rust
+pub struct StreamingCloudFetchProvider {
+    // Pipeline output — consumer reads ChunkHandles in order
+    result_rx: Mutex<mpsc::Receiver<ChunkHandle>>,
+
+    // Schema (extracted from first batch)
+    schema: OnceLock<SchemaRef>,
+
+    // Batch buffer (drains current ChunkHandle before advancing)
+    batch_buffer: Mutex<VecDeque<RecordBatch>>,
+
+    // Cancellation
+    cancel_token: CancellationToken,
+}
+```
+
+**Removed entirely:**
+
+| Field | Replaced by |
+|---|---|
+| `chunks: Arc<DashMap<i64, ChunkEntry>>` | `download_channel` + `result_channel` |
+| `chunks_in_memory: AtomicUsize` | Bounded `result_channel` capacity |
+| `max_chunks_in_memory: usize` | `mpsc::channel(max_chunks_in_memory)` bound |
+| `chunk_state_changed: Arc<Notify>` | `oneshot` receivers per chunk |
+| `next_download_index: AtomicI64` | Sequential counter owned by scheduler task |
+| `current_chunk_index: AtomicI64` | Implicit in sequential `result_rx.recv()` calls |
+| `end_of_stream: AtomicBool` | Implicit when `result_rx` returns `None` |
+
+### `ChunkEntry` / `ChunkState` (types.rs)
+
+Both types are no longer needed and can be deleted. The equivalent state lives on
+`ChunkDownloadTask` (pre-download) and `ChunkHandle` (post-download).
+
+---
+
+## Concurrency Model
+
+| Component | Concurrency primitive | Reason |
+|---|---|---|
+| Scheduler | Single `tokio::spawn` task | Sequential chunk ordering required |
+| Download workers | N `tokio::spawn` tasks sharing `download_channel` | Parallel downloads |
+| Consumer | Caller's task (no spawn) | Sequential result consumption |
+| `result_channel` | Bounded `mpsc` (capacity = `max_chunks_in_memory`) | Backpressure without manual counter |
+| URL refresh in worker | Local variable mutation | No shared state — no lock needed |
+
+**Thread safety:** No shared mutable state between components. Each `ChunkDownloadTask` is
+owned by exactly one worker at a time. Each `ChunkHandle` is owned by the consumer.
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Download fails after `max_retries` | `result_tx.send(Err(...))` — consumer gets error on `result_rx.await` |
+| URL refresh fails after `max_refresh_retries` | Same as above |
+| `refetch_link()` itself returns error | Propagated via `result_tx.send(Err(...))` |
+| Cancellation during sleep | `tokio::select\!` on `cancel_token.cancelled()` interrupts sleep |
+| Cancellation during `result_rx.await` | Consumer selects on `cancel_token.cancelled()` |
+| Scheduler exits (all chunks sent) | `download_channel` sender drops → workers drain then exit |
+| All workers exit | `oneshot` senders drop → `result_rx.await` returns `Err(RecvError)` |
+
+---
+
+## Configuration
+
+Three fields are **added** to `CloudFetchConfig` (matching C# `CloudFetchConfiguration`), one
+field is **removed**, and two defaults are **corrected** to match C#.
+
+### Fields Added
+
+| Field | Type | Default | C# equivalent | Purpose |
+|---|---|---|---|---|
+| `max_refresh_retries` | `u32` | `3` | `MaxUrlRefreshAttempts = 3` | Max URL refresh attempts before terminal error |
+| `num_download_workers` | `usize` | `3` | `ParallelDownloads = 3` | Number of parallel download worker tasks |
+| `url_expiration_buffer_secs` | `u32` | `60` | `UrlExpirationBufferSeconds = 60` | Seconds before expiry to trigger proactive refresh |
+
+> `LINK_EXPIRY_BUFFER_SECS` (currently hardcoded to `30`) is replaced by the configurable
+> `url_expiration_buffer_secs` (default `60`, matching C#).
+
+### Field Removed
+
+| Field | Reason |
+|---|---|
+| `chunk_ready_timeout` | Served only the `wait_for_chunk` Notify poll loop, which is deleted. The oneshot-based consumer resolves immediately on success, error, or sender drop — no timeout guard is needed. C# has no equivalent "wait for chunk" timeout for the same reason: `TaskCompletionSource` always completes. |
+
+### Fields Unchanged
+
+| Field | Old use | New use | Default change? |
+|---|---|---|---|
+| `max_chunks_in_memory` | Manual `AtomicUsize` counter | `mpsc::channel(max_chunks_in_memory)` capacity bound | No |
+| `max_retries` | Per-download retry limit | Unchanged | **Yes: 5 → 3** (align with C# `MaxRetries = 3`) |
+| `retry_delay` | Constant sleep | Linear backoff: `retry_delay * (attempt + 1)` — matches C# `RetryDelayMs * (retry + 1)` | **Yes: 1500ms → 500ms** (align with C# `RetryDelayMs = 500`) |
+| `link_prefetch_window` | Background prefetch ahead of consumer | Unchanged — owned by `SeaChunkLinkFetcher` | No |
+| `speed_threshold_mbps` | Download speed warning | Unchanged | No |
+| `enabled` | CloudFetch enable flag | Unchanged | No |
+
+---
+
+## Alternatives Considered
+
+### Keep DashMap, fix lock discipline incrementally
+
+Viable short-term (demonstrated by the current PR patches). Does not address Arrow data living
+in a concurrent map, and the lock discipline comments must be maintained indefinitely.
+
+### Keep DashMap, add `Arc<OnceLock<...>>` per entry for result delivery
+
+Would replace `Notify`-based polling with a future-based signal but still stores Arrow data in
+the map and retains the URL/lock complexity.
+
+### Use `tokio::sync::RwLock<HashMap>` instead of `DashMap`
+
+Trades shard-level locking for a single lock. Simpler discipline but higher contention; does not
+address the root issue of co-locating three concerns in one structure.
+
+---
+
+## Test Strategy
+
+### Unit Tests
+
+- `scheduler_sends_handles_in_chunk_index_order` — verify `result_channel` receives handles in sequence
+- `scheduler_processes_batch_links` — `fetch_links()` returns 3 links; verify all 3 tasks enqueued in order
+- `worker_retries_on_transient_error` — mock downloader fails N times then succeeds
+- `worker_uses_linear_backoff` — verify sleep duration is `retry_delay * (attempt + 1)`, not constant
+- `worker_refetches_url_on_401_403_404` — mock downloader returns auth error; verify `refetch_link` called inline
+- `worker_no_sleep_on_auth_error` — verify auth error does not sleep before refetch
+- `worker_gives_up_after_max_refresh_retries` — verify terminal error propagated via `result_tx`
+- `worker_proactively_refreshes_expiring_url` — link expires within `url_expiration_buffer_secs`; verify `refetch_link` called before first HTTP request
+- `backpressure_blocks_scheduler_at_capacity` — full `result_channel` blocks scheduler, not consumer
+
+### Integration Tests
+
+- `end_to_end_sequential_consumption` — all chunks downloaded and read in order
+- `end_to_end_cancellation_mid_stream` — cancel during active download, no deadlock or panic
+- `end_to_end_401_recovery` — presigned URL expires mid-stream, driver refetches and continues

--- a/rust/spec/sprint-plan-cloudfetch-redesign.md
+++ b/rust/spec/sprint-plan-cloudfetch-redesign.md
@@ -1,0 +1,294 @@
+# Sprint Plan: CloudFetch Pipeline Redesign (DashMap → Channel-Based)
+
+**Date:** 2026-02-28
+**Sprint Duration:** 2 weeks
+**JIRA Story:** [PECO-2926](https://databricks.atlassian.net/browse/PECO-2926)
+**Epic:** [PECO-2888](https://databricks.atlassian.net/browse/PECO-2888) — Databricks Driver Test Framework
+**Spec:** `rust/spec/cloudfetch-pipeline-redesign.md`
+
+---
+
+## Sprint Goal
+
+Replace the `DashMap<i64, ChunkEntry>` coordination structure in `StreamingCloudFetchProvider` with a two-channel pipeline (`download_channel` + `result_channel`) aligned with the C# reference implementation, eliminating lock discipline issues, large data in concurrent maps, and poll-based consumer synchronisation.
+
+---
+
+## Background
+
+The current implementation uses a single `DashMap` as the central coordination point for three unrelated concerns: presigned URL storage, download state machine, and result buffering (potentially 100 MB+). This causes:
+
+- Lock discipline burden (must not hold DashMap shard locks across `.await` points)
+- Unnatural indirection for URL refresh (two-`get_mut` dance)
+- Large Arrow data stored in a concurrent map with `Clone`-derivation risk
+- Poll-based consumer synchronisation via `Notify` loop
+
+The C# driver avoids all of these by flowing each chunk through two channels. This sprint implements the same pattern in Rust.
+
+---
+
+## Corrections from C# Reference Comparison
+
+Before implementation, the spec was audited against `csharp/src/Reader/CloudFetch/`. The following discrepancies were found and corrected in the spec:
+
+| Area | Original Spec | Corrected |
+|---|---|---|
+| `fetch_links()` return type | Implied single link per call | Returns `Vec<CloudFetchLink>` (batch) — scheduler must iterate |
+| Retry backoff | Said "exponential backoff is a follow-up" | **Linear**: `retry_delay * (attempt + 1)` matching C# `Task.Delay(_retryDelayMs * (retry + 1))` |
+| `url_expiration_buffer_secs` | Hardcoded constant `LINK_EXPIRY_BUFFER_SECS = 30` | Configurable field, default **60s** (matching C# `UrlExpirationBufferSeconds = 60`) |
+| `max_refresh_retries` | Referenced in spec but not defined | New `CloudFetchConfig` field, default **3** (matching C# `MaxUrlRefreshAttempts = 3`) |
+| `num_download_workers` | "N workers" with no source for N | New `CloudFetchConfig` field, default **3** (matching C# `ParallelDownloads = 3`) |
+| `max_retries` default | 5 | **3** (matching C# `MaxRetries = 3`) |
+| `retry_delay` default | 1500ms | **500ms** (matching C# `RetryDelayMs = 500`) |
+| `chunk_ready_timeout` | Not mentioned for removal | **Removed** — only served the `wait_for_chunk` Notify loop (deleted); C# has no equivalent wait-layer timeout |
+
+---
+
+## Architecture Overview
+
+```
+ChunkLinkFetcher → Scheduler → download_channel → Worker 1
+                            ↘                  → Worker 2
+                              result_channel      Worker N
+                                    ↓               ↓ (oneshot)
+                               Consumer       result_channel
+```
+
+**Two channels replace the DashMap:**
+- `download_channel` — unbounded; scheduler pushes `ChunkDownloadTask`, workers pull
+- `result_channel` — bounded to `max_chunks_in_memory`; scheduler pushes `ChunkHandle` in chunk-index order; consumer reads sequentially
+
+**Key new types:**
+
+```rust
+struct ChunkDownloadTask {
+    chunk_index: i64,
+    link: CloudFetchLink,
+    result_tx: oneshot::Sender<Result<Vec<RecordBatch>>>,
+}
+
+struct ChunkHandle {
+    chunk_index: i64,
+    result_rx: oneshot::Receiver<Result<Vec<RecordBatch>>>,
+}
+```
+
+---
+
+## Sub-Tasks
+
+### PECO-2927 — Update `CloudFetchConfig` and remove legacy types ✅ COMPLETED
+
+**Scope:** `rust/src/types/cloudfetch.rs`
+
+**Status:** Completed (commit c6e8251)
+
+**Changes:**
+- Add 3 new fields to `CloudFetchConfig`:
+  - `max_refresh_retries: u32` — default `3`
+  - `num_download_workers: usize` — default `3`
+  - `url_expiration_buffer_secs: u32` — default `60`
+- Remove `chunk_ready_timeout: Option<Duration>`
+- Correct defaults: `max_retries` 5→3, `retry_delay` 1500ms→500ms
+- Remove `LINK_EXPIRY_BUFFER_SECS` constant (replaced by `url_expiration_buffer_secs`)
+- Remove `ChunkEntry` and `ChunkState` types entirely
+- Update `CloudFetchLink::is_expired()` to accept a buffer parameter (in seconds) instead of using the hardcoded constant
+- Update all tests in this file
+
+**Implementation Notes:**
+- ChunkEntry and ChunkState were moved temporarily to `streaming_provider.rs` as local types to keep the build working
+- These local types will be removed when PECO-2928 through PECO-2931 implement the channel-based pipeline
+- Added new config options in database.rs: `max_refresh_retries`, `num_download_workers`, `url_expiration_buffer_secs`
+- Removed deprecated `chunk_ready_timeout_ms` option from database.rs
+
+---
+
+### PECO-2928 — Implement `ChunkDownloadTask`, `ChunkHandle`, and Scheduler ✅ COMPLETED
+
+**Scope:** New types + new scheduler task in `rust/src/reader/cloudfetch/`
+
+**Status:** Completed
+
+**Changes (Types - COMPLETED):**
+- Add `ChunkDownloadTask` struct with `chunk_index`, `link`, `result_tx` (oneshot sender)
+- Add `ChunkHandle` struct with `chunk_index`, `result_rx` (oneshot receiver)
+- Add `create_chunk_pair()` helper function for creating connected task/handle pairs
+- Types defined in new module: `rust/src/reader/cloudfetch/pipeline_types.rs`
+- Types exported from `mod.rs`
+
+**Changes (Scheduler - COMPLETED):**
+- Implemented scheduler as a `tokio::spawn` task in `rust/src/reader/cloudfetch/scheduler.rs`:
+  - `spawn_scheduler()` function creates channels and spawns scheduler task
+  - `scheduler_task()` calls `fetch_links()` which returns `Vec<CloudFetchLink>` (batch)
+  - For each link in the batch: creates `oneshot::channel()` via `create_chunk_pair()`, sends `ChunkHandle` to `result_channel`, then sends `ChunkDownloadTask` to `download_channel`
+  - `download_channel`: unbounded mpsc for `ChunkDownloadTask`
+  - `result_channel`: bounded mpsc (capacity = `max_chunks_in_memory`) for `ChunkHandle`
+  - Bounded `result_channel` provides automatic backpressure (blocks scheduler when `max_chunks_in_memory` reached)
+  - Exits when `has_more = false`
+  - Supports cancellation via `CancellationToken`
+- Returns `SchedulerChannels` struct containing both channel receivers
+
+**Key invariant:** `ChunkHandle` is enqueued to `result_channel` _before_ the corresponding `ChunkDownloadTask` is dispatched to `download_channel`, preserving sequential ordering even when downloads complete out of order.
+
+**Tests implemented:**
+- `scheduler_sends_handles_in_chunk_index_order` — verify handles received in sequence
+- `scheduler_processes_batch_links` — verify all tasks/handles enqueued from batch
+- `backpressure_blocks_scheduler_at_capacity` — verify bounded channel blocks scheduler
+- `scheduler_exits_when_has_more_false` — verify clean exit
+- `scheduler_cancellation` — verify early termination on cancel
+- `scheduler_handle_before_task` — verify ordering invariant
+- `scheduler_multiple_batches` — verify multiple fetch_links calls
+- `scheduler_empty_batch` — verify empty batch handling
+
+---
+
+### PECO-2929 — Implement Download Workers ✅ COMPLETED
+
+**Scope:** `rust/src/reader/cloudfetch/` (replaces `download_chunk_with_retry`)
+
+**Status:** Completed
+
+**Changes:**
+- Spawn `config.num_download_workers` long-lived `tokio::spawn` tasks
+- Each worker loops over `download_channel`:
+  1. **Proactive expiry check** using `url_expiration_buffer_secs` buffer — if link is expired or expiring soon, call `refetch_link()` before first HTTP request
+  2. `GET presigned_url`
+  3. On success: parse Arrow IPC → `result_tx.send(Ok(batches))`
+  4. On 401/403/404: call `refetch_link()`, retry immediately (no sleep), count against `max_refresh_retries`
+  5. On other errors: `sleep(retry_delay * (attempt + 1))` (linear backoff), retry, count against `max_retries`
+  6. On `max_retries` exceeded: `result_tx.send(Err(...))`
+- All sleeps use `tokio::select!` on `cancel_token.cancelled()` for cancellation
+
+**Retry contract:**
+
+| Error type | Sleep before retry | Counts against `max_retries` | Counts against `max_refresh_retries` |
+|---|---|---|---|
+| Network / 5xx | Yes — `retry_delay * (attempt + 1)` | Yes | No |
+| 401 / 403 / 404 | No | Yes | Yes |
+| Link proactively expired | No | No | Yes |
+
+**Implementation Notes:**
+- `download_workers.rs` module implements the worker pool with `spawn_download_workers()`
+- `WorkerConfig` struct extracts relevant configuration from `CloudFetchConfig`
+- Uses `DownloadError` enum from `chunk_downloader.rs` for categorized error handling
+- All tests pass including: `test_worker_retries_on_transient_error`, `test_worker_uses_linear_backoff`, `test_worker_refetches_url_on_401_403_404`, `test_worker_no_sleep_on_auth_error`, `test_worker_gives_up_after_max_refresh_retries`, `test_worker_proactively_refreshes_expiring_url`
+
+---
+
+### PECO-2930 — Implement Consumer (`next_batch`)
+
+**Scope:** `rust/src/reader/cloudfetch/streaming_provider.rs`
+
+**Changes:**
+- Replace `wait_for_chunk` + Notify poll loop with:
+  ```rust
+  let handle = result_rx.recv().await?;  // get next ChunkHandle in order
+  let batches = handle.result_rx.await?;  // await the oneshot directly
+  ```
+- `Ok(None)` when `result_rx` returns `None` (channel closed = end of stream)
+- Consumer selects on `cancel_token.cancelled()` when awaiting `result_rx`
+
+---
+
+### PECO-2931 — Refactor `StreamingCloudFetchProvider` struct
+
+**Scope:** `rust/src/reader/cloudfetch/streaming_provider.rs`
+
+**Remove these fields:**
+
+| Field | Replaced by |
+|---|---|
+| `chunks: Arc<DashMap<i64, ChunkEntry>>` | `download_channel` + `result_channel` |
+| `chunks_in_memory: AtomicUsize` | Bounded `result_channel` capacity |
+| `max_chunks_in_memory: usize` | `mpsc::channel(max_chunks_in_memory)` bound |
+| `chunk_state_changed: Arc<Notify>` | `oneshot` receivers per chunk |
+| `next_download_index: AtomicI64` | Sequential counter owned by scheduler task |
+| `current_chunk_index: AtomicI64` | Implicit in sequential `result_rx.recv()` calls |
+| `end_of_stream: AtomicBool` | Implicit when `result_rx` returns `None` |
+
+**New struct:**
+```rust
+pub struct StreamingCloudFetchProvider {
+    result_rx: Mutex<mpsc::Receiver<ChunkHandle>>,
+    schema: OnceLock<SchemaRef>,
+    batch_buffer: Mutex<VecDeque<RecordBatch>>,
+    cancel_token: CancellationToken,
+}
+```
+
+---
+
+### PECO-2932 — Unit Tests (9 tests)
+
+| Test | What it verifies |
+|---|---|
+| `scheduler_sends_handles_in_chunk_index_order` | `result_channel` receives handles in sequence |
+| `scheduler_processes_batch_links` | `fetch_links()` returns 3 links; all 3 tasks enqueued in order |
+| `worker_retries_on_transient_error` | Mock downloader fails N times then succeeds |
+| `worker_uses_linear_backoff` | Sleep duration is `retry_delay * (attempt + 1)`, not constant or exponential |
+| `worker_refetches_url_on_401_403_404` | Auth error triggers `refetch_link` inline |
+| `worker_no_sleep_on_auth_error` | Auth error does not sleep before refetch |
+| `worker_gives_up_after_max_refresh_retries` | Terminal error propagated via `result_tx` |
+| `worker_proactively_refreshes_expiring_url` | Link expiring within buffer triggers `refetch_link` before first HTTP request |
+| `backpressure_blocks_scheduler_at_capacity` | Full `result_channel` blocks scheduler, not consumer |
+
+---
+
+### PECO-2933 — Integration Tests (3 tests)
+
+| Test | What it verifies |
+|---|---|
+| `end_to_end_sequential_consumption` | All chunks downloaded and read in order |
+| `end_to_end_cancellation_mid_stream` | Cancel during active download — no deadlock or panic |
+| `end_to_end_401_recovery` | Presigned URL expires mid-stream; driver refetches and continues |
+
+---
+
+## Concurrency Model
+
+| Component | Primitive | Reason |
+|---|---|---|
+| Scheduler | Single `tokio::spawn` | Sequential chunk ordering required |
+| Download workers | N `tokio::spawn` sharing `download_channel` | Parallel downloads |
+| Consumer | Caller's task (no spawn) | Sequential result consumption |
+| `result_channel` | Bounded `mpsc` (capacity = `max_chunks_in_memory`) | Backpressure without manual counter |
+| URL refresh in worker | Local variable mutation | No shared state, no lock needed |
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Download fails after `max_retries` | `result_tx.send(Err(...))` — consumer sees error on `result_rx.await` |
+| URL refresh fails after `max_refresh_retries` | Same as above |
+| `refetch_link()` itself returns error | Propagated via `result_tx.send(Err(...))` |
+| Cancellation during sleep | `tokio::select!` on `cancel_token.cancelled()` interrupts sleep |
+| Cancellation during `result_rx.await` | Consumer selects on `cancel_token.cancelled()` |
+| Scheduler exits (all chunks sent) | `download_channel` sender drops → workers drain then exit |
+| All workers exit | `oneshot` senders drop → `result_rx.await` returns `Err(RecvError)` |
+
+---
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `rust/src/types/cloudfetch.rs` | Update `CloudFetchConfig`, remove `ChunkEntry`/`ChunkState` |
+| `rust/src/reader/cloudfetch/streaming_provider.rs` | Full rewrite of struct + pipeline |
+| `rust/src/reader/cloudfetch/chunk_downloader.rs` | Replace with worker loop |
+| `rust/src/reader/cloudfetch/link_fetcher.rs` | No changes (internal DashMap cache retained) |
+
+---
+
+## Definition of Done
+
+- [ ] `cargo build` passes with no warnings
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] All 9 unit tests pass
+- [ ] All 3 integration tests pass
+- [ ] `cargo fmt` applied
+- [ ] `DashMap` dependency removed from `streaming_provider.rs`
+- [ ] `ChunkEntry`, `ChunkState` types deleted
+- [ ] `chunk_ready_timeout` config field removed
+- [ ] `LINK_EXPIRY_BUFFER_SECS` constant removed

--- a/rust/src/database.rs
+++ b/rust/src/database.rs
@@ -222,10 +222,25 @@ impl Optionable for Database {
                         Err(DatabricksErrorHelper::set_invalid_option(&key, &value).to_adbc())
                     }
                 }
-                "databricks.cloudfetch.chunk_ready_timeout_ms" => {
+                "databricks.cloudfetch.max_refresh_retries" => {
                     if let Some(v) = Self::parse_int_option(&value) {
-                        self.cloudfetch_config.chunk_ready_timeout =
-                            Some(Duration::from_millis(v as u64));
+                        self.cloudfetch_config.max_refresh_retries = v as u32;
+                        Ok(())
+                    } else {
+                        Err(DatabricksErrorHelper::set_invalid_option(&key, &value).to_adbc())
+                    }
+                }
+                "databricks.cloudfetch.num_download_workers" => {
+                    if let Some(v) = Self::parse_int_option(&value) {
+                        self.cloudfetch_config.num_download_workers = v as usize;
+                        Ok(())
+                    } else {
+                        Err(DatabricksErrorHelper::set_invalid_option(&key, &value).to_adbc())
+                    }
+                }
+                "databricks.cloudfetch.url_expiration_buffer_secs" => {
+                    if let Some(v) = Self::parse_int_option(&value) {
+                        self.cloudfetch_config.url_expiration_buffer_secs = v as u32;
                         Ok(())
                     } else {
                         Err(DatabricksErrorHelper::set_invalid_option(&key, &value).to_adbc())

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -22,7 +22,7 @@ pub mod cloudfetch;
 pub mod sea;
 
 // Re-export commonly used types
-pub use cloudfetch::{ChunkEntry, ChunkState, CloudFetchConfig, CloudFetchLink};
+pub use cloudfetch::{CloudFetchConfig, CloudFetchLink};
 pub use sea::{
     ChunkInfo, ColumnInfo, CompressionCodec, ExecuteParams, ExecuteStatementRequest, ExternalLink,
     ResultData, ResultManifest, ResultSchema, ServiceError, StatementExecutionResponse,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/263/files) to review incremental changes.
- [**stack/task-1-update-cloudfetch-config**](https://github.com/adbc-drivers/databricks/pull/263) [[Files changed](https://github.com/adbc-drivers/databricks/pull/263/files)]
  - [stack/task-2-implement-pipeline-types](https://github.com/adbc-drivers/databricks/pull/264) [[Files changed](https://github.com/adbc-drivers/databricks/pull/264/files/9fd0b15828c4d9f6204091027d973b1b528256fa..04b700d1606ce29cde228c26a081a8d026175b04)]
    - [stack/task-3-implement-scheduler](https://github.com/adbc-drivers/databricks/pull/265) [[Files changed](https://github.com/adbc-drivers/databricks/pull/265/files/04b700d1606ce29cde228c26a081a8d026175b04..ee45c57d02775296a570a60b4f2247ef13bc39f5)]
      - [stack/task-4-implement-download-workers](https://github.com/adbc-drivers/databricks/pull/266) [[Files changed](https://github.com/adbc-drivers/databricks/pull/266/files/ee45c57d02775296a570a60b4f2247ef13bc39f5..3aebbb75f3fdf6da06510acd9cb663576b2afccb)]
        - [stack/task-5-implement-consumer](https://github.com/adbc-drivers/databricks/pull/267) [[Files changed](https://github.com/adbc-drivers/databricks/pull/267/files/3aebbb75f3fdf6da06510acd9cb663576b2afccb..2dc961dee25a77f993169fd04ff474bda58a924e)]
          - stack/task-6-refactor-provider-struct
            - [stack/task-peco-2933-integration-tests](https://github.com/adbc-drivers/databricks/pull/268) [[Files changed](https://github.com/adbc-drivers/databricks/pull/268/files/2dc961dee25a77f993169fd04ff474bda58a924e..0041ea103e47eb02da3846cb09135c5ea41ab995)]
              - [stack/task-peco-2933a-sequential-consumption-test](https://github.com/adbc-drivers/databricks/pull/269) [[Files changed](https://github.com/adbc-drivers/databricks/pull/269/files/0041ea103e47eb02da3846cb09135c5ea41ab995..bb9d6db40dd5321cabe44e4974f652e5fa19d486)]
                - [stack/task-peco-2933b-cancellation-test](https://github.com/adbc-drivers/databricks/pull/270) [[Files changed](https://github.com/adbc-drivers/databricks/pull/270/files/bb9d6db40dd5321cabe44e4974f652e5fa19d486..a78d71e1e3f2b5601c2f4eb1d9f0e485e31c5ad0)]
                  - [stack/task-peco-2933c-401-recovery-test](https://github.com/adbc-drivers/databricks/pull/271) [[Files changed](https://github.com/adbc-drivers/databricks/pull/271/files/a78d71e1e3f2b5601c2f4eb1d9f0e485e31c5ad0..389b3c7ca56ff0c62c77cadf2d2b6536718c1875)]

---------
Update CloudFetchConfig to align with C# CloudFetchConfiguration:

New fields:
- max_refresh_retries: u32 (default 3) - Max URL refresh attempts
- num_download_workers: usize (default 3) - Parallel download workers
- url_expiration_buffer_secs: u32 (default 60) - Proactive refresh buffer

Default corrections:
- max_retries: 5 → 3 (C# MaxRetries)
- retry_delay: 1500ms → 500ms (C# RetryDelayMs)

Removed:
- chunk_ready_timeout field (legacy Notify-based wait mechanism)
- LINK_EXPIRY_BUFFER_SECS constant (replaced by configurable buffer)
- ChunkEntry and ChunkState types from cloudfetch.rs (moved locally
  to streaming_provider.rs until channel-based pipeline is complete)

CloudFetchLink::is_expired() now accepts a buffer_secs parameter
instead of using a hardcoded constant.

Part of PECO-2927: CloudFetch Pipeline Redesign

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## What's Changed

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
