### PR TITLE
build(rust): add staticlib to crate-type for static linking

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -75,4 +75,4 @@ ffi = ["adbc_ffi"]
 
 [lib]
 name = "databricks_adbc"
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]


### PR DESCRIPTION
## Summary
- Adds `staticlib` to the `crate-type` list in `rust/Cargo.toml` alongside the existing `lib` and `cdylib` types
- This allows downstream consumers (e.g., the Databricks ODBC driver) to statically link the Rust ADBC driver, producing a single fat `.so` with no runtime dependency on `libdatabricks_adbc.so`
- No functional changes — existing `lib` and `cdylib` outputs are unaffected

## Test plan
- [ ] `cargo build` succeeds and produces `.a` in addition to `.so`
- [ ] `cargo test` passes (no behavior change)
- [ ] Downstream ODBC driver builds successfully with `CRATE_TYPES staticlib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)