### PR TITLE
fix(csharp): report distro PRETTY_NAME instead of kernel version in os_version telemetry

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -17,7 +17,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Auth;
@@ -284,7 +286,20 @@ namespace AdbcDrivers.Databricks.Telemetry
             }
         }
 
-        private static Proto.DriverSystemConfiguration BuildSystemConfiguration(string assemblyVersion)
+        // DriverSystemConfiguration is effectively process-wide constant: OS, runtime, driver
+        // version, process name, locale and encoding do not change during process lifetime.
+        // Cache the first-computed value to avoid repeated /etc/os-release reads and reflection
+        // lookups on every new connection.
+        private static Proto.DriverSystemConfiguration? s_systemConfiguration;
+
+        internal static Proto.DriverSystemConfiguration BuildSystemConfiguration(string assemblyVersion)
+        {
+            return LazyInitializer.EnsureInitialized(
+                ref s_systemConfiguration,
+                () => CreateSystemConfiguration(assemblyVersion))!;
+        }
+
+        private static Proto.DriverSystemConfiguration CreateSystemConfiguration(string assemblyVersion)
         {
             var osVersion = System.Environment.OSVersion;
             var processName = Process.GetCurrentProcess().ProcessName;
@@ -293,9 +308,9 @@ namespace AdbcDrivers.Databricks.Telemetry
                 DriverVersion = assemblyVersion,
                 DriverName = "Databricks ADBC Driver",
                 OsName = osVersion.Platform.ToString(),
-                OsVersion = osVersion.Version.ToString(),
-                OsArch = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString(),
-                RuntimeName = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
+                OsVersion = GetOsVersion(),
+                OsArch = RuntimeInformation.OSArchitecture.ToString(),
+                RuntimeName = RuntimeInformation.FrameworkDescription,
                 RuntimeVersion = System.Environment.Version.ToString(),
                 RuntimeVendor = "Microsoft",
                 LocaleName = System.Globalization.CultureInfo.CurrentCulture.Name,
@@ -303,6 +318,75 @@ namespace AdbcDrivers.Databricks.Telemetry
                 ProcessName = processName,
                 ClientAppName = processName
             };
