### PR TITLE
fix(csharp): populate process_name telemetry with entry assembly name (PECO-2989)

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -302,7 +303,11 @@ namespace AdbcDrivers.Databricks.Telemetry
         private static Proto.DriverSystemConfiguration CreateSystemConfiguration(string assemblyVersion)
         {
             var osVersion = System.Environment.OSVersion;
-            var processName = Process.GetCurrentProcess().ProcessName;
+            // Prefer the entry assembly name so process_name reflects the actual application
+            // (e.g. "MyApp") rather than the .NET host executable name ("dotnet"). Fall back
+            // to the OS process name when there is no entry assembly (e.g. unmanaged hosts).
+            var processName = Assembly.GetEntryAssembly()?.GetName().Name
+                ?? Process.GetCurrentProcess().ProcessName;
             return new Proto.DriverSystemConfiguration
             {
                 DriverVersion = assemblyVersion,

--- a/csharp/test/E2E/Telemetry/SystemConfigurationTests.cs
+++ b/csharp/test/E2E/Telemetry/SystemConfigurationTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Telemetry;
 using Apache.Arrow.Adbc;
@@ -80,10 +81,11 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         }
 
         /// <summary>
-        /// Tests that client_app_name is always set to the process name.
+        /// Tests that process_name and client_app_name default to the entry assembly name
+        /// (the actual application) instead of the .NET host executable ("dotnet").
         /// </summary>
         [SkippableFact]
-        public async Task SystemConfig_ClientAppName_IsProcessName()
+        public async Task SystemConfig_ProcessName_IsEntryAssemblyName()
         {
             CapturingTelemetryExporter exporter = null!;
             AdbcConnection? connection = null;
@@ -108,16 +110,25 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
 
                 var protoLog = TelemetryTestHelpers.GetProtoLog(logs[0]);
 
-                // Assert client_app_name is set to the current process name
                 Assert.NotNull(protoLog.SystemConfiguration);
+                Assert.False(string.IsNullOrEmpty(protoLog.SystemConfiguration.ProcessName),
+                    "process_name should be populated");
                 Assert.False(string.IsNullOrEmpty(protoLog.SystemConfiguration.ClientAppName),
-                    "client_app_name should be populated with process name when property not set");
+                    "client_app_name should be populated");
 
-                // Verify it matches the actual process name
-                string expectedProcessName = Process.GetCurrentProcess().ProcessName;
-                Assert.Equal(expectedProcessName, protoLog.SystemConfiguration.ClientAppName);
+                // On .NET Core / .NET 5+ hosts, the OS process name is "dotnet"; that is the
+                // bug this field is meant to avoid (PECO-2989). Regardless of runtime, the
+                // reported value should reflect the actual application, not the .NET host.
+                Assert.NotEqual("dotnet", protoLog.SystemConfiguration.ProcessName);
+                Assert.NotEqual("dotnet", protoLog.SystemConfiguration.ClientAppName);
 
-                OutputHelper?.WriteLine($"✓ client_app_name defaulted to process name: {protoLog.SystemConfiguration.ClientAppName}");
+                string expected = Assembly.GetEntryAssembly()?.GetName().Name
+                    ?? Process.GetCurrentProcess().ProcessName;
+                Assert.Equal(expected, protoLog.SystemConfiguration.ProcessName);
+                Assert.Equal(expected, protoLog.SystemConfiguration.ClientAppName);
+
+                OutputHelper?.WriteLine($"✓ process_name: {protoLog.SystemConfiguration.ProcessName}");
+                OutputHelper?.WriteLine($"✓ client_app_name: {protoLog.SystemConfiguration.ClientAppName}");
             }
             finally
             {

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetrySystemConfigurationTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetrySystemConfigurationTests.cs
@@ -1,0 +1,57 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Diagnostics;
+using System.Reflection;
+using AdbcDrivers.Databricks.Telemetry;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Regression tests for PECO-2989: <c>process_name</c> was populated from
+    /// <see cref="Process.GetCurrentProcess"/>, which returns the .NET host executable
+    /// name ("dotnet") for any .NET Core / .NET 5+ application and is worthless for
+    /// customer attribution. The field must reflect the entry assembly name, falling
+    /// back to the OS process name when no entry assembly is available.
+    /// </summary>
+    public class ConnectionTelemetrySystemConfigurationTests
+    {
+        [Fact]
+        public void ProcessName_UsesEntryAssemblyName_NotDotnetHost()
+        {
+            var config = ConnectionTelemetry.BuildSystemConfiguration(assemblyVersion: "1.2.3");
+
+            string expected = Assembly.GetEntryAssembly()?.GetName().Name
+                ?? Process.GetCurrentProcess().ProcessName;
+
+            Assert.Equal(expected, config.ProcessName);
+            Assert.NotEqual("dotnet", config.ProcessName);
+        }
+
+        [Fact]
+        public void ClientAppName_DefaultsToEntryAssemblyName_NotDotnetHost()
+        {
+            var config = ConnectionTelemetry.BuildSystemConfiguration(assemblyVersion: "1.2.3");
+
+            string expected = Assembly.GetEntryAssembly()?.GetName().Name
+                ?? Process.GetCurrentProcess().ProcessName;
+
+            Assert.Equal(expected, config.ClientAppName);
+            Assert.NotEqual("dotnet", config.ClientAppName);
+        }
+    }
+}

--- a/docs/designs/fix-telemetry-gaps-design.md
+++ b/docs/designs/fix-telemetry-gaps-design.md
@@ -115,7 +115,7 @@ flowchart TD
 | `client_app_name` | **NOT SET** | Should come from connection property or user-agent |
 | `locale_name` | Populated | CultureInfo.CurrentCulture |
 | `char_set_encoding` | Populated | Encoding.Default.WebName |
-| `process_name` | Populated | Process name |
+| `process_name` | Populated | Entry assembly name (fallback: OS process name) — PECO-2989 |
 
 #### DriverConnectionParameters (47 fields)
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/403/files) to review incremental changes.
- [**stack/PECO-2989-fix-process-name-telemetry**](https://github.com/adbc-drivers/databricks/pull/403) [[Files changed](https://github.com/adbc-drivers/databricks/pull/403/files)]

---------
## What's Changed

`entry.system_configuration.process_name` was populated from
`Process.GetCurrentProcess().ProcessName`, which on .NET Core / .NET 5+
returns the .NET host executable name (`"dotnet"`) regardless of the
hosting application. As a result, 100% of ADBC C# telemetry rows
reported `process_name = "dotnet"`, making the field worthless for
customer attribution. JDBC, by comparison, reports real names like
`DirectTestRunner`, `SparkSubmit`, `Server`, etc.

Fix: use `Assembly.GetEntryAssembly()?.GetName().Name` with a safe
fallback to `Process.GetCurrentProcess().ProcessName` for unmanaged
hosts where no entry assembly is available. `client_app_name` defaults
to the same value, so it inherits the improvement (a separate ticket
covers driving `client_app_name` from a connection property / user
agent).

### Tests

- New unit test `ConnectionTelemetrySystemConfigurationTests` asserts
  `process_name` and `client_app_name` equal the entry assembly name
  and are not `"dotnet"` (regression guard).
- Updated existing E2E test `SystemConfig_ClientAppName_IsProcessName`
  → `SystemConfig_ProcessName_IsEntryAssemblyName` to match the new
  behavior.

Closes PECO-2989.