### PR TITLE
refactor(csharp): emit individual span per PollOperationStatus poll

### DIFF
--- a/csharp/src/Reader/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Reader/DatabricksOperationStatusPoller.cs
@@ -192,7 +192,7 @@ namespace AdbcDrivers.Databricks.Reader
                                 { "consecutive_failures", consecutiveFailures },
                                 { "poll_count", _pollCount }
                             }));
-                        _internalCts?.Cancel();
+                        shouldStop = true;
                         return;
                     }
                 }

--- a/csharp/src/Reader/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Reader/DatabricksOperationStatusPoller.cs
@@ -25,7 +25,6 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
 using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Hive2;
 using Apache.Arrow.Adbc.Tracing;
@@ -88,91 +87,30 @@ namespace AdbcDrivers.Databricks.Reader
             var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(_internalCts.Token, externalToken).Token;
             _operationStatusPollingTask = Task.Run(async () =>
             {
-                if (_activityTracer != null)
-                {
-                    await _activityTracer.Trace.TraceActivityAsync(
-                        activity => PollOperationStatus(linkedToken, activity),
-                        activityName: "PollOperationStatus").ConfigureAwait(false);
-                }
-                else
-                {
-                    await PollOperationStatus(linkedToken, null).ConfigureAwait(false);
-                }
+                await PollOperationStatus(linkedToken).ConfigureAwait(false);
             });
         }
 
-        private async Task PollOperationStatus(CancellationToken cancellationToken, Activity? activity)
+        private async Task PollOperationStatus(CancellationToken cancellationToken)
         {
             int consecutiveFailures = 0;
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                try
+                (bool shouldBreak, int newConsecutiveFailures) result;
+                if (_activityTracer != null)
                 {
-                    TOperationHandle? operationHandle = _response.OperationHandle;
-                    if (operationHandle == null) break;
-
-                    using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    timeoutCts.CancelAfter(TimeSpan.FromSeconds(_requestTimeoutSeconds));
-
-                    TGetOperationStatusReq request = new TGetOperationStatusReq(operationHandle);
-                    TGetOperationStatusResp response = await _statement.Client.GetOperationStatus(request, timeoutCts.Token).ConfigureAwait(false);
-
-                    // Successful poll — reset failure counter
-                    consecutiveFailures = 0;
-
-                    // Track poll count for telemetry
-                    _pollCount++;
-
-                    activity?.AddEvent(new ActivityEvent("operation_status_poller.poll_success",
-                        tags: new ActivityTagsCollection
-                        {
-                            { "poll_count", _pollCount },
-                            { "operation_state", response.OperationState.ToString() }
-                        }));
-
-                    // end the heartbeat if the command has terminated
-                    if (response.OperationState == TOperationState.CANCELED_STATE ||
-                        response.OperationState == TOperationState.ERROR_STATE ||
-                        response.OperationState == TOperationState.CLOSED_STATE ||
-                        response.OperationState == TOperationState.TIMEDOUT_STATE ||
-                        response.OperationState == TOperationState.UKNOWN_STATE)
-                    {
-                        break;
-                    }
+                    result = await _activityTracer.Trace.TraceActivityAsync(
+                        activity => PollOnceAsync(cancellationToken, activity, consecutiveFailures),
+                        activityName: "PollOperationStatus").ConfigureAwait(false);
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                else
                 {
-                    // Cancellation was requested - exit the polling loop gracefully
-                    break;
+                    result = await PollOnceAsync(cancellationToken, null, consecutiveFailures).ConfigureAwait(false);
                 }
-                catch (Exception ex)
-                {
-                    consecutiveFailures++;
 
-                    // Log the error but continue polling. Transient errors (e.g. ObjectDisposedException
-                    // from TLS connection recycling) should not kill the heartbeat poller, as that would
-                    // cause the server-side command inactivity timeout to expire and terminate the query.
-                    activity?.AddEvent(new ActivityEvent("operation_status_poller.poll_error",
-                        tags: new ActivityTagsCollection
-                        {
-                            { "error.type", ex.GetType().Name },
-                            { "error.message", ex.Message },
-                            { "poll_count", _pollCount },
-                            { "consecutive_failures", consecutiveFailures }
-                        }));
-
-                    if (consecutiveFailures >= MaxConsecutiveFailures)
-                    {
-                        activity?.AddEvent(new ActivityEvent("operation_status_poller.max_failures_reached",
-                            tags: new ActivityTagsCollection
-                            {
-                                { "consecutive_failures", consecutiveFailures },
-                                { "poll_count", _pollCount }
-                            }));
-                        break;
-                    }
-                }
+                consecutiveFailures = result.newConsecutiveFailures;
+                if (result.shouldBreak) break;
 
                 // Wait before next poll.
                 try
@@ -181,13 +119,74 @@ namespace AdbcDrivers.Databricks.Reader
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // Normal shutdown — don't let this propagate as an error through TraceActivityAsync
+                    // Normal shutdown
                     break;
                 }
             }
