### PR TITLE
fix(ci): remove paths filter from e2e workflow pull_request trigger

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,11 +24,9 @@ on:
       - 'csharp/**'
   pull_request:
     # Only runs on PRs from the repo itself, not forks
+    # No paths filter — the gate step below auto-passes on PR events
+    # unless the e2e-test label is explicitly added
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - '.github/workflows/e2e-tests.yml'
-      - 'ci/scripts/**'
-      - 'csharp/**'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Remove `paths` filter from the `pull_request` trigger in `e2e-tests.yml`

The `paths` filter (scoped to `csharp/`, `ci/scripts/`, workflow file) prevented the workflow from running on Rust-only PRs, causing the required `run-e2e-tests` check to stay in "waiting" state forever — blocking merge.

The gate step (line 56-62) already auto-passes on PR events unless the `e2e-test` label is explicitly added, so the `paths` filter was redundant.

## Test plan
- [ ] Verify Rust-only PRs no longer get stuck waiting on `run-e2e-tests`
- [ ] Verify C# PRs still run e2e tests when `e2e-test` label is added

This pull request was AI-assisted by Isaac.