+        }
+
+        // Returns a human-readable OS version string, preferring the distro "PRETTY_NAME"
+        // from /etc/os-release on Linux (e.g. "Ubuntu 22.04.3 LTS") over the kernel release
+        // (e.g. "5.4.0.1156") that Environment.OSVersion.Version reports there.
+        internal static string GetOsVersion()
+        {
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    string? prettyName = TryReadLinuxPrettyName();
+                    if (!string.IsNullOrEmpty(prettyName))
+                    {
+                        return prettyName!;
+                    }
+                }
+
+                string description = RuntimeInformation.OSDescription;
+                if (!string.IsNullOrEmpty(description))
+                {
+                    return description;
+                }
+            }
+            catch
+            {
+                // Telemetry must never impact driver operations; fall through to the kernel version.
+            }
+
+            return System.Environment.OSVersion.Version.ToString();
+        }
+
+        private static string? TryReadLinuxPrettyName()
+        {
+            try
+            {
+                const string osReleasePath = "/etc/os-release";
+                if (!File.Exists(osReleasePath))
+                {
+                    return null;
+                }
+
+                foreach (string line in File.ReadAllLines(osReleasePath))
+                {
+                    const string key = "PRETTY_NAME=";
+                    if (line.StartsWith(key, StringComparison.Ordinal))
+                    {
+                        return UnquoteOsReleaseValue(line.Substring(key.Length));
+                    }
+                }
+            }
+            catch
+            {
+                // Intentionally swallowed - telemetry must not fail.
+            }
+
+            return null;
+        }
+
+        // os-release(5) allows values to be wrapped in double or single quotes.
+        internal static string UnquoteOsReleaseValue(string raw)
+        {
+            if (raw.Length >= 2
+                && ((raw[0] == '"' && raw[raw.Length - 1] == '"')
+                    || (raw[0] == '\'' && raw[raw.Length - 1] == '\'')))
+            {
+                return raw.Substring(1, raw.Length - 2);
+            }
+            return raw;
         }
 
         internal static Proto.DriverConnectionParameters BuildDriverConnectionParams(

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryOsVersionTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryOsVersionTests.cs
@@ -1,0 +1,75 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Runtime.InteropServices;
+using AdbcDrivers.Databricks.Telemetry;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Regression tests for PECO-2986: telemetry's <c>os_version</c> field previously reported
+    /// the Linux kernel release (e.g. <c>"5.4.0.1156"</c>) instead of the distro version
+    /// (e.g. <c>"Ubuntu 22.04.3 LTS"</c>) because it used <see cref="Environment.OSVersion"/>.
+    /// </summary>
+    public class ConnectionTelemetryOsVersionTests
+    {
+        [Fact]
+        public void GetOsVersion_IsPopulated()
+        {
+            string version = ConnectionTelemetry.GetOsVersion();
+            Assert.False(string.IsNullOrEmpty(version));
+        }
+
+        [Fact]
+        public void GetOsVersion_OnLinux_DoesNotReturnBareKernelVersion()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return;
+            }
+
+            string kernelVersion = Environment.OSVersion.Version.ToString();
+            string reported = ConnectionTelemetry.GetOsVersion();
+
+            Assert.NotEqual(kernelVersion, reported);
+        }
+
+        [Theory]
+        [InlineData("Ubuntu 22.04.3 LTS", "Ubuntu 22.04.3 LTS")]
+        [InlineData("\"Ubuntu 22.04.3 LTS\"", "Ubuntu 22.04.3 LTS")]
+        [InlineData("'Red Hat Enterprise Linux 9.2'", "Red Hat Enterprise Linux 9.2")]
+        [InlineData("\"\"", "")]
+        [InlineData("", "")]
+        [InlineData("\"", "\"")]
+        [InlineData("NoQuotes", "NoQuotes")]
+        public void UnquoteOsReleaseValue_StripsMatchingQuotes(string raw, string expected)
+        {
+            Assert.Equal(expected, ConnectionTelemetry.UnquoteOsReleaseValue(raw));
+        }
+
+        [Fact]
+        public void BuildSystemConfiguration_IsCachedAcrossCalls()
+        {
+            var first = ConnectionTelemetry.BuildSystemConfiguration("1.0.0-test");
+            var second = ConnectionTelemetry.BuildSystemConfiguration("1.0.0-test");
+
+            // Same reference — the proto is built once per process and reused.
+            Assert.Same(first, second);
+        }
+    }
+}

--- a/docs/designs/fix-telemetry-gaps-design.md
+++ b/docs/designs/fix-telemetry-gaps-design.md
@@ -109,7 +109,7 @@ flowchart TD
 | `runtime_version` | Populated | Environment.Version |
 | `runtime_vendor` | **NOT SET** | Should be "Microsoft" for .NET |
 | `os_name` | Populated | OSVersion.Platform |
-| `os_version` | Populated | OSVersion.Version |
+| `os_version` | Populated | `/etc/os-release` PRETTY_NAME on Linux, else `RuntimeInformation.OSDescription` (see PECO-2986) |
 | `os_arch` | Populated | RuntimeInformation.OSArchitecture |
 | `driver_name` | Populated | "Databricks ADBC Driver" |
 | `client_app_name` | **NOT SET** | Should come from connection property or user-agent |
@@ -669,22 +669,23 @@ Fix all gaps in the existing Thrift telemetry pipeline first, since the infrastr
 13. Track `retry_count` on SqlExecutionEvent
 14. Mark internal calls with `is_internal_call = true`
 15. Add metadata operation telemetry (GetObjects, GetTableTypes)
