### PR TITLE
fix(ci): fetch pinned SHA in dev_pr.yaml shallow clone

### DIFF
--- a/.github/workflows/dev_pr.yaml
+++ b/.github/workflows/dev_pr.yaml
@@ -50,9 +50,10 @@ jobs:
 
       - name: Check PR title format
         run: |
-          git clone --depth 1 https://github.com/adbc-drivers/dev && git -C dev checkout 9d4550a2a9fb2133a86cf16e9f7bfbc32ffb8c48
+          git clone --depth 1 https://github.com/adbc-drivers/dev && git -C dev fetch --depth 1 origin "$DEV_REPO_SHA" && git -C dev checkout "$DEV_REPO_SHA"
           python dev/adbc_drivers_dev/title_check.py $(pwd) "$PR_TITLE"
         env:
+          DEV_REPO_SHA: 9d4550a2a9fb2133a86cf16e9f7bfbc32ffb8c48
           # Set as env var to avoid direct shell interpolation of untrusted input
           PR_TITLE: ${{ github.event.pull_request.title }}
 


### PR DESCRIPTION
## Summary

- Fix the `Check PR` CI job that fails for all PRs since PR #382 was merged
- The `dev_pr.yaml` workflow does a shallow clone (`--depth 1`) of `adbc-drivers/dev` then tries to checkout a pinned SHA. Once the `dev` repo gets new commits, the pinned SHA is no longer the tip and becomes unreachable in the shallow clone
- Add an explicit `git fetch --depth 1 origin <sha>` before the checkout so the pinned commit is always available regardless of where HEAD is

## Test plan

- [ ] Verify the `Check PR` job passes on this PR
- [ ] Verify other open PRs can re-run `Check PR` successfully after merge

This pull request was AI-assisted by Isaac.