### PR TITLE
fix: use pull_request_target for labeled trigger to allow secrets in fork PRs

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -14,7 +14,9 @@
 name: Trigger Integration Tests
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [labeled]
   merge_group:  # Trigger when added to merge queue
 jobs:
   # =============================================================================
@@ -22,6 +24,7 @@ jobs:
   # =============================================================================
   remove-label-on-new-commit:
     if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+    # Note: runs on pull_request (not pull_request_target) — no secrets needed here
     runs-on: [self-hosted, Linux, X64, peco-driver]
     permissions:
       pull-requests: write
@@ -98,7 +101,7 @@ jobs:
   # (they run as a required gate in the merge queue)
   # =============================================================================
   skip-integration-tests-pr:
-    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token
@@ -153,7 +156,7 @@ jobs:
   # =============================================================================
   trigger-tests-pr:
     if: |
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       github.event.action == 'labeled' &&
       contains(github.event.pull_request.labels.*.name, 'integration-test')
     runs-on: [self-hosted, Linux, X64, peco-driver]


### PR DESCRIPTION
## Summary

- The \`trigger-tests-pr\` job fails for fork PRs with \`Error: Input required and not supplied: app-id\` because \`secrets.INTEGRATION_TEST_APP_ID\` is unavailable under the \`pull_request\` event
- Move the \`labeled\` trigger to \`pull_request_target\`, which runs in the base repo context and has full access to repository secrets
- Update \`trigger-tests-pr\` condition to match \`pull_request_target\`; \`skip-integration-tests-pr\` already only fires on \`pull_request\` so it's unaffected by fork label events

**Security note:** This change is safe. \`trigger-tests-pr\` never checks out any fork code — it only reads PR metadata (number, SHA, author) and dispatches a \`repository_dispatch\` event to the internal test repo. There is no code execution from the fork in this job.

**Who can trigger tests:** GitHub restricts label management to collaborators with \`triage\` access or higher — external contributors and read-only users cannot add labels. This means only trusted collaborators can trigger the integration test workflow.

## Root cause

Discovered while investigating adbc-drivers/databricks#397 — adding the \`integration-test\` label triggered the workflow but the \`Generate GitHub App Token\` step failed because fork PR workflows don't receive repo secrets under \`pull_request\`.

## Test plan
- [ ] Add \`integration-test\` label to a fork PR and verify \`trigger-tests-pr\` completes successfully
- [ ] Verify \`skip-integration-tests-pr\` still fires on \`opened\`/\`synchronize\`/\`reopened\` events
- [ ] Verify \`remove-label-on-new-commit\` still fires on \`synchronize\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)