### PR TITLE
feat(csharp): bump driver version to 1.1.0

### DIFF
--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />

--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -442,6 +442,7 @@ namespace AdbcDrivers.Databricks
         protected override bool GetObjectsPatternsRequireLowerCase => true;
 
         protected override string DriverName => DatabricksDriverName;
+        protected override string ProductVersionDefault => "1.1.0";
 
         internal override IArrowArrayStream NewReader<T>(T statement, Schema schema, IResponse response, TGetResultSetMetadataResp? metadataResp = null)
         {

--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -51,6 +51,7 @@ namespace AdbcDrivers.Databricks
     internal class DatabricksConnection : SparkHttpConnection
     {
         internal const string DatabricksDriverName = "ADBC Databricks Driver";
+        internal const string DriverVersion = "1.1.0";
         internal static new readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(DatabricksConnection));
         internal static new readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksConnection));
 
@@ -442,7 +443,7 @@ namespace AdbcDrivers.Databricks
         protected override bool GetObjectsPatternsRequireLowerCase => true;
 
         protected override string DriverName => DatabricksDriverName;
-        protected override string ProductVersionDefault => "1.1.0";
+        protected override string ProductVersionDefault => DriverVersion;
 
         internal override IArrowArrayStream NewReader<T>(T statement, Schema schema, IResponse response, TGetResultSetMetadataResp? metadataResp = null)
         {

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -352,7 +352,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         {
             // Use DatabricksJDBCDriverOSS prefix for server-side feature compatibility
             // (e.g., INLINE_OR_EXTERNAL_LINKS disposition support)
-            string baseUserAgent = $"DatabricksJDBCDriverOSS/{AssemblyVersion} (ADBC)";
+            string baseUserAgent = $"DatabricksJDBCDriverOSS/{DatabricksConnection.DriverVersion} (ADBC)";
 
             // Check if a client has provided a user-agent entry
             string userAgentEntry = PropertyHelper.GetStringProperty(properties, "adbc.spark.user_agent_entry", string.Empty);


### PR DESCRIPTION
## Summary

- Updates `hiveserver2` submodule to pick up [adbc-drivers/hiveserver2#32](https://github.com/adbc-drivers/hiveserver2/pull/32), which makes `ProductVersionDefault` a virtual property in `SparkConnection`
- Overrides `ProductVersionDefault` in `DatabricksConnection` to report `1.1.0` in User-Agent headers

## Test plan

- [ ] Verify User-Agent header reports `ADBCDatabricksDriver/1.1.0` in query history

🤖 Generated with [Claude Code](https://claude.com/claude-code)