### PR TITLE
fix(csharp): use next_chunk_index from last ExternalLink for SEA CloudFetch navigation

### DIFF
--- a/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
@@ -89,9 +89,10 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
 
             // Process the initial external links (chunk 0)
             ProcessExternalLinks(_initialExternalLinks, cancellationToken);
-            _currentChunkIndex = 1; // Start fetching from chunk 1
 
-            // Check if there are more chunks to fetch
+            // Use next_chunk_index from the last link to determine continuation
+            var lastInitialLink = _initialExternalLinks[_initialExternalLinks.Count - 1];
+            _currentChunkIndex = (int)(lastInitialLink.NextChunkIndex ?? _manifest.TotalChunkCount);
             _hasMoreResults = _currentChunkIndex < _manifest.TotalChunkCount;
         }
 
@@ -131,9 +132,15 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 if (resultData.ExternalLinks != null && resultData.ExternalLinks.Count > 0)
                 {
                     ProcessExternalLinks(resultData.ExternalLinks, cancellationToken);
+                    // Use next_chunk_index from the last link to determine the next fetch
+                    var lastLink = resultData.ExternalLinks[resultData.ExternalLinks.Count - 1];
+                    _currentChunkIndex = (int)(lastLink.NextChunkIndex ?? _manifest.TotalChunkCount);
+                }
+                else
+                {
+                    _currentChunkIndex = (int)_manifest.TotalChunkCount;
                 }
 
-                _currentChunkIndex++;
                 _hasMoreResults = _currentChunkIndex < _manifest.TotalChunkCount;
             }
             catch (Exception ex)

--- a/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
+++ b/csharp/src/Reader/CloudFetch/StatementExecutionResultFetcher.cs
@@ -132,15 +132,14 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 if (resultData.ExternalLinks != null && resultData.ExternalLinks.Count > 0)
                 {
                     ProcessExternalLinks(resultData.ExternalLinks, cancellationToken);
-                    // Use next_chunk_index from the last link to determine the next fetch
-                    var lastLink = resultData.ExternalLinks[resultData.ExternalLinks.Count - 1];
-                    _currentChunkIndex = (int)(lastLink.NextChunkIndex ?? _manifest.TotalChunkCount);
-                }
-                else
-                {
-                    _currentChunkIndex = (int)_manifest.TotalChunkCount;
                 }
 
+                // Use next_chunk_index from the last link to determine the next fetch;
+                // null (or no links) means no more chunks
+                var lastLink = resultData.ExternalLinks != null && resultData.ExternalLinks.Count > 0
+                    ? resultData.ExternalLinks[resultData.ExternalLinks.Count - 1]
+                    : null;
+                _currentChunkIndex = (int)(lastLink?.NextChunkIndex ?? _manifest.TotalChunkCount);
                 _hasMoreResults = _currentChunkIndex < _manifest.TotalChunkCount;
             }
             catch (Exception ex)

--- a/csharp/test/E2E/CloudFetch/StatementExecutionResultFetcherTest.cs
+++ b/csharp/test/E2E/CloudFetch/StatementExecutionResultFetcherTest.cs
@@ -69,7 +69,8 @@ namespace AdbcDrivers.Databricks.Tests.CloudFetch
                             RowOffset = 100,
                             RowCount = 100,
                             ByteCount = 1024,
-                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                            NextChunkIndex = 2
                         }
                     }
                 });
@@ -247,7 +248,8 @@ namespace AdbcDrivers.Databricks.Tests.CloudFetch
                             RowOffset = 0,
                             RowCount = 100,
                             ByteCount = 1024,
-                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                            NextChunkIndex = 1
                         }
                     }
                 });
@@ -268,7 +270,8 @@ namespace AdbcDrivers.Databricks.Tests.CloudFetch
                             RowOffset = 100,
                             RowCount = 100,
                             ByteCount = 1024,
-                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                            NextChunkIndex = null
                         }
                     }
                 });
@@ -594,7 +597,8 @@ namespace AdbcDrivers.Databricks.Tests.CloudFetch
                     RowOffset = 0,
                     RowCount = 100,
                     ByteCount = 1024,
-                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                    NextChunkIndex = chunkCount > 1 ? (long?)1 : null
                 }
             };
 

--- a/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
+++ b/csharp/test/Unit/Reader/CloudFetch/StatementExecutionResultFetcherTests.cs
@@ -310,7 +310,8 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Reader.CloudFetch
                             RowOffset = 0,
                             RowCount = 100,
                             ByteCount = 1024,
-                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                            NextChunkIndex = 1
                         }
                     }
                 });
@@ -331,7 +332,8 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Reader.CloudFetch
                             RowOffset = 100,
                             RowCount = 100,
                             ByteCount = 1024,
-                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                            Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                            NextChunkIndex = null
                         }
                     }
                 });
@@ -361,6 +363,104 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Reader.CloudFetch
 
             // 2 download results + end guard
             Assert.Equal(3, results.Count);
