### PR TITLE
fix(csharp): use TypeText for Spark:DataType:SqlName in SEA schema metadata

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -482,7 +482,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 // it here for now. Add it if a consumer requires it (PECO-2950).
                 var metadata = new Dictionary<string, string>
                 {
-                    ["Spark:DataType:SqlName"] = ColumnMetadataHelper.GetSparkSqlName(column.TypeName ?? string.Empty)
+                    ["Spark:DataType:SqlName"] = ColumnMetadataHelper.GetSparkSqlName(column.TypeText ?? column.TypeName ?? string.Empty)
                 };
                 fields.Add(new Field(column.Name, arrowType, true, metadata));
             }


### PR DESCRIPTION
## Summary
- `TypeName` is an enum of base types only (`ARRAY`, `DECIMAL`, `STRUCT`) and loses detail for complex and parameterized types
- `TypeText` contains the full SQL type specification (`ARRAY<INT>`, `DECIMAL(10,2)`, `STRUCT<id:INT,name:STRING>`) — matching what the Thrift server embeds in `Spark:DataType:SqlName`
- Falls back to `TypeName` if `TypeText` is absent

## Test plan
- [ ] Verify `Spark:DataType:SqlName` for a `DECIMAL(10,2)` column returns `DECIMAL(10,2)` not `DECIMAL`
- [ ] Verify `Spark:DataType:SqlName` for an `ARRAY<INT>` column returns `ARRAY<INT>` not `ARRAY`
- [ ] Verify `Spark:DataType:SqlName` for a `STRUCT<id:INT,name:STRING>` column returns the full struct spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)