### PR TITLE
fix(csharp): enforce query timeout in SEA PollUntilCompleteAsync (PECO-2937)

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -22,6 +22,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Reader.CloudFetch;
+using AdbcDrivers.HiveServer2;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tracing;
@@ -49,6 +50,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private readonly string? _resultCompression;
         private readonly int _waitTimeoutSeconds;
         private readonly int _pollingIntervalMs;
+        private readonly int _queryTimeoutSeconds; // 0 = no timeout
 
         // Connection properties for CloudFetch configuration
         private readonly IReadOnlyDictionary<string, string> _properties;
@@ -93,6 +95,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _waitTimeoutSeconds = waitTimeoutSeconds;
             _pollingIntervalMs = pollingIntervalMs;
             _properties = properties ?? throw new ArgumentNullException(nameof(properties));
+            _queryTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(
+                properties, ApacheParameters.QueryTimeoutSeconds, 0);
             _recyclableMemoryStreamManager = recyclableMemoryStreamManager ?? throw new ArgumentNullException(nameof(recyclableMemoryStreamManager));
             _lz4BufferPool = lz4BufferPool ?? throw new ArgumentNullException(nameof(lz4BufferPool));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -156,7 +160,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             var state = response.Status?.State;
             if (state == "PENDING" || state == "RUNNING")
             {
-                response = await PollUntilCompleteAsync(response.StatementId, cancellationToken).ConfigureAwait(false);
+                response = await PollWithTimeoutAsync(response.StatementId, cancellationToken).ConfigureAwait(false);
                 state = response.Status?.State;
             }
 
@@ -195,6 +199,41 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Return query result - use -1 if row count is not available
             long rowCount = response.Manifest?.TotalRowCount ?? -1;
             return new QueryResult(rowCount, reader);
