### PR TITLE
chore(csharp): bump version to 1.1.1 and add CHANGELOG

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to the C# Databricks ADBC driver are documented in this file.
+
+## [1.1.1] - Unreleased
+
+### Fixed
+
+- Populate `process_name` telemetry with entry assembly name (#403)
+- Use `next_chunk_index` from last ExternalLink for SEA CloudFetch navigation (#404)
+- Report distro `PRETTY_NAME` instead of kernel version in `os_version` telemetry (#399)
+- Emit bare hostname for telemetry `host_url` to match JDBC (#401)
+- Report OAuth U2M access-token passthrough as `auth_mech=OAUTH` (#396)
+- Add `scope=sql` to `RefreshTokenAsync` for AAD service principal tokens (#389)
+- Retry telemetry 429/503 via `EnsureSuccessOrThrow` (#393)
+- Populate `driver_connection_params.http_path` in telemetry (#392, #391)
+
+### Changed
+
+- Emit individual span per `PollOperationStatus` poll (#390)
+- Sync with updated hiveserver2 for assembly version updates (#406)
+
+## [1.1.0] - 2025-04-11
+
+Initial public release of the C# Databricks ADBC driver.

--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the C# Databricks ADBC driver are documented in this file
 
 ### Fixed
 
+- Set telemetry `is_compressed` and `execution_result` from actual result, not connection capability (#402)
 - Populate `process_name` telemetry with entry assembly name (#403)
 - Use `next_chunk_index` from last ExternalLink for SEA CloudFetch navigation (#404)
 - Report distro `PRETTY_NAME` instead of kernel version in `os_version` telemetry (#399)

--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -1,3 +1,19 @@
+<!--
+  Copyright (c) 2025 ADBC Drivers Contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 # Changelog
 
 All notable changes to the C# Databricks ADBC driver are documented in this file.

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` in `csharp/Directory.Build.props` from `1.1.0` to `1.1.1`
- Add `csharp/CHANGELOG.md` documenting all C# driver changes since v1.1.0

## Changes since v1.1.0

- fix: populate `process_name` telemetry with entry assembly name (#403)
- fix: use `next_chunk_index` from last ExternalLink for SEA CloudFetch navigation (#404)
- fix: report distro `PRETTY_NAME` instead of kernel version in `os_version` telemetry (#399)
- fix: emit bare hostname for telemetry `host_url` to match JDBC (#401)
- fix: report OAuth U2M access-token passthrough as `auth_mech=OAUTH` (#396)
- fix: add `scope=sql` to `RefreshTokenAsync` for AAD service principal tokens (#389)
- fix: retry telemetry 429/503 via `EnsureSuccessOrThrow` (#393)
- fix: populate `driver_connection_params.http_path` in telemetry (#392, #391)
- refactor: emit individual span per `PollOperationStatus` poll (#390)
- chore: sync with updated hiveserver2 for assembly version updates (#406)

## Test plan

- [ ] CI passes
- [ ] Verify `DriverVersion` resolves to `1.1.1-SNAPSHOT` in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)