### PR TITLE
fix(csharp): throw ArgumentException for GetPrimaryKeys with null table name (PECO-2956)

### DIFF
--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -698,6 +698,9 @@ namespace AdbcDrivers.Databricks
                 activity?.SetTag("statement.table_name", TableName ?? "(none)");
                 activity?.SetTag("statement.feature.pk_fk_enabled", enablePKFK);
 
+                if (string.IsNullOrEmpty(TableName))
+                    throw new ArgumentException("Table name is required for GetPrimaryKeys");
+
                 if (ShouldReturnEmptyPkFkResult())
                 {
                     activity?.AddEvent("statement.get_primary_keys.returning_empty_result", [

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1262,11 +1262,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 activity?.SetTag("table", _metadataTableName ?? "(none)");
                 activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
 
+                if (string.IsNullOrEmpty(_metadataTableName))
+                    throw new ArgumentException("Table name is required for GetPrimaryKeys");
+
                 if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
                     return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
 
-                if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName) ||
-                    string.IsNullOrEmpty(_metadataTableName))
+                if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName))
                     return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
 
                 string sql = new ShowKeysCommand(_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!).Build();


### PR DESCRIPTION
## Summary
- **GetPrimaryKeys** in SEA mode silently returned an empty result when table name was null/empty, while Thrift mode threw via the server — inconsistent behavior
- Added client-side `ArgumentException` validation for null/empty table name in both **SEA** (`StatementExecutionStatement.cs`) and **Thrift** (`DatabricksStatement.cs`) paths
- Both protocols now consistently throw `ArgumentException("Table name is required for GetPrimaryKeys")` before any server call
- JDBC SEA also returns empty for null table (not throws), so this fix aligns C# with Thrift behavior rather than JDBC

## Test plan
- [ ] Verify `GetPrimaryKeys` with null table name throws `ArgumentException` in SEA mode
- [ ] Verify `GetPrimaryKeys` with null table name throws `ArgumentException` in Thrift mode
- [ ] Verify `GetPrimaryKeys` with valid table name still works in both modes
- [ ] Verify `GetColumnsExtended` (which calls `GetPrimaryKeys` internally) still works with valid params

Closes PECO-2956

🤖 Generated with [Claude Code](https://claude.com/claude-code)