### PR TITLE
fix(csharp): empty string pattern in SEA metadata should match nothing

### DIFF
--- a/csharp/src/StatementExecution/MetadataCommands/MetadataCommandBase.cs
+++ b/csharp/src/StatementExecution/MetadataCommands/MetadataCommandBase.cs
@@ -37,7 +37,7 @@ namespace AdbcDrivers.Databricks.StatementExecution.MetadataCommands
 
         protected static string ConvertPattern(string? pattern)
         {
-            if (string.IsNullOrEmpty(pattern))
+            if (pattern == null)
                 return "*";
 
             var result = new StringBuilder(pattern!.Length);

--- a/csharp/test/Unit/StatementExecution/ShowCommandTests.cs
+++ b/csharp/test/Unit/StatementExecution/ShowCommandTests.cs
@@ -186,7 +186,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         [Fact]
         public void ShowCatalogs_EmptyPattern()
         {
-            Assert.Equal("SHOW CATALOGS LIKE '*'", new ShowCatalogsCommand("").Build());
+            Assert.Equal("SHOW CATALOGS LIKE ''", new ShowCatalogsCommand("").Build());
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Bug**: `ConvertPattern("")` in `MetadataCommandBase.cs` used `string.IsNullOrEmpty()` which treated `""` the same as `null`, returning `"*"` wildcard. This caused `LIKE '*'` to match all rows (e.g. 1383 rows) when an empty string filter `""` was provided.
- **Fix**: Changed to `pattern == null` check so only `null` returns the `"*"` wildcard. An empty string `""` now correctly flows through the conversion loop, producing `LIKE ''` which matches no catalog/schema/table names (0 rows).
- Updated the existing unit test `ShowCatalogs_EmptyPattern` to expect the corrected behavior.

## Test plan
- [x] All 23 `ShowCommandTests` unit tests pass
- [ ] Verify SEA metadata queries with empty string pattern return 0 rows
- [ ] Verify SEA metadata queries with null pattern still return all rows (match-all behavior)

This pull request was AI-assisted by Isaac.