### PR TITLE
fix(csharp): populate driver_connection_params.http_path in telemetry

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -311,7 +311,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             bool useDescTableExtended,
             int connectTimeoutMilliseconds)
         {
-            properties.TryGetValue("adbc.spark.http_path", out string? httpPath);
+            properties.TryGetValue(SparkParameters.Path, out string? httpPath);
 
             var authMech = Proto.DriverAuthMech.Types.Type.Unspecified;
             var authFlow = Proto.DriverAuthFlow.Types.Type.Unspecified;

--- a/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
+++ b/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
@@ -41,6 +41,62 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         }
 
         /// <summary>
+        /// Regression test for PECO-2981: driver_connection_params.http_path was empty for
+        /// 100% of ADBC rows because <c>BuildDriverConnectionParams</c> looked up the wrong
+        /// property key ("adbc.spark.http_path") instead of <see cref="SparkParameters.Path"/>.
+        /// </summary>
+        [SkippableFact]
+        public async Task ConnectionParams_HttpPath_IsPopulated()
+        {
+            CapturingTelemetryExporter exporter = null!;
+            AdbcConnection? connection = null;
+
+            try
+            {
+                var properties = TestEnvironment.GetDriverParameters(TestConfiguration);
+
+                // Force use of SparkParameters.Path to match what's emitted into telemetry.
+                // The test environment may supply the path via AdbcOptions.Uri alone; in that
+                // case, extract the path so we have a deterministic expected value.
+                if (!properties.TryGetValue(SparkParameters.Path, out string? expectedHttpPath)
+                    || string.IsNullOrEmpty(expectedHttpPath))
+                {
+                    Assert.True(
+                        properties.TryGetValue(AdbcOptions.Uri, out string? uri) && !string.IsNullOrEmpty(uri),
+                        $"Test configuration must set {SparkParameters.Path} or {AdbcOptions.Uri}");
+                    expectedHttpPath = new Uri(uri!).AbsolutePath;
+                    properties[SparkParameters.Path] = expectedHttpPath;
+                }
+
+                (connection, exporter) = TelemetryTestHelpers.CreateConnectionWithCapturingTelemetry(properties);
+
+                using var statement = connection.CreateStatement();
+                statement.SqlQuery = "SELECT 1 AS test_value";
+                var result = statement.ExecuteQuery();
+                using var reader = result.Stream;
+
+                statement.Dispose();
+
+                var logs = await TelemetryTestHelpers.WaitForTelemetryEvents(exporter, expectedCount: 1);
+                TelemetryTestHelpers.AssertLogCount(logs, 1);
+
+                var protoLog = TelemetryTestHelpers.GetProtoLog(logs[0]);
+
+                Assert.NotNull(protoLog.DriverConnectionParams);
+                Assert.False(string.IsNullOrEmpty(protoLog.DriverConnectionParams.HttpPath),
+                    "http_path should be populated (regression for PECO-2981)");
+                Assert.Equal(expectedHttpPath, protoLog.DriverConnectionParams.HttpPath);
+
+                OutputHelper?.WriteLine($"✓ http_path: {protoLog.DriverConnectionParams.HttpPath}");
+            }
+            finally
+            {
+                connection?.Dispose();
+                TelemetryTestHelpers.ClearExporterOverride();
+            }
+        }
+
+        /// <summary>
         /// Tests that enable_arrow is set to true for ADBC driver.
         /// </summary>
         [SkippableFact]

--- a/csharp/test/E2E/Telemetry/TelemetryTestHelpers.cs
+++ b/csharp/test/E2E/Telemetry/TelemetryTestHelpers.cs
@@ -95,7 +95,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         public static async Task<List<TelemetryFrontendLog>> WaitForTelemetryEvents(
             CapturingTelemetryExporter exporter,
             int expectedCount,
-            int timeoutMs = 5000)
+            int timeoutMs = 15000)
         {
             var startTime = DateTime.UtcNow;
             while ((DateTime.UtcNow - startTime).TotalMilliseconds < timeoutMs)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/391/files) to review incremental changes.
- [**stack/PECO-2981-fix-http-path-telemetry**](https://github.com/adbc-drivers/databricks/pull/391) [[Files changed](https://github.com/adbc-drivers/databricks/pull/391/files)]

---------
## What's Changed

BuildDriverConnectionParams looked up the literal key "adbc.spark.http_path"
but the actual property key is SparkParameters.Path = "adbc.spark.path", so
http_path was emitted as empty for 100% of ADBC rows. Switch to the constant
and add a regression test that asserts http_path is populated and matches
the configured path.

Closes PECO-2981

Co-authored-by: Isaac

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
