### PR TITLE
chore(csharp): update hiveserver2 submodule reference to align with version 0.24.0

### DIFF
--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>0.24.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>0.23.0</VersionPrefix>
+    <VersionPrefix>0.24.0</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 

--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />

--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -51,9 +51,9 @@ namespace AdbcDrivers.Databricks
     internal class DatabricksConnection : SparkHttpConnection
     {
         internal const string DatabricksDriverName = "ADBC Databricks Driver";
-        internal const string DriverVersion = "1.1.0";
         internal static new readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(DatabricksConnection));
         internal static new readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksConnection));
+        private readonly Lazy<string> _assemblyVersion;
 
         /// <summary>
         /// The environment variable name that contains the path to the default Databricks configuration file.
@@ -140,6 +140,9 @@ namespace AdbcDrivers.Databricks
             System.Buffers.ArrayPool<byte>? lz4BufferPool)
             : base(properties)
         {
+            // This handles if class is inherited and ensures assembly version is always from the actual runtime type
+            _assemblyVersion = new(() => GetType().Assembly.GetName().Version.ToString(3));
+
             // Use provided manager (from Database) or create new instance (for direct construction)
             RecyclableMemoryStreamManager = memoryStreamManager ?? new Microsoft.IO.RecyclableMemoryStreamManager();
             // Use provided pool (from Database) or create new instance (for direct construction)
@@ -442,7 +445,7 @@ namespace AdbcDrivers.Databricks
         protected override bool GetObjectsPatternsRequireLowerCase => true;
 
         protected override string DriverName => DatabricksDriverName;
-        protected override string ProductVersionDefault => DriverVersion;
+        protected override string ProductVersionDefault => _assemblyVersion.Value;
 
         /// <summary>
         /// Overrides GetObjects to emit telemetry with appropriate operation type based on depth.

--- a/csharp/src/FeatureFlagCache.cs
+++ b/csharp/src/FeatureFlagCache.cs
@@ -135,7 +135,7 @@ namespace AdbcDrivers.Databricks
                 }
 
                 // Create HttpClient only on cache miss (lazy creation)
-                using var httpClient = Http.HttpClientFactory.CreateFeatureFlagHttpClient(properties, host, driverVersion);
+                using var httpClient = Http.HttpClientFactory.CreateFeatureFlagHttpClient(properties, host);
 
                 // Create context asynchronously - this waits for initial fetch to complete
                 context = await FeatureFlagContext.CreateAsync(

--- a/csharp/src/Http/HttpClientFactory.cs
+++ b/csharp/src/Http/HttpClientFactory.cs
@@ -30,6 +30,8 @@ namespace AdbcDrivers.Databricks.Http
     /// </summary>
     internal static class HttpClientFactory
     {
+        private static readonly string s_assemblyVersion = typeof(HttpClientFactory).Assembly.GetName().Version.ToString(3);
+
         /// <summary>
         /// Creates an HttpClientHandler with TLS and proxy settings from connection properties.
         /// This is the base handler used by all HttpClient instances.
@@ -86,12 +88,10 @@ namespace AdbcDrivers.Databricks.Http
         /// </summary>
         /// <param name="properties">Connection properties.</param>
         /// <param name="host">The Databricks host (without protocol).</param>
-        /// <param name="assemblyVersion">The driver version for the User-Agent.</param>
         /// <returns>Configured HttpClient for feature flags.</returns>
         public static HttpClient CreateFeatureFlagHttpClient(
             IReadOnlyDictionary<string, string> properties,
-            string host,
-            string assemblyVersion)
+            string host)
         {
             const int DefaultFeatureFlagTimeoutSeconds = 10;
 
@@ -110,7 +110,7 @@ namespace AdbcDrivers.Databricks.Http
             };
 
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(
-                UserAgentHelper.GetUserAgent(assemblyVersion, properties));
+                UserAgentHelper.GetUserAgent(s_assemblyVersion, properties));
 
             string? orgId = PropertyHelper.ParseOrgIdFromProperties(properties);
             if (!string.IsNullOrEmpty(orgId))
@@ -126,13 +126,11 @@ namespace AdbcDrivers.Databricks.Http
         /// </summary>
         /// <param name="properties">Connection properties.</param>
         /// <param name="host">The Databricks host (without protocol).</param>
