### PR TITLE
fix(csharp): auto-close server operation when result stream is exhausted

### DIFF
--- a/csharp/src/Reader/DatabricksCompositeReader.cs
+++ b/csharp/src/Reader/DatabricksCompositeReader.cs
@@ -56,6 +56,7 @@ namespace AdbcDrivers.Databricks.Reader
 
         private IOperationStatusPoller? operationStatusPoller;
         private bool _disposed;
+        private bool _operationClosed;
         private readonly HttpClient _httpClient;
 
         /// <summary>
@@ -196,6 +197,13 @@ namespace AdbcDrivers.Databricks.Reader
 
         public override async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
         {
+            // If we already closed the operation (previous call returned null), return null
+            // immediately to avoid re-initializing a reader on a closed operation.
+            if (_operationClosed)
+            {
+                return null;
+            }
+
             return await this.TraceActivityAsync(async activity =>
             {
                 if (_activeReader != null)
@@ -204,11 +212,17 @@ namespace AdbcDrivers.Databricks.Reader
                 }
 
                 var result = await ReadNextRecordBatchInternalAsync(cancellationToken, activity);
-                // Stop the poller when we've reached the end of results
                 if (result == null)
                 {
                     activity?.AddEvent("composite_reader.end_of_results");
                     StopOperationStatusPoller();
+
+                    // Close the server-side operation immediately when results are exhausted.
+                    // Without this, the server command stays open until Dispose() is called.
+                    // Power BI's M engine has no deterministic disposal — it relies on GC,
+                    // which leaves commands open for ~22 min (CommandInactivityTimeout),
+                    // blocking warehouse autostop.
+                    CloseOperationBestEffort(activity);
                 }
                 else
                 {
@@ -218,6 +232,16 @@ namespace AdbcDrivers.Databricks.Reader
                 }
                 return result;
             });
+        }
+
+        /// <summary>
+        /// Destructor ensures server-side operations are cleaned up if Dispose() is never called.
+        /// This is a safety net for environments like Power BI's M engine where IDisposable
+        /// resources may be garbage-collected without explicit disposal.
+        /// </summary>
+        ~DatabricksCompositeReader()
+        {
+            Dispose(disposing: false);
         }
 
         protected override void Dispose(bool disposing)
@@ -237,22 +261,36 @@ namespace AdbcDrivers.Databricks.Reader
                         {
                             activity?.AddEvent("composite_reader.disposing");
                             StopOperationStatusPoller();
-                            if (_activeReader == null)
+
+                            // If the operation was already closed (e.g., on result exhaustion),
+                            // skip the close to avoid sending a duplicate TCloseOperationReq.
+                            if (!_operationClosed)
                             {
-                                activity?.AddEvent("composite_reader.close_operation_no_reader");
-                                _ = HiveServer2Reader.CloseOperationAsync(_statement, _response)
-                                    .ConfigureAwait(false).GetAwaiter().GetResult();
-                            }
-                            else
-                            {
-                                activity?.AddEvent("composite_reader.disposing_active_reader", [
-                                    new("reader_type", _activeReader.GetType().Name)
-                                ]);
-                                // Note: Have the contained reader close the operation to avoid duplicate calls.
-                                _activeReader.Dispose();
-                                _activeReader = null;
+                                if (_activeReader == null)
+                                {
+                                    activity?.AddEvent("composite_reader.close_operation_no_reader");
+                                    _ = HiveServer2Reader.CloseOperationAsync(_statement, _response)
+                                        .ConfigureAwait(false).GetAwaiter().GetResult();
+                                }
+                                else
+                                {
+                                    activity?.AddEvent("composite_reader.disposing_active_reader", [
+                                        new("reader_type", _activeReader.GetType().Name)
+                                    ]);
+                                    // Note: Have the contained reader close the operation to avoid duplicate calls.
+                                    _activeReader.Dispose();
+                                    _activeReader = null;
+                                }
+                                _operationClosed = true;
                             }
                             activity?.AddEvent("composite_reader.disposed");
+                        }
+                        else
+                        {
+                            // Called from finalizer (disposing: false).
+                            // Best-effort cleanup: stop the poller and attempt to close the operation.
+                            // Managed objects may already be finalized, so catch all exceptions.
+                            CloseOperationBestEffort(activity: null);
                         }
                     }
                 }
