### PR TITLE
fix(csharp): report OAuth U2M access-token passthrough as auth_mech=OAUTH

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -324,19 +324,13 @@ namespace AdbcDrivers.Databricks.Telemetry
             bool isOAuth = SparkAuthTypeParser.TryParse(authType, out SparkAuthType authTypeValue)
                 && authTypeValue == SparkAuthType.OAuth;
 
-            if (!string.IsNullOrEmpty(grantType) &&
-                grantType == DatabricksConstants.OAuthGrantTypes.ClientCredentials)
+            if (isOAuth)
             {
                 authMech = Proto.DriverAuthMech.Types.Type.Oauth;
-                authFlow = Proto.DriverAuthFlow.Types.Type.ClientCredentials;
-            }
-            else if (isOAuth)
-            {
-                // OAuth U2M access-token passthrough (e.g., browser flow, GitHub OIDC federation).
-                // authType=oauth with no grant_type (or grant_type=access_token) means the caller
-                // supplied a pre-acquired access token via SparkParameters.AccessToken.
-                authMech = Proto.DriverAuthMech.Types.Type.Oauth;
-                authFlow = Proto.DriverAuthFlow.Types.Type.TokenPassthrough;
+                authFlow = !string.IsNullOrEmpty(grantType) &&
+                           grantType == DatabricksConstants.OAuthGrantTypes.ClientCredentials
+                    ? Proto.DriverAuthFlow.Types.Type.ClientCredentials
+                    : Proto.DriverAuthFlow.Types.Type.TokenPassthrough;
             }
             else
             {

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -305,7 +305,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             };
         }
 
