### PR TITLE
fix(ci): remove paths filter from e2e-tests pull_request trigger

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,12 +23,10 @@ on:
       - 'ci/scripts/**'
       - 'csharp/**'
   pull_request:
-    # Only runs on PRs from the repo itself, not forks
+    # No paths filter — workflow must always fire so the gate step can post
+    # the auto-pass check for non-csharp PRs. Path-based gating is handled
+    # in the gate step below (same pattern as trigger-integration-tests.yml).
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - '.github/workflows/e2e-tests.yml'
-      - 'ci/scripts/**'
-      - 'csharp/**'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
## Summary

The `run-e2e-tests` required status check was stuck as *"Waiting for status to be reported"* on PRs that don't touch `csharp/` files (e.g. docs-only or rust-only PRs). The root cause: `e2e-tests.yml` had a `paths:` filter on the `pull_request` trigger, so the workflow never fired and the gate step never got to post the auto-pass check.

**Fix:** remove `paths:` from the `pull_request` trigger. Path-based gating is already handled correctly:
- **PR events** → gate step auto-passes (no tests run)
- **Merge queue** → gate step runs `git diff` and skips if no csharp files changed

This aligns `e2e-tests.yml` with `trigger-integration-tests.yml`, which has no `paths:` filter for the same reason.

## Test plan
- [ ] Verify `run-e2e-tests` posts auto-pass on a docs/rust-only PR
- [ ] Verify `run-e2e-tests` still runs in merge queue when csharp files changed
- [ ] Verify `run-e2e-tests` skips in merge queue when no csharp files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)