+        }
 
-            // Add telemetry tags to current activity when polling completes
-            activity?.SetTag(StatementExecutionEvent.PollCount, _pollCount);
+        /// <summary>
+        /// Performs a single GetOperationStatus poll.
+        /// Returns (shouldBreak, updatedConsecutiveFailures).
+        /// </summary>
+        private async Task<(bool shouldBreak, int consecutiveFailures)> PollOnceAsync(CancellationToken cancellationToken, Activity? activity, int consecutiveFailures)
+        {
+            try
+            {
+                TOperationHandle? operationHandle = _response.OperationHandle;
+                if (operationHandle == null) return (true, consecutiveFailures);
+
+                using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(TimeSpan.FromSeconds(_requestTimeoutSeconds));
+
+                TGetOperationStatusReq request = new TGetOperationStatusReq(operationHandle);
+                TGetOperationStatusResp response = await _statement.Client.GetOperationStatus(request, timeoutCts.Token).ConfigureAwait(false);
+
+                // Successful poll — reset failure counter
+                consecutiveFailures = 0;
+
+                // Track poll count for telemetry
+                _pollCount++;
+
+                activity?.SetTag("poll_count", _pollCount);
+                activity?.SetTag("operation_state", response.OperationState.ToString());
+
+                // end the heartbeat if the command has terminated
+                if (response.OperationState == TOperationState.CANCELED_STATE ||
+                    response.OperationState == TOperationState.ERROR_STATE ||
+                    response.OperationState == TOperationState.CLOSED_STATE ||
+                    response.OperationState == TOperationState.TIMEDOUT_STATE ||
+                    response.OperationState == TOperationState.UKNOWN_STATE)
+                {
+                    return (true, consecutiveFailures);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Cancellation was requested - exit the polling loop gracefully
+                return (true, consecutiveFailures);
+            }
+            catch (Exception ex)
+            {
+                consecutiveFailures++;
+
+                // Log the error but continue polling. Transient errors (e.g. ObjectDisposedException
+                // from TLS connection recycling) should not kill the heartbeat poller, as that would
+                // cause the server-side command inactivity timeout to expire and terminate the query.
+                activity?.SetTag("error.type", ex.GetType().Name);
+                activity?.SetTag("error.message", ex.Message);
+                activity?.SetTag("poll_count", _pollCount);
+                activity?.SetTag("consecutive_failures", consecutiveFailures);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
+                if (consecutiveFailures >= MaxConsecutiveFailures)
+                {
+                    activity?.SetTag("max_failures_reached", true);
+                    return (true, consecutiveFailures);
+                }
+            }
+
+            return (false, consecutiveFailures);
         }
 
         public void Stop()

--- a/csharp/src/Reader/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Reader/DatabricksOperationStatusPoller.cs
@@ -95,8 +95,9 @@ namespace AdbcDrivers.Databricks.Reader
         private async Task PollOperationStatus(CancellationToken cancellationToken)
         {
             int consecutiveFailures = 0;
+            bool shouldStop = false;
 
-            while (!cancellationToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested && !shouldStop)
             {
                 if (_activityTracer != null)
                 {
@@ -109,7 +110,7 @@ namespace AdbcDrivers.Databricks.Reader
                     await PollOnceAsync(cancellationToken, null).ConfigureAwait(false);
                 }
 
-                if (cancellationToken.IsCancellationRequested) break;
+                if (shouldStop) break;
 
                 // Wait before next poll.
                 try
@@ -156,7 +157,7 @@ namespace AdbcDrivers.Databricks.Reader
                         response.OperationState == TOperationState.TIMEDOUT_STATE ||
                         response.OperationState == TOperationState.UKNOWN_STATE)
                     {
-                        _internalCts?.Cancel();
+                        shouldStop = true;
                         return;
                     }
                 }

--- a/csharp/src/Reader/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Reader/DatabricksOperationStatusPoller.cs
@@ -25,6 +25,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
 using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Hive2;
 using Apache.Arrow.Adbc.Tracing;
@@ -97,20 +98,18 @@ namespace AdbcDrivers.Databricks.Reader
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                (bool shouldBreak, int newConsecutiveFailures) result;
                 if (_activityTracer != null)
                 {
-                    result = await _activityTracer.Trace.TraceActivityAsync(
-                        activity => PollOnceAsync(cancellationToken, activity, consecutiveFailures),
+                    await _activityTracer.Trace.TraceActivityAsync(
+                        activity => PollOnceAsync(cancellationToken, activity),
                         activityName: "PollOperationStatus").ConfigureAwait(false);
                 }
                 else
                 {
-                    result = await PollOnceAsync(cancellationToken, null, consecutiveFailures).ConfigureAwait(false);
+                    await PollOnceAsync(cancellationToken, null).ConfigureAwait(false);
                 }
 
-                consecutiveFailures = result.newConsecutiveFailures;
-                if (result.shouldBreak) break;
+                if (cancellationToken.IsCancellationRequested) break;
 
                 // Wait before next poll.
                 try
@@ -119,74 +118,82 @@ namespace AdbcDrivers.Databricks.Reader
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // Normal shutdown
+                    // Normal shutdown — don't let this propagate as an error through TraceActivityAsync
                     break;
                 }
             }
