### PR TITLE
fix(rust): implement StatementPrepare as no-op for ADBC consumer compat

### DIFF
--- a/rust/src/statement.rs
+++ b/rust/src/statement.rs
@@ -105,9 +105,15 @@ impl adbc_core::Statement for Statement {
     }
 
     fn prepare(&mut self) -> Result<()> {
-        Err(DatabricksErrorHelper::not_implemented()
-            .message("prepare")
-            .to_adbc())
+        // Databricks doesn't have server-side prepared statements, but
+        // ADBC consumers (e.g. DuckDB's adbc_scanner) call prepare before
+        // execute. Accept it as a no-op as long as a query has been set.
+        if self.query.is_none() {
+            return Err(DatabricksErrorHelper::invalid_state()
+                .message("No query set before prepare")
+                .to_adbc());
+        }
+        Ok(())
     }
 
     fn get_parameter_schema(&self) -> Result<Schema> {


### PR DESCRIPTION
## Summary

- DuckDB's `adbc_scanner` (and likely other ADBC consumers) calls `StatementPrepare` before `StatementExecuteQuery`. The current stub returns `NOT_IMPLEMENTED`, which breaks `adbc_scan`.
- Databricks doesn't have server-side prepared statements, so implement `prepare` as a no-op that validates a query has been set via `SetSqlQuery`. This matches the Go driver's behavior.

## Test plan

- [ ] Existing unit/integration tests pass (`cargo test`)
- [ ] Manual test: load driver through DuckDB's `adbc_scanner` and run `adbc_scan(conn, 'SELECT 1')`