@@ -262,6 +300,47 @@ namespace AdbcDrivers.Databricks.Reader
                     _disposed = true;
                 }
             }, activityName: nameof(DatabricksCompositeReader) + "." + nameof(Dispose));
+        }
+
+        /// <summary>
+        /// Closes the server-side operation on a best-effort basis, catching all exceptions.
+        /// Used when results are exhausted or from the finalizer — must never throw.
+        /// </summary>
+        private void CloseOperationBestEffort(Activity? activity)
+        {
+            if (_operationClosed)
+            {
+                return;
+            }
+
+            try
+            {
+                StopOperationStatusPoller();
+
+                if (_activeReader != null)
+                {
+                    activity?.AddEvent("composite_reader.auto_close_active_reader", [
+                        new("reader_type", _activeReader.GetType().Name)
+                    ]);
+                    _activeReader.Dispose();
+                    _activeReader = null;
+                }
+                else
+                {
+                    activity?.AddEvent("composite_reader.auto_close_no_reader");
+                    _ = HiveServer2Reader.CloseOperationAsync(_statement, _response)
+                        .ConfigureAwait(false).GetAwaiter().GetResult();
+                }
+
+                _operationClosed = true;
+            }
+            catch (Exception)
+            {
+                // Best-effort: the close may fail if the connection is already dead
+                // (e.g., called from finalizer after managed objects are finalized).
+                // The server will eventually clean up via CommandInactivityTimeout.
+                _operationClosed = true;
+            }
         }
 
         private void StopOperationStatusPoller()


### PR DESCRIPTION
## Summary

Fixes abandoned PowerBI result fetches that prevent SQL warehouse auto-stop. Affects ~5,000 warehouses daily, wasting ~30,000 compute-hours/day fleet-wide.

**Root cause**: `DatabricksCompositeReader` only sends `TCloseOperationReq` inside `Dispose()`. Power BI's M engine (Power Query) has no `using` blocks or deterministic disposal — it relies on GC to clean up `IArrowArrayStream` objects. Since the reader has no finalizer, GC collects it silently without closing the server command. Commands stay open for ~22 min (`CommandInactivityTimeout`), and the autostop scheduler sees `HasOnClusterOrSchedulingCommand=true`, blocking warehouse shutdown.

**Fix** (single file: `DatabricksCompositeReader.cs`):
- **Auto-close on exhaustion**: When `ReadNextRecordBatchAsync` returns null, send `TCloseOperationReq` immediately via `CloseOperationBestEffort()`. This covers the dominant PowerBI pattern (`Table.Buffer()` reads all results).
- **Finalizer safety net**: Add `~DatabricksCompositeReader()` for readers abandoned without any reads (e.g., cancelled previews).
- **Idempotent Dispose**: `_operationClosed` flag prevents duplicate `TCloseOperationReq` when both auto-close and `Dispose()` fire.

## Test plan

Verified with A/B repro against warehouse `00adc7b6c00429b8` (5-min auto-stop timeout):

| Run | Driver | Result |
|-----|--------|--------|
| Without fix | Original | Warehouse stayed RUNNING 10+ min past last query |
| With fix | Auto-close on exhaustion | Warehouse auto-stopped within timeout |
| Fix commented out | Original (control) | Warehouse stayed RUNNING again |

Repro tool at `csharp/tools/AbandonedResultRepro/` — executes queries, reads all results without calling `Dispose()`, holds process alive 10 min.

- [ ] Verify existing unit tests pass
- [ ] Verify E2E tests pass (CloudFetch + inline results)
- [ ] Verify PowerBI connector works end-to-end with fixed driver

This pull request was AI-assisted by Isaac.