-        /// <param name="assemblyVersion">The driver version for the User-Agent.</param>
         /// <param name="existingTokenProvider">Optional existing OAuthClientCredentialsProvider to reuse for token caching.</param>
         /// <returns>Configured HttpClient for telemetry.</returns>
         public static HttpClient CreateTelemetryHttpClient(
             IReadOnlyDictionary<string, string> properties,
             string host,
-            string assemblyVersion,
             Auth.OAuthClientCredentialsProvider? existingTokenProvider = null)
         {
             const int DefaultTelemetryTimeoutSeconds = 10;
@@ -148,7 +146,7 @@ namespace AdbcDrivers.Databricks.Http
             };
 
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(
-                UserAgentHelper.GetUserAgent(assemblyVersion, properties));
+                UserAgentHelper.GetUserAgent(s_assemblyVersion, properties));
 
             string? orgId = PropertyHelper.ParseOrgIdFromProperties(properties);
             if (!string.IsNullOrEmpty(orgId))

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -49,6 +49,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private readonly HttpClient _cloudFetchHttpClient; // Separate HttpClient without auth headers for CloudFetch downloads
         private readonly IReadOnlyDictionary<string, string> _properties;
         private readonly bool _ownsHttpClient;
+        private readonly Lazy<string> _assemblyVersion;
 
         // Session management
         private string? _sessionId;
@@ -117,6 +118,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             bool ownsHttpClient)
             : base(properties) // Initialize TracingConnection base class
         {
+            _assemblyVersion = new Lazy<string>(() => GetType().Assembly.GetName().Version.ToString(3));
             _properties = properties ?? throw new ArgumentNullException(nameof(properties));
             _ownsHttpClient = ownsHttpClient;
 
@@ -352,7 +354,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         {
             // Use DatabricksJDBCDriverOSS prefix for server-side feature compatibility
             // (e.g., INLINE_OR_EXTERNAL_LINKS disposition support)
-            string baseUserAgent = $"DatabricksJDBCDriverOSS/{DatabricksConnection.DriverVersion} (ADBC)";
+            string baseUserAgent = $"DatabricksJDBCDriverOSS/{AssemblyVersion} (ADBC)";
 
             // Check if a client has provided a user-agent entry
             string userAgentEntry = PropertyHelper.GetStringProperty(properties, "adbc.spark.user_agent_entry", string.Empty);
@@ -908,7 +910,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // TracingConnection provides IActivityTracer implementation
         internal bool EnableComplexDatatypeSupport => _enableComplexDatatypeSupport;
 
-        public override string AssemblyVersion => GetType().Assembly.GetName().Version?.ToString() ?? "1.0.0";
+        public override string AssemblyVersion => _assemblyVersion.Value;
+
         public override string AssemblyName => "AdbcDrivers.Databricks";
     }
 }

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -42,6 +42,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
     /// </summary>
     internal class StatementExecutionStatement : TracingStatement
     {
+        private readonly Lazy<string> _assemblyVersion;
         private readonly IStatementExecutionClient _client;
         private readonly string? _sessionId;
         private readonly string _warehouseId;
@@ -106,6 +107,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             StatementExecutionConnection connection)
             : base(connection)
         {
+            _assemblyVersion = new Lazy<string>(() => GetType().Assembly.GetName().Version.ToString(3));
             _connection = connection ?? throw new ArgumentNullException(nameof(connection));
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _sessionId = sessionId;
@@ -1399,7 +1401,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         // TracingStatement implementation
-        public override string AssemblyVersion => GetType().Assembly.GetName().Version?.ToString() ?? "1.0.0";
+        public override string AssemblyVersion => _assemblyVersion.Value;
         public override string AssemblyName => "AdbcDrivers.Databricks";
 
         // ─── Helpers for GetColumnsExtended fallback (mirrors HiveServer2Statement) ──

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -92,7 +92,7 @@ namespace AdbcDrivers.Databricks.Telemetry
                 }
 
                 HttpClient telemetryHttpClient = HttpClientFactory.CreateTelemetryHttpClient(
-                    properties, host, assemblyVersion, oauthTokenProvider);
+                    properties, host, oauthTokenProvider);
 
                 ITelemetryClient telemetryClient = TelemetryClientManager.GetInstance().GetOrCreateClient(
                     host,


### PR DESCRIPTION
## What's Changed

Update `hiveserver2` submodule reference to align with version 0.24.0

- update this driver's version to `1.1.0`
- update `adbc-drivers/hiveserver2` submodule commit reference [c9534e0](https://github.com/adbc-drivers/hiveserver2/pull/35)
- update `Microsoft.NET.Test.Sdk` package version to `18.4.0`
- refactors how the concise (3-digit) assembly version is obtained.

