### PR TITLE
fix(csharp): populate driver_connection_params.http_path in telemetry

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -25,6 +25,7 @@ using AdbcDrivers.Databricks.Http;
 using AdbcDrivers.Databricks.Telemetry.Models;
 using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Spark;
+using Apache.Arrow.Adbc;
 using Apache.Hive.Service.Rpc.Thrift;
 
 namespace AdbcDrivers.Databricks.Telemetry
@@ -312,6 +313,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             int connectTimeoutMilliseconds)
         {
             properties.TryGetValue(SparkParameters.Path, out string? httpPath);
+            int port = ResolvePort(properties);
 
             var authMech = Proto.DriverAuthMech.Types.Type.Unspecified;
             var authFlow = Proto.DriverAuthFlow.Types.Type.Unspecified;
@@ -339,8 +341,8 @@ namespace AdbcDrivers.Databricks.Telemetry
                 Mode = Proto.DriverMode.Types.Type.Thrift,
                 HostInfo = new Proto.HostDetails
                 {
-                    HostUrl = $"https://{host}:443",
-                    Port = 0
+                    HostUrl = $"https://{host}:{port}",
+                    Port = port
                 },
                 AuthMech = authMech,
                 AuthFlow = authFlow,
@@ -379,6 +381,27 @@ namespace AdbcDrivers.Databricks.Telemetry
                 return batchSize;
             }
             return (int)DatabricksStatement.DatabricksBatchSizeDefault;
+        }
+
+        private const int DefaultHttpsPort = 443;
+
+        private static int ResolvePort(IReadOnlyDictionary<string, string> properties)
+        {
+            if (properties.TryGetValue(SparkParameters.Port, out string? portStr) &&
+                int.TryParse(portStr, out int port) && port > 0)
+            {
+                return port;
+            }
+
+            if (properties.TryGetValue(AdbcOptions.Uri, out string? uri) &&
+                !string.IsNullOrEmpty(uri) &&
+                Uri.TryCreate(uri, UriKind.Absolute, out Uri? parsedUri) &&
+                parsedUri.Port > 0)
+            {
+                return parsedUri.Port;
+            }
+
+            return DefaultHttpsPort;
         }
     }
 }

--- a/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
+++ b/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
@@ -97,6 +97,64 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         }
 
         /// <summary>
+        /// Regression test for PECO-2982: driver_connection_params.host_info.port was hard-coded
+        /// to 0 for 100% of ADBC rows. The port should be resolved from <see cref="SparkParameters.Port"/>,
+        /// then <see cref="AdbcOptions.Uri"/>, defaulting to 443.
+        /// </summary>
+        [SkippableFact]
+        public async Task ConnectionParams_HostInfoPort_IsPopulated()
+        {
+            CapturingTelemetryExporter exporter = null!;
+            AdbcConnection? connection = null;
+
+            try
+            {
+                var properties = TestEnvironment.GetDriverParameters(TestConfiguration);
+
+                // Determine the expected port using the same precedence as the driver.
+                int expectedPort = 443;
+                if (properties.TryGetValue(SparkParameters.Port, out string? portStr)
+                    && int.TryParse(portStr, out int configuredPort) && configuredPort > 0)
+                {
+                    expectedPort = configuredPort;
+                }
+                else if (properties.TryGetValue(AdbcOptions.Uri, out string? uri)
+                    && !string.IsNullOrEmpty(uri)
+                    && Uri.TryCreate(uri, UriKind.Absolute, out Uri? parsedUri)
+                    && parsedUri.Port > 0)
+                {
+                    expectedPort = parsedUri.Port;
+                }
+
+                (connection, exporter) = TelemetryTestHelpers.CreateConnectionWithCapturingTelemetry(properties);
+
+                using var statement = connection.CreateStatement();
+                statement.SqlQuery = "SELECT 1 AS test_value";
+                var result = statement.ExecuteQuery();
+                using var reader = result.Stream;
+
+                statement.Dispose();
+
+                var logs = await TelemetryTestHelpers.WaitForTelemetryEvents(exporter, expectedCount: 1);
+                TelemetryTestHelpers.AssertLogCount(logs, 1);
+
+                var protoLog = TelemetryTestHelpers.GetProtoLog(logs[0]);
+
+                Assert.NotNull(protoLog.DriverConnectionParams);
+                Assert.NotNull(protoLog.DriverConnectionParams.HostInfo);
+                Assert.NotEqual(0, protoLog.DriverConnectionParams.HostInfo.Port);
+                Assert.Equal(expectedPort, protoLog.DriverConnectionParams.HostInfo.Port);
+
+                OutputHelper?.WriteLine($"✓ host_info.port: {protoLog.DriverConnectionParams.HostInfo.Port}");
+            }
+            finally
+            {
+                connection?.Dispose();
+                TelemetryTestHelpers.ClearExporterOverride();
+            }
+        }
+
+        /// <summary>
         /// Tests that enable_arrow is set to true for ADBC driver.
         /// </summary>
         [SkippableFact]


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/392/files) to review incremental changes.
- [**stack/PECO-2982**](https://github.com/adbc-drivers/databricks/pull/392) [[Files changed](https://github.com/adbc-drivers/databricks/pull/392/files)]

---------
## What's Changed

## 🥞 Stacked PR
Use this
[link](https://github.com/adbc-drivers/databricks/pull/391/files) to
review incremental changes.
-
[**stack/PECO-2981-fix-http-path-telemetry**](https://github.com/adbc-drivers/databricks/pull/391)
[[Files
changed](https://github.com/adbc-drivers/databricks/pull/391/files)]

---------
## What's Changed

BuildDriverConnectionParams looked up the literal key
"adbc.spark.http_path"
but the actual property key is SparkParameters.Path = "adbc.spark.path",
so
http_path was emitted as empty for 100% of ADBC rows. Switch to the
constant
and add a regression test that asserts http_path is populated and
matches
the configured path.