+        }
+
+        [Fact]
+        public async Task StartAsync_WithBatchReturningMultipleLinks_UsesNextChunkIndexNotSequentialCounter()
+        {
+            // Server returns links for chunks 0 and 1 in a single /chunks/0 response.
+            // The driver must use next_chunk_index from the last link (= 2) for the next call,
+            // and must NOT redundantly call /chunks/1.
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 3,
+                TotalRowCount = 300,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 },
+                    new ResultChunk { ChunkIndex = 1, RowOffset = 100, RowCount = 100, ByteCount = 1024 },
+                    new ResultChunk { ChunkIndex = 2, RowOffset = 200, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink { ChunkIndex = 0, ExternalLinkUrl = "https://s3/chunk0.arrow", RowOffset = 0, RowCount = 100, ByteCount = 1024, Expiration = DateTime.UtcNow.AddHours(1).ToString("O") },
+                        new ExternalLink { ChunkIndex = 1, ExternalLinkUrl = "https://s3/chunk1.arrow", RowOffset = 100, RowCount = 100, ByteCount = 1024, Expiration = DateTime.UtcNow.AddHours(1).ToString("O"), NextChunkIndex = 2 }
+                    }
+                });
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 2, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink { ChunkIndex = 2, ExternalLinkUrl = "https://s3/chunk2.arrow", RowOffset = 200, RowCount = 100, ByteCount = 1024, Expiration = DateTime.UtcNow.AddHours(1).ToString("O"), NextChunkIndex = null }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object, _testStatementId, manifest, initialExternalLinks: null,
+                _mockMemoryManager.Object, _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            // Must call chunk 0 and chunk 2, but NOT chunk 1 (already returned in chunk 0 batch)
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()), Times.Once);
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()), Times.Never);
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 2, It.IsAny<CancellationToken>()), Times.Once);
+
+            var results = DrainQueue();
+            // 3 links (chunks 0, 1, 2) + end guard
+            Assert.Equal(4, results.Count);
+            Assert.IsType<EndOfResultsGuard>(results.Last());
+        }
+
+        [Fact]
+        public async Task StartAsync_WithNullNextChunkIndex_StopsEarlyRegardlessOfTotalChunkCount()
+        {
+            // TotalChunkCount says 3 chunks exist, but server signals end via next_chunk_index = null
+            var manifest = new ResultManifest
+            {
+                TotalChunkCount = 3,
+                TotalRowCount = 300,
+                Chunks = new List<ResultChunk>
+                {
+                    new ResultChunk { ChunkIndex = 0, RowOffset = 0, RowCount = 100, ByteCount = 1024 }
+                }
+            };
+
+            _mockClient.Setup(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResultData
+                {
+                    ExternalLinks = new List<ExternalLink>
+                    {
+                        new ExternalLink { ChunkIndex = 0, ExternalLinkUrl = "https://s3/chunk0.arrow", RowOffset = 0, RowCount = 100, ByteCount = 1024, Expiration = DateTime.UtcNow.AddHours(1).ToString("O"), NextChunkIndex = null }
+                    }
+                });
+
+            var fetcher = new StatementExecutionResultFetcher(
+                _mockClient.Object, _testStatementId, manifest, initialExternalLinks: null,
+                _mockMemoryManager.Object, _downloadQueue);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await fetcher.StartAsync(cts.Token);
+            await WaitForFetcherCompletionAsync(fetcher, cts.Token);
+
+            // Only chunk 0 fetched; chunks 1 and 2 never called
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 0, It.IsAny<CancellationToken>()), Times.Once);
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 1, It.IsAny<CancellationToken>()), Times.Never);
+            _mockClient.Verify(c => c.GetResultChunkAsync(_testStatementId, 2, It.IsAny<CancellationToken>()), Times.Never);
+
+            var results = DrainQueue();
+            // 1 link + end guard
+            Assert.Equal(2, results.Count);
+            Assert.IsType<EndOfResultsGuard>(results.Last());
         }
 
         #endregion
@@ -600,6 +700,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Reader.CloudFetch
             };
 
             // Initial external links for chunk 0 (from result.external_links)
+            // Set NextChunkIndex so the fetcher knows to continue to chunk 1 (if there are more chunks)
             var initialExternalLinks = new List<ExternalLink>
             {
                 new ExternalLink
@@ -609,11 +710,22 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Reader.CloudFetch
                     RowOffset = 0,
                     RowCount = 100,
                     ByteCount = 1024,
-                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O")
+                    Expiration = DateTime.UtcNow.AddHours(1).ToString("O"),
+                    NextChunkIndex = chunkCount > 1 ? (long?)1 : null
                 }
             };
 
             return (manifest, initialExternalLinks);
+        }
+
+        private List<IDownloadResult> DrainQueue()
+        {
+            var results = new List<IDownloadResult>();
+            while (_downloadQueue.TryTake(out var result, TimeSpan.FromMilliseconds(100)))
+            {
+                results.Add(result);
+            }
+            return results;
         }
 
         private async Task WaitForFetcherCompletionAsync(StatementExecutionResultFetcher fetcher, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- Previously `StatementExecutionResultFetcher` incremented `_currentChunkIndex++` after each batch, assuming one link per API call
- If the server returns multiple `ExternalLink`s per `GET /result/chunks/{N}` call, the old code would make redundant API calls and enqueue duplicate download entries, producing duplicate rows in the result set
- `TotalChunkCount` is retained as a fallback termination guard

Example:
```
{
  "manifest": {
    "total_chunk_count": 35,
    "total_row_count": 1439935
  },
  "result": {
    "external_links": [
      { "chunk_index": 0,  "row_offset": 0,       "row_count": 48996, "next_chunk_index": 1,  "external_link": "https://..." },
      { "chunk_index": 1,  "row_offset": 48996,   "row_count": 49321, "next_chunk_index": 2,  "external_link": "https://..." },
      { "chunk_index": 2,  "row_offset": 98317,   "row_count": 49321, "next_chunk_index": 3,  "external_link": "https://..." },
      "...",
      { "chunk_index": 31, "row_offset": 1215458, "row_count": 65089, "next_chunk_index": 32, "external_link": "https://..." }
    ]
  }
}

```
## Test plan

- [ ] Build passes (`dotnet build`)
- [ ] Run existing CloudFetch E2E tests against a live warehouse to verify correct result counts
- [ ] Verify no duplicate rows on queries returning multiple CloudFetch chunks

Verified in PBI desktop, it fetch the correct chunkIndex.
Closes PECO-3001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_This PR was created with [GitHub MCP](http://go/mcps)._