### PR TITLE
fix(csharp): stabilize merge-queue E2E tests against workspace data drift

### DIFF
--- a/csharp/test/AssemblyInfo.cs
+++ b/csharp/test/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xunit;
+
+// E2E tests run against a single shared Databricks workspace and share fixture
+// tables under main.adbc_testing. Cross-class parallelism races on these
+// tables (e.g. one class DROPs+CREATEs while another reads), causing flaky
+// merge-queue failures. Serialize the whole assembly to avoid the races.
+// Within-class test order is already sequential by xUnit default.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
@@ -32,12 +31,11 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
     /// for the test table main.adbc_testing.all_column_types.
     /// Both Thrift and SEA are tested for parity.
     /// </summary>
-    public class SeaMetadataE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>, IAsyncLifetime
+    public class SeaMetadataE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {
         private const string TestCatalog = "main";
         private const string TestSchema = "adbc_testing";
         private const string TestTable = "all_column_types";
-        private const string RefTable = "fk_test_ref_table";
 
         public SeaMetadataE2ETests(ITestOutputHelper? outputHelper)
             : base(outputHelper, new DatabricksTestEnvironment.Factory())
@@ -47,54 +45,6 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         private void SkipIfNotConfigured()
         {
             Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable), "Test configuration not available");
-        }
-
-        // Idempotently create the fixture tables this class depends on. The
-        // shared main.adbc_testing workspace can drift (tables dropped by TTL
-        // or unrelated workloads), so we self-bootstrap with CREATE IF NOT
-        // EXISTS. No DROP — other test classes may depend on the same table
-        // and assembly-level parallelism is disabled so within-run races are
-        // not a concern.
-        //
-        // Best-effort: if bootstrap fails (missing schema, permissions, etc.)
-        // we log and continue so tests still fail with their own assertions
-        // rather than masking the real problem behind a setup error.
-        public async Task InitializeAsync()
-        {
-            if (!Utils.CanExecuteTestConfig(TestConfigVariable))
-            {
-                return;
-            }
-
-            var refFullName = $"`{TestCatalog}`.`{TestSchema}`.`{RefTable}`";
-            var tableFullName = $"`{TestCatalog}`.`{TestSchema}`.`{TestTable}`";
-
-            try
-            {
-                await ExecuteSqlFromResourceAsync("Resources/create_reference_table.sql", refFullName);
-                await ExecuteSqlFromResourceAsync("Resources/create_table_all_types.sql", tableFullName, RefTable);
-            }
-            catch (Exception ex)
-            {
-                OutputHelper?.WriteLine($"SeaMetadataE2ETests fixture bootstrap failed (continuing): {ex.Message}");
-            }
-        }
-
-        public Task DisposeAsync() => Task.CompletedTask;
-
-        private async Task ExecuteSqlFromResourceAsync(string resourcePath, string fullTableName, string? refTableName = null)
-        {
-            var sql = File.ReadAllText(resourcePath).Replace("{TABLE_NAME}", fullTableName);
-            if (refTableName != null)
-            {
-                sql = sql.Replace("{CATALOG_NAME}", TestCatalog)
-                         .Replace("{SCHEMA_NAME}", TestSchema)
-                         .Replace("{REF_TABLE_NAME}", refTableName);
-            }
-
-            using var stmt = Connection.CreateStatement();
-            stmt.SqlQuery = sql;
-            await stmt.ExecuteUpdateAsync();
         }
 
         private AdbcConnection CreateThriftConnection()

--- a/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
@@ -31,11 +32,12 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
     /// for the test table main.adbc_testing.all_column_types.
     /// Both Thrift and SEA are tested for parity.
     /// </summary>
-    public class SeaMetadataE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
+    public class SeaMetadataE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>, IAsyncLifetime
     {
         private const string TestCatalog = "main";
         private const string TestSchema = "adbc_testing";
         private const string TestTable = "all_column_types";
+        private const string RefTable = "fk_test_ref_table";
 
         public SeaMetadataE2ETests(ITestOutputHelper? outputHelper)
             : base(outputHelper, new DatabricksTestEnvironment.Factory())
@@ -45,6 +47,54 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         private void SkipIfNotConfigured()
         {
             Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable), "Test configuration not available");
+        }
+
+        // Idempotently create the fixture tables this class depends on. The
+        // shared main.adbc_testing workspace can drift (tables dropped by TTL
+        // or unrelated workloads), so we self-bootstrap with CREATE IF NOT
+        // EXISTS. No DROP — other test classes may depend on the same table
+        // and assembly-level parallelism is disabled so within-run races are
+        // not a concern.
+        //
+        // Best-effort: if bootstrap fails (missing schema, permissions, etc.)
+        // we log and continue so tests still fail with their own assertions
+        // rather than masking the real problem behind a setup error.
+        public async Task InitializeAsync()
+        {
+            if (!Utils.CanExecuteTestConfig(TestConfigVariable))
+            {
+                return;
+            }
+
+            var refFullName = $"`{TestCatalog}`.`{TestSchema}`.`{RefTable}`";
+            var tableFullName = $"`{TestCatalog}`.`{TestSchema}`.`{TestTable}`";
+
+            try
+            {
+                await ExecuteSqlFromResourceAsync("Resources/create_reference_table.sql", refFullName);
+                await ExecuteSqlFromResourceAsync("Resources/create_table_all_types.sql", tableFullName, RefTable);
+            }
+            catch (Exception ex)
+            {
+                OutputHelper?.WriteLine($"SeaMetadataE2ETests fixture bootstrap failed (continuing): {ex.Message}");
+            }
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        private async Task ExecuteSqlFromResourceAsync(string resourcePath, string fullTableName, string? refTableName = null)
+        {
+            var sql = File.ReadAllText(resourcePath).Replace("{TABLE_NAME}", fullTableName);
+            if (refTableName != null)
+            {
+                sql = sql.Replace("{CATALOG_NAME}", TestCatalog)
+                         .Replace("{SCHEMA_NAME}", TestSchema)
+                         .Replace("{REF_TABLE_NAME}", refTableName);
+            }
+
+            using var stmt = Connection.CreateStatement();
+            stmt.SqlQuery = sql;
+            await stmt.ExecuteUpdateAsync();
         }
 
         private AdbcConnection CreateThriftConnection()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/395/files) to review incremental changes.
- [**stack/PECO-3000-stabilize-merge-queue-e2e-tests**](https://github.com/adbc-drivers/databricks/pull/395) [[Files changed](https://github.com/adbc-drivers/databricks/pull/395/files)]

---------
## What's Changed

The merge-queue Tests Workflow intermittently fails because E2E tests
run in parallel across test classes and share fixture tables under
main.adbc_testing. Two failure modes:

1. Cross-class races: StatementTests.CanGetColumnsExtended drops and
   recreates main.adbc_testing.all_column_types during its run. While
   that window is open, SeaMetadataE2ETests reading the same table sees
   it missing and fails.
2. External TTL / unrelated workloads drop fixture tables between runs.

Fix:

- Disable assembly-level test parallelization so E2E tests run
  sequentially. Within-class order was already sequential by xUnit
  default; this extends the guarantee across classes, eliminating the
  drop/recreate race on shared tables.
- Add best-effort idempotent bootstrap (CREATE IF NOT EXISTS) for
  all_column_types and fk_test_ref_table at the start of each
  SeaMetadataE2ETests instance, so a table dropped by external cleanup
  is recreated before the tests run. Bootstrap errors are logged and
  suppressed so tests still fail with their original assertions when
  the underlying environment is misconfigured.

Closes PECO-3000

Co-authored-by: Isaac

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
