### PR TITLE
ci: use GITHUB_TOKEN for skip-integration-tests-pr to fix fork PRs

### DIFF
--- a/.github/workflows/skip-checks-reporter.yml
+++ b/.github/workflows/skip-checks-reporter.yml
@@ -1,0 +1,76 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Report Integration Test Skip
+
+# Runs in the base repo context (has secrets) even for fork PRs.
+# Creates the required "C# Integration Tests" and "Rust Integration Tests"
+# check runs via the Driver Integration Test GitHub App whenever a PR
+# triggers the "Trigger Integration Tests" workflow.
+on:
+  workflow_run:
+    workflows: ["Trigger Integration Tests"]
+    types: [requested]
+
+jobs:
+  report-skip:
+    # Only for pull_request events; merge_group runs the real tests
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: adbc-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+          owner: adbc-drivers
+          repositories: databricks
+
+      - name: Skip C# Integration Tests
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          github-token: ${{ steps.adbc-token.outputs.token }}
+          script: |
+            await github.rest.checks.create({
+              owner: 'adbc-drivers',
+              repo: 'databricks',
+              name: 'C# Integration Tests',
+              head_sha: context.payload.workflow_run.head_sha,
+              status: 'completed',
+              conclusion: 'success',
+              completed_at: new Date().toISOString(),
+              output: {
+                title: 'Skipped on PR - runs in merge queue',
+                summary: '✅ Integration tests are skipped on PRs and run as a required gate in the merge queue.'
+              }
+            });
+
+      - name: Skip Rust Integration Tests
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          github-token: ${{ steps.adbc-token.outputs.token }}
+          script: |
+            await github.rest.checks.create({
+              owner: 'adbc-drivers',
+              repo: 'databricks',
+              name: 'Rust Integration Tests',
+              head_sha: context.payload.workflow_run.head_sha,
+              status: 'completed',
+              conclusion: 'success',
+              completed_at: new Date().toISOString(),
+              output: {
+                title: 'Skipped on PR - runs in merge queue',
+                summary: '✅ Integration tests are skipped on PRs and run as a required gate in the merge queue.'
+              }
+            });

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -100,20 +100,13 @@ jobs:
   skip-integration-tests-pr:
     if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     steps:
-      - name: Generate GitHub App Token
-        id: adbc-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
-        with:
-          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
-          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
-          owner: adbc-drivers
-          repositories: databricks
-
       - name: Skip C# Integration Tests
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
-          github-token: ${{ steps.adbc-token.outputs.token }}
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',
@@ -132,7 +125,7 @@ jobs:
       - name: Skip Rust Integration Tests
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
-          github-token: ${{ steps.adbc-token.outputs.token }}
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -100,13 +100,22 @@ jobs:
   skip-integration-tests-pr:
     if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
+      - name: Generate GitHub App Token
+        id: adbc-token
+        if: ${{ secrets.INTEGRATION_TEST_APP_ID != '' }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+          owner: adbc-drivers
+          repositories: databricks
+
       - name: Skip C# Integration Tests
+        if: steps.adbc-token.conclusion == 'success'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.adbc-token.outputs.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',
@@ -123,9 +132,10 @@ jobs:
             });
 
       - name: Skip Rust Integration Tests
+        if: steps.adbc-token.conclusion == 'success'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.adbc-token.outputs.token }}
           script: |
             await github.rest.checks.create({
               owner: 'adbc-drivers',

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -94,64 +94,6 @@ jobs:
             });
 
   # =============================================================================