-        private static Proto.DriverConnectionParameters BuildDriverConnectionParams(
+        internal static Proto.DriverConnectionParameters BuildDriverConnectionParams(
             IReadOnlyDictionary<string, string> properties,
             string host,
             bool enableDirectResults,
@@ -321,11 +321,22 @@ namespace AdbcDrivers.Databricks.Telemetry
             properties.TryGetValue(SparkParameters.AuthType, out string? authType);
             properties.TryGetValue(DatabricksParameters.OAuthGrantType, out string? grantType);
 
+            bool isOAuth = SparkAuthTypeParser.TryParse(authType, out SparkAuthType authTypeValue)
+                && authTypeValue == SparkAuthType.OAuth;
+
             if (!string.IsNullOrEmpty(grantType) &&
                 grantType == DatabricksConstants.OAuthGrantTypes.ClientCredentials)
             {
                 authMech = Proto.DriverAuthMech.Types.Type.Oauth;
                 authFlow = Proto.DriverAuthFlow.Types.Type.ClientCredentials;
+            }
+            else if (isOAuth)
+            {
+                // OAuth U2M access-token passthrough (e.g., browser flow, GitHub OIDC federation).
+                // authType=oauth with no grant_type (or grant_type=access_token) means the caller
+                // supplied a pre-acquired access token via SparkParameters.AccessToken.
+                authMech = Proto.DriverAuthMech.Types.Type.Oauth;
+                authFlow = Proto.DriverAuthFlow.Types.Type.TokenPassthrough;
             }
             else
             {

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryAuthMechTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryAuthMechTests.cs
@@ -1,0 +1,124 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using AdbcDrivers.Databricks.Telemetry;
+using AdbcDrivers.HiveServer2.Spark;
+using DriverAuthFlowType = AdbcDrivers.Databricks.Telemetry.Proto.DriverAuthFlow.Types.Type;
+using DriverAuthMechType = AdbcDrivers.Databricks.Telemetry.Proto.DriverAuthMech.Types.Type;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Regression tests for PECO-2985: OAuth U2M access-token passthrough was mislabeled
+    /// as <c>auth_mech=PAT, auth_flow=TOKEN_PASSTHROUGH</c> because any authenticated
+    /// connection without the <c>client_credentials</c> grant fell into the PAT branch
+    /// of <see cref="ConnectionTelemetry.BuildDriverConnectionParams"/>.
+    /// </summary>
+    public class ConnectionTelemetryAuthMechTests
+    {
+        private const string Host = "test.databricks.com";
+        private const int DefaultTimeoutMs = 30_000;
+
+        private static Dictionary<string, string> BaseProperties() => new()
+        {
+            { SparkParameters.Path, "/sql/1.0/warehouses/abc123" },
+        };
+
+        [Fact]
+        public void AuthMech_Pat_WhenAuthTypeIsTokenAndNoOAuthGrantType()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.Token;
+            properties[SparkParameters.Token] = "dapi-redacted";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+        }
+
+        [Fact]
+        public void AuthMech_Oauth_ClientCredentials_WhenGrantTypeIsClientCredentials()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
+            properties[DatabricksParameters.OAuthGrantType] =
+                DatabricksConstants.OAuthGrantTypes.ClientCredentials;
+            properties[DatabricksParameters.OAuthClientId] = "client-id";
+            properties[DatabricksParameters.OAuthClientSecret] = "client-secret";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.ClientCredentials, connParams.AuthFlow);
+        }
+
+        /// <summary>
+        /// PECO-2985: OAuth U2M access-token passthrough — caller sets <c>auth_type=oauth</c>
+        /// with a pre-acquired <c>access_token</c> and no grant_type. This must report
+        /// <c>auth_mech=OAUTH, auth_flow=TOKEN_PASSTHROUGH</c>, not PAT.
+        /// </summary>
+        [Fact]
+        public void AuthMech_Oauth_TokenPassthrough_WhenAuthTypeIsOauthWithNoGrantType()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
+            properties[SparkParameters.AccessToken] = "oauth-access-token-redacted";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+        }
+
+        /// <summary>
+        /// PECO-2985: OAuth U2M access-token passthrough with the grant_type explicitly
+        /// set to <c>access_token</c> must also report <c>auth_mech=OAUTH, auth_flow=TOKEN_PASSTHROUGH</c>.
+        /// </summary>
+        [Fact]
+        public void AuthMech_Oauth_TokenPassthrough_WhenGrantTypeIsAccessToken()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
+            properties[DatabricksParameters.OAuthGrantType] =
+                DatabricksConstants.OAuthGrantTypes.AccessToken;
+            properties[SparkParameters.AccessToken] = "oauth-access-token-redacted";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+        }
+
+        [Fact]
+        public void AuthMech_Pat_WhenNoAuthConfigured()
+        {
+            var properties = BaseProperties();
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+        }
+    }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/396/files) to review incremental changes.
- [**stack/PECO-2985-fix-oauth-u2m-auth-mech**](https://github.com/adbc-drivers/databricks/pull/396) [[Files changed](https://github.com/adbc-drivers/databricks/pull/396/files)]

---------
## What's Changed

`BuildDriverConnectionParams` only branched on `grant_type=client_credentials`, so any other authenticated connection — including OAuth U2M access-token passthrough (`auth_type=oauth` with a pre-acquired access token, e.g. browser flow or GitHub OIDC federation) — was mislabeled as `auth_mech=PAT, auth_flow=TOKEN_PASSTHROUGH`.

Add a dedicated branch for `isOAuth` so U2M passthrough reports `auth_mech=OAUTH, auth_flow=TOKEN_PASSTHROUGH` instead.

### Auth-mech mapping after this fix

| `auth_type` | `oauth.grant_type` | `auth_mech` | `auth_flow` |
|---|---|---|---|
| `oauth` | `client_credentials` | OAUTH | CLIENT_CREDENTIALS |
| `oauth` | `access_token` or unset | **OAUTH** (was PAT) | TOKEN_PASSTHROUGH |
| other (`token`, unset, …) | — | PAT | TOKEN_PASSTHROUGH |

### Tests

Exposed `BuildDriverConnectionParams` as `internal` and added `ConnectionTelemetryAuthMechTests` covering the PAT, OAuth client_credentials, OAuth U2M (no grant), OAuth U2M (`grant_type=access_token`), and no-auth branches. All 265 unit telemetry tests pass.

Closes PECO-2985

Co-authored-by: Isaac