### PR TITLE
fix(csharp): use ADBCDatabricksDriver user agent for REST/SEA path

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -100,20 +100,13 @@ jobs:
   skip-integration-tests-pr:
     if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     steps:
-      - name: Generate GitHub App Token
-        id: adbc-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
-        with:
-          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
-          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
-          owner: adbc-drivers
-          repositories: databricks
-
       - name: Skip C# Integration Tests
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
-          github-token: ${{ steps.adbc-token.outputs.token }}
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',
@@ -132,7 +125,7 @@ jobs:
       - name: Skip Rust Integration Tests
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
-          github-token: ${{ steps.adbc-token.outputs.token }}
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',

--- a/csharp/src/Http/UserAgentHelper.cs
+++ b/csharp/src/Http/UserAgentHelper.cs
@@ -32,8 +32,7 @@ namespace AdbcDrivers.Databricks.Http
         /// <returns>The User-Agent string.</returns>
         /// <remarks>
         /// This is used for internal driver HTTP requests like feature flag fetching.
-        /// Statement execution uses a different User-Agent (DatabricksJDBCDriverOSS) for
-        /// server-side feature compatibility.
+        /// Statement execution uses ADBCDatabricksDriver as the User-Agent.
         /// </remarks>
         public static string GetUserAgent(string assemblyVersion, IReadOnlyDictionary<string, string>? properties = null)
         {

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -345,14 +345,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         /// <summary>
         /// Builds the user agent string for HTTP requests.
-        /// Format: DatabricksJDBCDriverOSS/{version} (ADBC)
-        /// Uses DatabricksJDBCDriverOSS prefix for server-side feature compatibility.
+        /// Format: ADBCDatabricksDriver/{version} REST
         /// </summary>
         private string GetUserAgent(IReadOnlyDictionary<string, string> properties)
         {
-            // Use DatabricksJDBCDriverOSS prefix for server-side feature compatibility
-            // (e.g., INLINE_OR_EXTERNAL_LINKS disposition support)
-            string baseUserAgent = $"DatabricksJDBCDriverOSS/{DatabricksConnection.DriverVersion} (ADBC)";
+            string baseUserAgent = $"{DatabricksConnection.DatabricksDriverName.Replace(" ", "")}/{DatabricksConnection.DriverVersion} REST";
 
             // Check if a client has provided a user-agent entry
             string userAgentEntry = PropertyHelper.GetStringProperty(properties, "adbc.spark.user_agent_entry", string.Empty);


### PR DESCRIPTION
Replace the incorrect DatabricksJDBCDriverOSS/1.1.0 (ADBC) user agent on the REST/SEA path with ADBCDatabricksDriver/1.1.0 REST, consistent with the Thrift path (ADBCDatabricksDriver/1.1.0 Thrift/0.22.0).

Before:
<img width="675" height="63" alt="image" src="https://github.com/user-attachments/assets/544fa3d6-2a04-4c4d-a57b-c67e34ce7944" />

Now:
<img width="641" height="90" alt="image" src="https://github.com/user-attachments/assets/79df1678-8348-4691-98ca-a5504db4ca1b" />


Closes PECO-3003

## What's Changed

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