+        }
+
+        /// <summary>
+        /// Wraps PollUntilCompleteAsync with query timeout enforcement.
+        /// If _queryTimeoutSeconds > 0, cancels the server-side statement and throws on timeout.
+        /// </summary>
+        private async Task<ExecuteStatementResponse> PollWithTimeoutAsync(string statementId, CancellationToken cancellationToken)
+        {
+            if (_queryTimeoutSeconds <= 0)
+            {
+                return await PollUntilCompleteAsync(statementId, cancellationToken).ConfigureAwait(false);
+            }
+
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(_queryTimeoutSeconds));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            try
+            {
+                return await PollUntilCompleteAsync(statementId, linkedCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                // Timeout fired (not caller cancellation) — cancel statement on server, best-effort
+                try
+                {
+                    await _client.CancelStatementAsync(statementId, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort; ignore cancel errors
+                }
+                throw new AdbcException(
+                    $"Query timed out after {_queryTimeoutSeconds} seconds (statement {statementId}). " +
+                    $"Increase timeout via '{ApacheParameters.QueryTimeoutSeconds}' or set to 0 for no timeout.");
+            }
         }
 
         /// <summary>
@@ -427,7 +466,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             var state = response.Status?.State;
             if (state == "PENDING" || state == "RUNNING")
             {
-                response = await PollUntilCompleteAsync(response.StatementId, cancellationToken).ConfigureAwait(false);
+                response = await PollWithTimeoutAsync(response.StatementId, cancellationToken).ConfigureAwait(false);
                 state = response.Status?.State;
             }
 

--- a/csharp/test/Unit/StatementExecution/StatementExecutionQueryTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionQueryTimeoutTests.cs
@@ -1,0 +1,305 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.StatementExecution;
+using AdbcDrivers.HiveServer2;
+using Apache.Arrow.Adbc;
+using AdbcDrivers.HiveServer2.Spark;
+using Microsoft.IO;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
+{
+    /// <summary>
+    /// Tests that query timeout (adbc.apache.statement.query_timeout_s) is enforced
+    /// during polling in PollUntilCompleteAsync (PECO-2937).
+    /// </summary>
+    public class StatementExecutionQueryTimeoutTests : IDisposable
+    {
+        private const string StatementId = "stmt-timeout-test";
+        private readonly Mock<IStatementExecutionClient> _mockClient;
+        private readonly HttpClient _httpClient;
+        private readonly RecyclableMemoryStreamManager _memoryManager;
+
+        public StatementExecutionQueryTimeoutTests()
+        {
+            _mockClient = new Mock<IStatementExecutionClient>();
+            _memoryManager = new RecyclableMemoryStreamManager();
+
+            // Minimal HTTP client for creating StatementExecutionConnection (tracing only)
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonSerializer.Serialize(new { session_id = "s1" }))
+                });
+            _httpClient = new HttpClient(handler.Object);
+        }
+
+        private StatementExecutionStatement CreateStatement(int queryTimeoutSeconds, int pollingIntervalMs = 50)
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.HostName, "test.databricks.com" },
+                { DatabricksParameters.WarehouseId, "wh-1" },
+                { SparkParameters.AccessToken, "token" },
+                { ApacheParameters.QueryTimeoutSeconds, queryTimeoutSeconds.ToString() }
+            };
+
+            var connection = new StatementExecutionConnection(properties, _httpClient);
+
+            var stmt = new StatementExecutionStatement(
+                _mockClient.Object,
+                sessionId: "session-1",
+                warehouseId: "wh-1",
+                catalog: null,
+                schema: null,
+                resultDisposition: "INLINE_OR_EXTERNAL_LINKS",
+                resultFormat: "ARROW_STREAM",
+                resultCompression: null,
+                waitTimeoutSeconds: 0,
+                pollingIntervalMs: pollingIntervalMs,
+                properties: properties,
+                recyclableMemoryStreamManager: _memoryManager,
+                lz4BufferPool: System.Buffers.ArrayPool<byte>.Shared,
+                httpClient: _httpClient,
+                connection: connection);
+
+            stmt.SqlQuery = "SELECT 1";
+            return stmt;
+        }
+
+        private void SetupExecuteReturnsRunning()
+        {
+            _mockClient
+                .Setup(c => c.ExecuteStatementAsync(It.IsAny<ExecuteStatementRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ExecuteStatementResponse
+                {
+                    StatementId = StatementId,
+                    Status = new StatementStatus { State = "RUNNING" }
+                });
+        }
+
+        [Fact]
+        public async Task ExecuteQueryAsync_NoTimeout_CompletesNormally()
+        {
+            SetupExecuteReturnsRunning();
+
+            // GetStatement: first call returns RUNNING, second returns SUCCEEDED
+            var callCount = 0;
+            _mockClient
+                .Setup(c => c.GetStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    callCount++;
+                    return callCount == 1
+                        ? new GetStatementResponse { StatementId = StatementId, Status = new StatementStatus { State = "RUNNING" } }
+                        : new GetStatementResponse
+                        {
+                            StatementId = StatementId,
+                            Status = new StatementStatus { State = "SUCCEEDED" },
+                            Manifest = new ResultManifest { Format = "ARROW_STREAM", Chunks = new System.Collections.Generic.List<ResultChunk>() }
+                        };
+                });
+
+            using var stmt = CreateStatement(queryTimeoutSeconds: 0);
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.RowCount);
+        }
+
+        [Fact]
+        public async Task ExecuteQueryAsync_WithTimeout_CompletesBeforeTimeout()
+        {
+            SetupExecuteReturnsRunning();
+
+            // Returns SUCCEEDED on first GetStatement poll
+            _mockClient
+                .Setup(c => c.GetStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetStatementResponse
+                {
+                    StatementId = StatementId,
+                    Status = new StatementStatus { State = "SUCCEEDED" },
+                    Manifest = new ResultManifest { Format = "ARROW_STREAM", Chunks = new System.Collections.Generic.List<ResultChunk>() }
+                });
+
+            using var stmt = CreateStatement(queryTimeoutSeconds: 30);
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task ExecuteQueryAsync_TimeoutExpires_ThrowsAdbcExceptionAndCancelsStatement()
+        {
+            SetupExecuteReturnsRunning();
+
+            // GetStatement always returns RUNNING (query never finishes)
+            _mockClient
+                .Setup(c => c.GetStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .Returns<string, CancellationToken>(async (id, ct) =>
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                    return null!; // never reached
+                });
+
+            _mockClient
+                .Setup(c => c.CancelStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            using var stmt = CreateStatement(queryTimeoutSeconds: 1, pollingIntervalMs: 50);
+
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stmt.ExecuteQueryAsync(CancellationToken.None));
+
+            Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(StatementId, ex.Message);
+            Assert.Contains("1", ex.Message); // timeout value
+            Assert.Contains(ApacheParameters.QueryTimeoutSeconds, ex.Message);
+
+            // Server-side cancel should have been called
+            _mockClient.Verify(c =>
+                c.CancelStatementAsync(StatementId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteQueryAsync_CallerCancels_ThrowsOperationCanceledNotTimeoutMessage()
+        {
+            SetupExecuteReturnsRunning();
+
+            _mockClient
+                .Setup(c => c.GetStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .Returns<string, CancellationToken>(async (id, ct) =>
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                    return null!;
+                });
+
+            using var cts = new CancellationTokenSource(millisecondsDelay: 200);
+            using var stmt = CreateStatement(queryTimeoutSeconds: 30, pollingIntervalMs: 50);
+
+            // Should throw OperationCanceledException, not AdbcException with timeout message
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                stmt.ExecuteQueryAsync(cts.Token));
+
+            // Server-side cancel should NOT have been called (it's the caller who cancelled)
+            _mockClient.Verify(c =>
+                c.CancelStatementAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ExecuteQueryAsync_ZeroTimeout_DisablesTimeout()
+        {
+            SetupExecuteReturnsRunning();
+
+            var callCount = 0;
+            _mockClient
+                .Setup(c => c.GetStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    callCount++;
+                    if (callCount < 3) return new GetStatementResponse { StatementId = StatementId, Status = new StatementStatus { State = "RUNNING" } };
+                    return new GetStatementResponse
+                    {
+                        StatementId = StatementId,
+                        Status = new StatementStatus { State = "SUCCEEDED" },
+                        Manifest = new ResultManifest { Format = "ARROW_STREAM", Chunks = new System.Collections.Generic.List<ResultChunk>() }
+                    };
+                });
+
+            using var stmt = CreateStatement(queryTimeoutSeconds: 0);
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+
+            Assert.NotNull(result);
+            Assert.Equal(3, callCount);
+        }
+
+        [Fact]
+        public async Task ExecuteUpdateAsync_TimeoutExpires_ThrowsAdbcExceptionAndCancelsStatement()
+        {
+            SetupExecuteReturnsRunning();
+
+            _mockClient
+                .Setup(c => c.GetStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .Returns<string, CancellationToken>(async (id, ct) =>
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                    return null!;
+                });
+
+            _mockClient
+                .Setup(c => c.CancelStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            using var stmt = CreateStatement(queryTimeoutSeconds: 1, pollingIntervalMs: 50);
+
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stmt.ExecuteUpdateAsync(CancellationToken.None));
+
+            Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+            _mockClient.Verify(c =>
+                c.CancelStatementAsync(StatementId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteQueryAsync_CancelStatementFails_TimeoutExceptionStillThrown()
+        {
+            SetupExecuteReturnsRunning();
+
+            _mockClient
+                .Setup(c => c.GetStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .Returns<string, CancellationToken>(async (id, ct) =>
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                    return null!;
+                });
+
+            // Cancel fails — should not suppress the timeout exception
+            _mockClient
+                .Setup(c => c.CancelStatementAsync(StatementId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Network error"));
+
+            using var stmt = CreateStatement(queryTimeoutSeconds: 1, pollingIntervalMs: 50);
+
+            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+                stmt.ExecuteQueryAsync(CancellationToken.None));
+
+            Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `PollUntilCompleteAsync` polled indefinitely when `CancellationToken.None` was passed — `adbc.apache.statement.query_timeout_s` was read from properties but never applied in the SEA code path
- Added `PollWithTimeoutAsync()` that creates a `CancellationTokenSource` linked to the configured timeout and the caller's token, wrapping `PollUntilCompleteAsync`
- On timeout: cancels the statement server-side (best-effort, errors swallowed), then throws `AdbcException` with the timeout duration and the property name so callers know how to adjust
- On caller cancellation: `OperationCanceledException` propagates unchanged (not treated as timeout)

## Reference
- **JDBC SEA**: `TimeoutHandler.checkTimeout()` called at each poll iteration, calls `cancelStatement()` on expiry
- **C# Thrift**: `ThriftResultFetcher` uses `CancellationTokenSource(TimeSpan.FromSeconds(queryTimeoutSeconds))`
- This implementation follows the C# Thrift pattern (linked CTS) rather than JDBC's elapsed-time check

## Test plan
- [ ] 7 new unit tests: no timeout, completes before timeout, timeout fires + cancel called, caller cancels (not timeout), zero disables timeout, update path, cancel failure doesn't suppress exception
- [ ] All 104 StatementExecution unit tests pass (104 passed, 11 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)