### PR TITLE
fix(csharp): retry telemetry 429/503 via EnsureSuccessOrThrow

### DIFF
--- a/csharp/src/Telemetry/DatabricksTelemetryExporter.cs
+++ b/csharp/src/Telemetry/DatabricksTelemetryExporter.cs
@@ -287,12 +287,18 @@ namespace AdbcDrivers.Databricks.Telemetry
         /// <summary>
         /// Sends the HTTP request to the telemetry endpoint.
         /// </summary>
+        /// <remarks>
+        /// Uses EnsureSuccessOrThrow (not EnsureSuccessStatusCode) so non-success responses raise
+        /// HttpExceptionWithStatusCode carrying the real status code. ExceptionClassifier only
+        /// inspects that typed exception, so without this the retry predicate can't distinguish
+        /// terminal 4xx from retryable 429/5xx.
+        /// </remarks>
         private async Task SendRequestAsync(string endpointUrl, string json, CancellationToken ct)
         {
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             using var response = await _httpClient.PostAsync(endpointUrl, content, ct).ConfigureAwait(false);
 
-            response.EnsureSuccessStatusCode();
+            response.EnsureSuccessOrThrow();
         }
     }
 }

--- a/csharp/test/Unit/Telemetry/DatabricksTelemetryExporterTests.cs
+++ b/csharp/test/Unit/Telemetry/DatabricksTelemetryExporterTests.cs
@@ -551,6 +551,96 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
             Assert.Contains("test-event-123", protoLogJson);
         }
 
+        [Theory]
+        [InlineData(429)] // Too Many Requests
+        [InlineData(500)] // Internal Server Error
+        [InlineData(502)] // Bad Gateway
+        [InlineData(503)] // Service Unavailable
+        [InlineData(504)] // Gateway Timeout
+        public async Task DatabricksTelemetryExporter_ExportAsync_RetryableStatus_RetriesUntilExhausted(int statusCode)
+        {
+            var attemptCount = 0;
+            var handler = new MockHttpMessageHandler((request, ct) =>
+            {
+                attemptCount++;
+                return Task.FromResult(new HttpResponseMessage((HttpStatusCode)statusCode));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            var config = new TelemetryConfiguration { MaxRetries = 3, RetryDelayMs = 10 };
+            var exporter = new DatabricksTelemetryExporter(httpClient, TestHost, true, config);
+
+            var logs = new List<TelemetryFrontendLog>
+            {
+                new TelemetryFrontendLog { WorkspaceId = 12345 }
+            };
+
+            var result = await exporter.ExportAsync(logs);
+
+            Assert.Equal(4, attemptCount); // 1 initial + 3 retries
+            Assert.False(result, $"ExportAsync should return false after retries exhausted on status {statusCode}");
+        }
+
+        [Theory]
+        [InlineData(429)]
+        [InlineData(503)]
+        public async Task DatabricksTelemetryExporter_ExportAsync_RetryableStatus_SucceedsAfterTransientFailure(int statusCode)
+        {
+            var attemptCount = 0;
+            var handler = new MockHttpMessageHandler((request, ct) =>
+            {
+                attemptCount++;
+                if (attemptCount < 3)
+                {
+                    return Task.FromResult(new HttpResponseMessage((HttpStatusCode)statusCode));
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            var config = new TelemetryConfiguration { MaxRetries = 3, RetryDelayMs = 10 };
+            var exporter = new DatabricksTelemetryExporter(httpClient, TestHost, true, config);
+
+            var logs = new List<TelemetryFrontendLog>
+            {
+                new TelemetryFrontendLog { WorkspaceId = 12345 }
+            };
+
+            var result = await exporter.ExportAsync(logs);
+
+            Assert.Equal(3, attemptCount);
+            Assert.True(result, $"ExportAsync should return true after recovering from transient {statusCode}");
+        }
+
+        [Theory]
+        [InlineData(400)] // Bad Request
+        [InlineData(401)] // Unauthorized
+        [InlineData(403)] // Forbidden
+        [InlineData(404)] // Not Found
+        public async Task DatabricksTelemetryExporter_ExportAsync_TerminalStatus_DoesNotRetry(int statusCode)
+        {
+            var attemptCount = 0;
+            var handler = new MockHttpMessageHandler((request, ct) =>
+            {
+                attemptCount++;
+                return Task.FromResult(new HttpResponseMessage((HttpStatusCode)statusCode));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            var config = new TelemetryConfiguration { MaxRetries = 3, RetryDelayMs = 10 };
+            var exporter = new DatabricksTelemetryExporter(httpClient, TestHost, true, config);
+
+            var logs = new List<TelemetryFrontendLog>
+            {
+                new TelemetryFrontendLog { WorkspaceId = 12345 }
+            };
+
+            var result = await exporter.ExportAsync(logs);
+
+            Assert.Equal(1, attemptCount);
+            Assert.False(result, $"ExportAsync should return false without retrying on terminal status {statusCode}");
+        }
+
         [Fact]
         public async Task DatabricksTelemetryExporter_ExportAsync_GenericException_ReturnsFalse()
         {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/393/files) to review incremental changes.
- [**stack/PECO-2984-fix-telemetry-retry**](https://github.com/adbc-drivers/databricks/pull/393) [[Files changed](https://github.com/adbc-drivers/databricks/pull/393/files)]

---------
## What's Changed

DatabricksTelemetryExporter used HttpResponseMessage.EnsureSuccessStatusCode, which
throws a plain HttpRequestException. ExceptionClassifier.IsTerminalException only
inspects HttpExceptionWithStatusCode, so the retry predicate never saw the real
HTTP status code - 4xx terminal responses were retried and 429/5xx retry behavior
was indistinguishable from unknown errors. Swap to EnsureSuccessOrThrow (already
defined in HttpResponseExtensions) so the classifier gets the status code, 429
and 5xx retry correctly up to telemetry.max_retries, and 400/401/403/404 stop
after the first attempt.

Tests: add unit cases exercising actual HTTP status responses (429/500/502/503/504
retry until exhausted; 429/503 succeed after transient; 400/401/403/404 no retry).

PECO-2984

Co-authored-by: Isaac

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