-        }
 
-        /// <summary>
-        /// Performs a single GetOperationStatus poll.
-        /// Returns (shouldBreak, updatedConsecutiveFailures).
-        /// </summary>
-        private async Task<(bool shouldBreak, int consecutiveFailures)> PollOnceAsync(CancellationToken cancellationToken, Activity? activity, int consecutiveFailures)
-        {
-            try
+            async Task PollOnceAsync(CancellationToken ct, Activity? activity)
             {
-                TOperationHandle? operationHandle = _response.OperationHandle;
-                if (operationHandle == null) return (true, consecutiveFailures);
-
-                using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                timeoutCts.CancelAfter(TimeSpan.FromSeconds(_requestTimeoutSeconds));
-
-                TGetOperationStatusReq request = new TGetOperationStatusReq(operationHandle);
-                TGetOperationStatusResp response = await _statement.Client.GetOperationStatus(request, timeoutCts.Token).ConfigureAwait(false);
-
-                // Successful poll — reset failure counter
-                consecutiveFailures = 0;
-
-                // Track poll count for telemetry
-                _pollCount++;
-
-                activity?.SetTag("poll_count", _pollCount);
-                activity?.SetTag("operation_state", response.OperationState.ToString());
-
-                // end the heartbeat if the command has terminated
-                if (response.OperationState == TOperationState.CANCELED_STATE ||
-                    response.OperationState == TOperationState.ERROR_STATE ||
-                    response.OperationState == TOperationState.CLOSED_STATE ||
-                    response.OperationState == TOperationState.TIMEDOUT_STATE ||
-                    response.OperationState == TOperationState.UKNOWN_STATE)
+                try
                 {
-                    return (true, consecutiveFailures);
+                    TOperationHandle? operationHandle = _response.OperationHandle;
+                    if (operationHandle == null) return;
+
+                    using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    timeoutCts.CancelAfter(TimeSpan.FromSeconds(_requestTimeoutSeconds));
+
+                    TGetOperationStatusReq request = new TGetOperationStatusReq(operationHandle);
+                    TGetOperationStatusResp response = await _statement.Client.GetOperationStatus(request, timeoutCts.Token).ConfigureAwait(false);
+
+                    // Successful poll — reset failure counter
+                    consecutiveFailures = 0;
+
+                    // Track poll count for telemetry
+                    _pollCount++;
+
+                    activity?.AddEvent(new ActivityEvent("operation_status_poller.poll_success",
+                        tags: new ActivityTagsCollection
+                        {
+                            { "poll_count", _pollCount },
+                            { "operation_state", response.OperationState.ToString() }
+                        }));
+
+                    // end the heartbeat if the command has terminated
+                    if (response.OperationState == TOperationState.CANCELED_STATE ||
+                        response.OperationState == TOperationState.ERROR_STATE ||
+                        response.OperationState == TOperationState.CLOSED_STATE ||
+                        response.OperationState == TOperationState.TIMEDOUT_STATE ||
+                        response.OperationState == TOperationState.UKNOWN_STATE)
+                    {
+                        _internalCts?.Cancel();
+                        return;
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Cancellation was requested - exit the polling loop gracefully
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    consecutiveFailures++;
+
+                    // Log the error but continue polling. Transient errors (e.g. ObjectDisposedException
+                    // from TLS connection recycling) should not kill the heartbeat poller, as that would
+                    // cause the server-side command inactivity timeout to expire and terminate the query.
+                    activity?.AddEvent(new ActivityEvent("operation_status_poller.poll_error",
+                        tags: new ActivityTagsCollection
+                        {
+                            { "error.type", ex.GetType().Name },
+                            { "error.message", ex.Message },
+                            { "poll_count", _pollCount },
+                            { "consecutive_failures", consecutiveFailures }
+                        }));
+
+                    if (consecutiveFailures >= MaxConsecutiveFailures)
+                    {
+                        activity?.AddEvent(new ActivityEvent("operation_status_poller.max_failures_reached",
+                            tags: new ActivityTagsCollection
+                            {
+                                { "consecutive_failures", consecutiveFailures },
+                                { "poll_count", _pollCount }
+                            }));
+                        _internalCts?.Cancel();
+                        return;
+                    }
                 }
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                // Cancellation was requested - exit the polling loop gracefully
-                return (true, consecutiveFailures);
-            }
-            catch (Exception ex)
-            {
-                consecutiveFailures++;
-
-                // Log the error but continue polling. Transient errors (e.g. ObjectDisposedException
-                // from TLS connection recycling) should not kill the heartbeat poller, as that would
-                // cause the server-side command inactivity timeout to expire and terminate the query.
-                activity?.SetTag("error.type", ex.GetType().Name);
-                activity?.SetTag("error.message", ex.Message);
-                activity?.SetTag("poll_count", _pollCount);
-                activity?.SetTag("consecutive_failures", consecutiveFailures);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-
-                if (consecutiveFailures >= MaxConsecutiveFailures)
-                {
-                    activity?.SetTag("max_failures_reached", true);
-                    return (true, consecutiveFailures);
-                }
-            }
-
-            return (false, consecutiveFailures);
         }
 
         public void Stop()

--- a/csharp/src/Reader/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Reader/DatabricksOperationStatusPoller.cs
@@ -26,7 +26,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
-using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
 using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Hive2;
 using Apache.Arrow.Adbc.Tracing;

--- a/csharp/src/Reader/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Reader/DatabricksOperationStatusPoller.cs
@@ -26,6 +26,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
+using AdbcDrivers.Databricks.Telemetry.TagDefinitions;
 using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Hive2;
 using Apache.Arrow.Adbc.Tracing;
@@ -143,6 +144,7 @@ namespace AdbcDrivers.Databricks.Reader
                     // Track poll count for telemetry
                     _pollCount++;
 
+                    activity?.SetTag(StatementExecutionEvent.PollCount, _pollCount);
                     activity?.AddEvent(new ActivityEvent("operation_status_poller.poll_success",
                         tags: new ActivityTagsCollection
                         {


### PR DESCRIPTION
## Summary

- Previously the entire `PollOperationStatus` loop was wrapped in a single `TraceActivityAsync` call, producing one long-running span with all poll results as events — written only when the loop exited (potentially minutes later)
- Move `TraceActivityAsync` inside the loop so each `GetOperationStatus` call gets its own `PollOperationStatus` span, written immediately on completion
- Use a local function (`PollOnceAsync`) and a captured `shouldStop` boolean to cleanly signal loop exit without side effects on `_internalCts`

## Test plan

- [ ] Run existing unit tests for `DatabricksOperationStatusPoller`
- [ ] Verify trace logs show individual `PollOperationStatus` spans (one per poll, ~1 minute apart) rather than a single long-running span

🤖 Generated with [Claude Code](https://claude.com/claude-code)