-16. Verify all Phase 1 E2E tests pass
+16. Fix `os_version` to report the Linux distro PRETTY_NAME instead of the bare kernel version (PECO-2986)
+17. Verify all Phase 1 E2E tests pass
 
 ### Phase 2: SEA Telemetry (Wire Telemetry into StatementExecutionConnection)
 
 Once Thrift telemetry is complete, extend coverage to the SEA protocol using the shared `TelemetryHelper`.
 
 **E2E Tests (test-first):**
-17. Write failing E2E tests for SEA telemetry (expect telemetry events from SEA connections)
+18. Write failing E2E tests for SEA telemetry (expect telemetry events from SEA connections)
 
 **Implementation:**
-18. Extract `TelemetryHelper` from `DatabricksConnection` for shared use (already done - verify coverage)
-19. Wire `InitializeTelemetry()` into `StatementExecutionConnection` with `mode=SEA`
-20. Add `EmitTelemetry()` to `StatementExecutionStatement`
-21. Wire telemetry dispose/flush into `StatementExecutionConnection.Dispose()`
-22. Wire `SetChunkDetails()` in `StatementExecutionStatement.EmitTelemetry()` for SEA CloudFetch
-23. Verify all Phase 2 SEA E2E tests pass
+19. Extract `TelemetryHelper` from `DatabricksConnection` for shared use (already done - verify coverage)
+20. Wire `InitializeTelemetry()` into `StatementExecutionConnection` with `mode=SEA`
+21. Add `EmitTelemetry()` to `StatementExecutionStatement`
+22. Wire telemetry dispose/flush into `StatementExecutionConnection.Dispose()`
+23. Wire `SetChunkDetails()` in `StatementExecutionStatement.EmitTelemetry()` for SEA CloudFetch
+24. Verify all Phase 2 SEA E2E tests pass
 
 ---
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/399/files) to review incremental changes.
- [**stack/jade-PECO-2986-fix-os-version-telemetry**](https://github.com/adbc-drivers/databricks/pull/399) [[Files changed](https://github.com/adbc-drivers/databricks/pull/399/files)]

---------

## Summary

- Fix `system_configuration.os_version` in telemetry so it reports the Linux distro (e.g. `"Ubuntu 22.04.3 LTS"`) instead of the bare kernel release (e.g. `"5.4.0.1157"`). The old value came from `Environment.OSVersion.Version`, which on Linux returns the kernel — not useful for observability dashboards or customer diagnostics.
- New helper `ConnectionTelemetry.GetOsVersion()`:
  - On Linux, reads `PRETTY_NAME` from `/etc/os-release`.
  - Otherwise, falls back to `RuntimeInformation.OSDescription` (e.g. `"Microsoft Windows 10.0.19045"`, `"Darwin 22.6.0"`).
  - Final fallback to `Environment.OSVersion.Version.ToString()` if everything else fails.
- Cache the whole `DriverSystemConfiguration` proto at process scope via `LazyInitializer.EnsureInitialized`. Every input (driver version, OS info, runtime, process name, locale, encoding) is process-wide constant, so building this per connection was wasted work — and now avoids re-reading `/etc/os-release` on every new connection too.
- All parsing is wrapped in `try`/`catch` to honor the design principle that telemetry must never impact driver operations.
- Updated `docs/designs/fix-telemetry-gaps-design.md` to note the fix.

## Test plan

- [x] New unit tests in `ConnectionTelemetryOsVersionTests` cover:
  - `GetOsVersion()` is always populated.
  - On Linux, the returned value is not the bare kernel version (regression guard).
  - `UnquoteOsReleaseValue` strips matching double/single quotes per `os-release(5)` spec.
  - `BuildSystemConfiguration` returns the same cached reference across calls.
- [x] \`dotnet test --filter "FullyQualifiedName~Unit.Telemetry"\` → 275 passed.
- [x] \`dotnet build\` passes for all target frameworks.

Closes PECO-2986.