### PR TITLE
feat(rust): support /sql/1.0/endpoints/ HTTP path format (PECOBLR-2139)

### DIFF
--- a/rust/src/database.rs
+++ b/rust/src/database.rs
@@ -82,11 +82,14 @@ impl Database {
     }
 
     /// Extract warehouse ID from HTTP path if provided.
-    /// Format: /sql/1.0/warehouses/{warehouse_id}
+    /// Supports both `/sql/1.0/warehouses/{id}` and `/sql/1.0/endpoints/{id}`
+    /// formats (they are equivalent on the server side).
     fn extract_warehouse_id(http_path: &str) -> Option<String> {
         http_path
             .strip_prefix("/sql/1.0/warehouses/")
             .or_else(|| http_path.strip_prefix("sql/1.0/warehouses/"))
+            .or_else(|| http_path.strip_prefix("/sql/1.0/endpoints/"))
+            .or_else(|| http_path.strip_prefix("sql/1.0/endpoints/"))
             .map(|s| s.trim_end_matches('/').to_string())
     }
 
@@ -497,6 +500,20 @@ mod tests {
             Some("abc123".to_string())
         );
         assert_eq!(Database::extract_warehouse_id("/other/path"), None);
+
+        // /sql/1.0/endpoints/ format (Simba-compatible)
+        assert_eq!(
+            Database::extract_warehouse_id("/sql/1.0/endpoints/abc123"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            Database::extract_warehouse_id("sql/1.0/endpoints/abc123"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            Database::extract_warehouse_id("/sql/1.0/endpoints/abc123/"),
+            Some("abc123".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `/sql/1.0/endpoints/{id}` as an accepted HTTP path format in `extract_warehouse_id()`
- Both `/sql/1.0/warehouses/{id}` and `/sql/1.0/endpoints/{id}` are equivalent on the server side
- The `/endpoints/` format is used by the multi-DBR test harness in universe

Companion ODBC PR adds SSL, Port, and case-insensitive key support.

## Test plan
- [x] `test_database_extract_warehouse_id` updated and passing with new endpoint path patterns
- [ ] Existing integration tests still pass

This pull request was AI-assisted by Isaac.