-  # For PRs: Always skip integration tests on non-label events
-  # (they run as a required gate in the merge queue)
-  # =============================================================================
-  skip-integration-tests-pr:
-    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App Token
-        id: adbc-token
-        if: ${{ secrets.INTEGRATION_TEST_APP_ID != '' }}
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
-        with:
-          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
-          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
-          owner: adbc-drivers
-          repositories: databricks
-
-      - name: Skip C# Integration Tests
-        if: steps.adbc-token.conclusion == 'success'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-        with:
-          github-token: ${{ steps.adbc-token.outputs.token }}
-          script: |
-            await github.rest.checks.create({
-              owner: 'adbc-drivers',
-              repo: 'databricks',
-              name: 'C# Integration Tests',
-              head_sha: context.payload.pull_request.head.sha,
-              status: 'completed',
-              conclusion: 'success',
-              completed_at: new Date().toISOString(),
-              output: {
-                title: 'Skipped on PR - runs in merge queue',
-                summary: '✅ Integration tests are skipped on PRs and run as a required gate in the merge queue.'
-              }
-            });
-
-      - name: Skip Rust Integration Tests
-        if: steps.adbc-token.conclusion == 'success'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-        with:
-          github-token: ${{ steps.adbc-token.outputs.token }}
-          script: |
-            await github.rest.checks.create({
-              owner: 'adbc-drivers',
-              repo: 'databricks',
-              name: 'Rust Integration Tests',
-              head_sha: context.payload.pull_request.head.sha,
-              status: 'completed',
-              conclusion: 'success',
-              completed_at: new Date().toISOString(),
-              output: {
-                title: 'Skipped on PR - runs in merge queue',
-                summary: '✅ Integration tests are skipped on PRs and run as a required gate in the merge queue.'
-              }
-            });
-
-  # =============================================================================
   # For PRs: Dispatch real tests when integration-test label is added
   # =============================================================================
   trigger-tests-pr:

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -94,14 +94,11 @@ jobs:
             });
 
   # =============================================================================
-  # For non-fork PRs: skip integration tests on non-label events
-  # (fork PRs are handled by skip-checks-reporter.yml via workflow_run once on main)
+  # For PRs: Always skip integration tests on non-label events
+  # (they run as a required gate in the merge queue)
   # =============================================================================
   skip-integration-tests-pr:
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.action != 'labeled' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -94,6 +94,64 @@ jobs:
             });
 
   # =============================================================================
+  # For non-fork PRs: skip integration tests on non-label events
+  # (fork PRs are handled by skip-checks-reporter.yml via workflow_run once on main)
+  # =============================================================================
+  skip-integration-tests-pr:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action != 'labeled' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: adbc-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+          owner: adbc-drivers
+          repositories: databricks
+
+      - name: Skip C# Integration Tests
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          github-token: ${{ steps.adbc-token.outputs.token }}
+          script: |
+            await github.rest.checks.create({
+              owner: 'adbc-drivers',
+              repo: 'databricks',
+              name: 'C# Integration Tests',
+              head_sha: context.payload.pull_request.head.sha,
+              status: 'completed',
+              conclusion: 'success',
+              completed_at: new Date().toISOString(),
+              output: {
+                title: 'Skipped on PR - runs in merge queue',
+                summary: '✅ Integration tests are skipped on PRs and run as a required gate in the merge queue.'
+              }
+            });
+
+      - name: Skip Rust Integration Tests
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          github-token: ${{ steps.adbc-token.outputs.token }}
+          script: |
+            await github.rest.checks.create({
+              owner: 'adbc-drivers',
+              repo: 'databricks',
+              name: 'Rust Integration Tests',
+              head_sha: context.payload.pull_request.head.sha,
+              status: 'completed',
+              conclusion: 'success',
+              completed_at: new Date().toISOString(),
+              output: {
+                title: 'Skipped on PR - runs in merge queue',
+                summary: '✅ Integration tests are skipped on PRs and run as a required gate in the merge queue.'
+              }
+            });
+
+  # =============================================================================
   # For PRs: Dispatch real tests when integration-test label is added
   # =============================================================================
   trigger-tests-pr:


### PR DESCRIPTION
## Summary

- `skip-integration-tests-pr` was using a GitHub App token (`INTEGRATION_TEST_APP_ID`) to create skip check runs
- For fork PRs, repository secrets are unavailable, so `app-id` is empty and the job fails — blocking merge queue entry (seen on PR #406)
- `GITHUB_TOKEN` with `checks: write` is sufficient to create check runs; no GitHub App needed for the skip path

## Change

- Remove the `Generate GitHub App Token` step from `skip-integration-tests-pr`
- Add `permissions: checks: write` to the job
- Use `github.token` directly in both skip steps

---
_This PR was created with [GitHub MCP](http://go/mcps)._