### PR TITLE
fix(csharp): use consistent user agent for SEA and Thrift modes

### DIFF
--- a/csharp/src/Http/UserAgentHelper.cs
+++ b/csharp/src/Http/UserAgentHelper.cs
@@ -31,9 +31,7 @@ namespace AdbcDrivers.Databricks.Http
         /// <param name="properties">Connection properties (optional, for user_agent_entry).</param>
         /// <returns>The User-Agent string.</returns>
         /// <remarks>
-        /// This is used for internal driver HTTP requests like feature flag fetching.
-        /// Statement execution uses a different User-Agent (DatabricksJDBCDriverOSS) for
-        /// server-side feature compatibility.
+        /// Used for all driver HTTP requests (feature flags, Thrift, and SEA statement execution).
         /// </remarks>
         public static string GetUserAgent(string assemblyVersion, IReadOnlyDictionary<string, string>? properties = null)
         {

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -304,7 +304,6 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         /// <summary>
         /// Builds the user agent string for HTTP requests.
-        /// Format: DatabricksJDBCDriverOSS/{version} (ADBC)
         /// Uses the same format as Thrift mode for consistency.
         /// </summary>
         private string GetUserAgent(IReadOnlyDictionary<string, string> properties)

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -305,22 +305,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// <summary>
         /// Builds the user agent string for HTTP requests.
         /// Format: DatabricksJDBCDriverOSS/{version} (ADBC)
-        /// Uses DatabricksJDBCDriverOSS prefix for server-side feature compatibility.
+        /// Uses the same format as Thrift mode for consistency.
         /// </summary>
         private string GetUserAgent(IReadOnlyDictionary<string, string> properties)
         {
-            // Use DatabricksJDBCDriverOSS prefix for server-side feature compatibility
-            // (e.g., INLINE_OR_EXTERNAL_LINKS disposition support)
-            string baseUserAgent = $"DatabricksJDBCDriverOSS/{AssemblyVersion} (ADBC)";
-
-            // Check if a client has provided a user-agent entry
-            string userAgentEntry = PropertyHelper.GetStringProperty(properties, "adbc.spark.user_agent_entry", string.Empty);
-            if (!string.IsNullOrWhiteSpace(userAgentEntry))
-            {
-                return $"{baseUserAgent} {userAgentEntry}";
-            }
-
-            return baseUserAgent;
+            return UserAgentHelper.GetUserAgent(AssemblyVersion, properties);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- SEA mode was using a hardcoded `DatabricksJDBCDriverOSS/{version} (ADBC)` user agent
- Now uses `UserAgentHelper.GetUserAgent` — the same as Thrift mode — producing `AdbcDatabricksDriver/{version}`
- Also respects the `adbc.spark.user_agent_entry` property for custom suffixes, consistent with Thrift behavior