### PR TITLE
ci(csharp): automate release branch sync on version bump

### DIFF
--- a/.github/workflows/csharp-sync-latest.yml
+++ b/.github/workflows/csharp-sync-latest.yml
@@ -12,33 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Sync release/csharp/latest
+name: Sync C# release branches
 
+# Runs whenever a commit lands on main that bumps the C# version.
+# Keeps the release branch, version tag, and release/csharp/latest all in sync.
 on:
   push:
     branches:
-      - 'release/csharp/v*.latest'
+      - main
+    paths:
+      - 'csharp/Directory.Build.props'
 
 jobs:
-  sync-latest:
+  sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Sync release/csharp/latest if this is the newest minor version
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse version and derive names
+        id: ver
         run: |
-          CURRENT="${{ github.ref_name }}"
-          CURRENT_VER=$(echo "$CURRENT" | grep -oP 'v\d+\.\d+')
-
-          NEWEST=$(gh api repos/${{ github.repository }}/branches --paginate \
-            --jq '.[].name' \
-            | grep '^release/csharp/v[0-9]' \
-            | grep -oP 'v\d+\.\d+' \
-            | sort -V | tail -1)
-
-          if [ "$CURRENT_VER" = "$NEWEST" ]; then
-            echo "Syncing release/csharp/latest → $CURRENT"
-            git push origin "$CURRENT:refs/heads/release/csharp/latest" --force
-          else
-            echo "$CURRENT ($CURRENT_VER) is not the newest ($NEWEST), skipping"
+          VERSION=$(grep -oP '(?<=<VersionPrefix>)[^<]+' csharp/Directory.Build.props)
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not parse VersionPrefix from csharp/Directory.Build.props"
+            exit 1
           fi
+          MINOR=$(echo "$VERSION" | grep -oP '^\d+\.\d+')
+          echo "version=$VERSION"                                  >> "$GITHUB_OUTPUT"
+          echo "branch=release/csharp/v${MINOR}.latest"           >> "$GITHUB_OUTPUT"
+          echo "tag=csharp/v${VERSION}"                           >> "$GITHUB_OUTPUT"
+
+      - name: Push main to release branch (create if new minor version)
+        run: |
+          TARGET="${{ steps.ver.outputs.branch }}"
+          if git ls-remote --exit-code origin "refs/heads/$TARGET" > /dev/null 2>&1; then
+            echo "Updating existing branch: $TARGET"
+          else
+            echo "Creating new release branch: $TARGET"
+          fi
+          git push origin "HEAD:refs/heads/$TARGET"
+
+      - name: Tag the release
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+          if git ls-remote --exit-code origin "refs/tags/$TAG" > /dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Created tag: $TAG"
+          fi
+
+      - name: Update release/csharp/latest
+        run: |
+          echo "Syncing release/csharp/latest → ${{ steps.ver.outputs.branch }}"
+          git push origin "HEAD:refs/heads/release/csharp/latest" --force

--- a/.github/workflows/csharp-sync-latest.yml
+++ b/.github/workflows/csharp-sync-latest.yml
@@ -39,12 +39,12 @@ jobs:
             echo "ERROR: could not parse VersionPrefix from csharp/Directory.Build.props"
             exit 1
           fi
-          MINOR=$(echo "$VERSION" | grep -oP '^\d+\.\d+')
-          echo "version=$VERSION"                                  >> "$GITHUB_OUTPUT"
-          echo "branch=release/csharp/v${MINOR}.latest"           >> "$GITHUB_OUTPUT"
-          echo "tag=csharp/v${VERSION}"                           >> "$GITHUB_OUTPUT"
+          MAJOR_MINOR=$(echo "$VERSION" | grep -oP '^\d+\.\d+')
+          echo "version=$VERSION"                                        >> "$GITHUB_OUTPUT"
+          echo "branch=release/csharp/v${MAJOR_MINOR}.latest"           >> "$GITHUB_OUTPUT"
+          echo "tag=csharp/v${VERSION}"                                  >> "$GITHUB_OUTPUT"
 
-      - name: Push main to release branch (create if new minor version)
+      - name: Push main to release branch (create if new)
         run: |
           TARGET="${{ steps.ver.outputs.branch }}"
           if git ls-remote --exit-code origin "refs/heads/$TARGET" > /dev/null 2>&1; then

--- a/.github/workflows/csharp-sync-latest.yml
+++ b/.github/workflows/csharp-sync-latest.yml
@@ -23,23 +23,38 @@ on:
     paths:
       - 'csharp/Directory.Build.props'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Parse version and derive names
         id: ver
         run: |
-          VERSION=$(grep -oP '(?<=<VersionPrefix>)[^<]+' csharp/Directory.Build.props)
+          VERSION=$(grep -oP '(?<=<VersionPrefix>)[^<]+' csharp/Directory.Build.props | head -n1)
+          VERSION=$(printf '%s' "$VERSION" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
           if [ -z "$VERSION" ]; then
             echo "ERROR: could not parse VersionPrefix from csharp/Directory.Build.props"
             exit 1
           fi
-          MAJOR_MINOR=$(echo "$VERSION" | grep -oP '^\d+\.\d+')
+          if ! printf '%s' "$VERSION" | grep -qP '^\d+\.\d+\.\d+$'; then
+            echo "ERROR: VersionPrefix must be in X.Y.Z format, got: '$VERSION'"
+            exit 1
+          fi
+          MAJOR_MINOR=$(printf '%s' "$VERSION" | grep -oP '^\d+\.\d+')
+          if [ -z "$MAJOR_MINOR" ]; then
+            echo "ERROR: failed to derive major.minor from VersionPrefix: '$VERSION'"
+            exit 1
+          fi
           echo "version=$VERSION"                                        >> "$GITHUB_OUTPUT"
           echo "branch=release/csharp/v${MAJOR_MINOR}.latest"           >> "$GITHUB_OUTPUT"
           echo "tag=csharp/v${VERSION}"                                  >> "$GITHUB_OUTPUT"
@@ -67,5 +82,6 @@ jobs:
 
       - name: Update release/csharp/latest
         run: |
-          echo "Syncing release/csharp/latest → ${{ steps.ver.outputs.branch }}"
-          git push origin "HEAD:refs/heads/release/csharp/latest" --force
+          SOURCE="${{ steps.ver.outputs.branch }}"
+          echo "Syncing release/csharp/latest → $SOURCE"
+          git push origin "refs/heads/$SOURCE:refs/heads/release/csharp/latest" --force

--- a/.github/workflows/csharp-sync-latest.yml
+++ b/.github/workflows/csharp-sync-latest.yml
@@ -82,6 +82,5 @@ jobs:
 
       - name: Update release/csharp/latest
         run: |
-          SOURCE="${{ steps.ver.outputs.branch }}"
-          echo "Syncing release/csharp/latest → $SOURCE"
-          git push origin "refs/heads/$SOURCE:refs/heads/release/csharp/latest" --force
+          echo "Syncing release/csharp/latest → main"
+          git push origin "HEAD:refs/heads/release/csharp/latest" --force

--- a/csharp/RELEASE_PROCESS.md
+++ b/csharp/RELEASE_PROCESS.md
@@ -77,12 +77,12 @@ flowchart LR
 
 ### Cutoff
 
-When ready to release a new minor version:
+When ready to release a new major or minor version:
 
-1. Open a PR on `main` that bumps `VersionPrefix` in `csharp/Directory.Build.props` to the new version (e.g. `1.2.0`) and updates `csharp/CHANGELOG.md`.
+1. Open a PR on `main` that bumps `VersionPrefix` in `csharp/Directory.Build.props` to the new version (e.g. `1.2.0` or `2.0.0`) and updates `csharp/CHANGELOG.md`.
 2. Merge the PR. CI automatically:
-   - Creates `release/csharp/v1.2.latest` from `main` (new branch)
-   - Tags the tip as `csharp/v1.2.0`
+   - Creates `release/csharp/v1.2.latest` (or `v2.0.latest`) from `main` (new branch)
+   - Tags the tip as `csharp/v1.2.0` (or `csharp/v2.0.0`)
    - Updates `release/csharp/latest`
 
 ### Post-Cutoff (Maintenance)

--- a/csharp/RELEASE_PROCESS.md
+++ b/csharp/RELEASE_PROCESS.md
@@ -75,24 +75,21 @@ flowchart LR
     R3 -.->|update| LATEST[release/csharp/latest]
 ```
 
-### Cutoff
+### Releasing a new version
 
-When ready to release a new major or minor version:
+For any version bump (patch, minor, or major) on the **current** release line:
 
-1. Open a PR on `main` that bumps `VersionPrefix` in `csharp/Directory.Build.props` to the new version (e.g. `1.2.0` or `2.0.0`) and updates `csharp/CHANGELOG.md`.
+1. Open a PR on `main` that bumps `VersionPrefix` in `csharp/Directory.Build.props` and updates `csharp/CHANGELOG.md`.
+
+   | Bump type | Example | Branch result |
+   |-----------|---------|---------------|
+   | Patch | `1.1.0` → `1.1.1` | Updates existing `release/csharp/v1.1.latest` |
+   | Minor | `1.1.x` → `1.2.0` | Creates new `release/csharp/v1.2.latest` |
+   | Major | `1.x` → `2.0.0` | Creates new `release/csharp/v2.0.latest` |
+
 2. Merge the PR. CI automatically:
-   - Creates `release/csharp/v1.2.latest` (or `v2.0.latest`) from `main` (new branch)
-   - Tags the tip as `csharp/v1.2.0` (or `csharp/v2.0.0`)
-   - Updates `release/csharp/latest`
-
-### Post-Cutoff (Maintenance)
-
-For the **current** release branch (newest version):
-
-1. Open a PR on `main` with the fix and a `VersionPrefix` bump (e.g. `1.1.0` → `1.1.1`) and update `csharp/CHANGELOG.md`.
-2. Merge the PR. CI automatically:
-   - Fast-forwards `release/csharp/v1.1.latest` to the new `main` tip
-   - Tags the tip as `csharp/v1.1.1`
+   - Pushes `main` to the matching `release/csharp/vX.Y.latest` (creating it if new)
+   - Tags the tip as `csharp/vX.Y.Z`
    - Updates `release/csharp/latest`
 
 For **older** release branches (e.g. `v1.0.latest` when `v1.1.latest` exists), automation does not apply — cherry-pick the fix directly onto the older branch and tag manually:

--- a/csharp/RELEASE_PROCESS.md
+++ b/csharp/RELEASE_PROCESS.md
@@ -87,7 +87,7 @@ When ready to release a new major or minor version:
 
 ### Post-Cutoff (Maintenance)
 
-For the **current** release branch (newest minor version):
+For the **current** release branch (newest version):
 
 1. Open a PR on `main` with the fix and a `VersionPrefix` bump (e.g. `1.1.0` → `1.1.1`) and update `csharp/CHANGELOG.md`.
 2. Merge the PR. CI automatically:

--- a/csharp/RELEASE_PROCESS.md
+++ b/csharp/RELEASE_PROCESS.md
@@ -79,29 +79,30 @@ flowchart LR
 
 When ready to release a new minor version:
 
-1. Create the release branch from the desired commit on `main`:
-   ```bash
-   git checkout main && git pull origin main
-   git checkout -b release/csharp/v1.1.latest
-   git push origin release/csharp/v1.1.latest
-   ```
-2. Tag the cutoff commit:
-   ```bash
-   git tag csharp/v1.1.0
-   git push origin csharp/v1.1.0
-   ```
-3. `release/csharp/latest` is updated automatically by CI (see [CI/CD](#cicd)).
+1. Open a PR on `main` that bumps `VersionPrefix` in `csharp/Directory.Build.props` to the new version (e.g. `1.2.0`) and updates `csharp/CHANGELOG.md`.
+2. Merge the PR. CI automatically:
+   - Creates `release/csharp/v1.2.latest` from `main` (new branch)
+   - Tags the tip as `csharp/v1.2.0`
+   - Updates `release/csharp/latest`
 
 ### Post-Cutoff (Maintenance)
 
-1. Fix goes to `main` first, then synced or cherry-picked to the target release branch (see [Versioning Rules](#versioning-rules)).
-2. After the fix lands on the release branch, tag the new patch:
+For the **current** release branch (newest minor version):
+
+1. Open a PR on `main` with the fix and a `VersionPrefix` bump (e.g. `1.1.0` → `1.1.1`) and update `csharp/CHANGELOG.md`.
+2. Merge the PR. CI automatically:
+   - Fast-forwards `release/csharp/v1.1.latest` to the new `main` tip
+   - Tags the tip as `csharp/v1.1.1`
+   - Updates `release/csharp/latest`
+
+For **older** release branches (e.g. `v1.0.latest` when `v1.1.latest` exists), automation does not apply — cherry-pick the fix directly onto the older branch and tag manually:
    ```bash
-   git fetch origin
-   git tag csharp/v1.1.1 origin/release/csharp/v1.1.latest
-   git push origin csharp/v1.1.1
+   git checkout release/csharp/v1.0.latest
+   git cherry-pick <fix-commit>
+   git push origin release/csharp/v1.0.latest
+   git tag csharp/v1.0.2
+   git push origin csharp/v1.0.2
    ```
-3. `release/csharp/latest` is updated automatically by CI (see [CI/CD](#cicd)).
 
 ## Branch Protection
 
@@ -130,7 +131,7 @@ The release branch contains the full monorepo (Git doesn't support partial branc
 ## CI/CD
 
 - `csharp.yml` — runs build and tests on PRs targeting and pushes to `release/csharp/*` branches
-- `csharp-sync-latest.yml` — automatically syncs `release/csharp/latest` to the tip of the newest minor version branch on every push
+- `csharp-sync-latest.yml` — triggers on every push to `main` that changes `csharp/Directory.Build.props`; reads `VersionPrefix`, pushes `main` to the matching `release/csharp/vX.Y.latest` (creating it if new), tags the tip as `csharp/vX.Y.Z`, and force-updates `release/csharp/latest`
 
 ## Consumer Mapping (e.g., PowerBI)
 

--- a/csharp/RELEASE_PROCESS.md
+++ b/csharp/RELEASE_PROCESS.md
@@ -123,7 +123,7 @@ The release branch contains the full monorepo (Git doesn't support partial branc
 
 ## Latest Branch
 
-`release/csharp/latest` always points to the tip of the most recent release branch. It is updated automatically by the `csharp-sync-latest.yml` workflow whenever any `release/csharp/v*.latest` branch is pushed to — the workflow determines which branch is the newest by sorting all release branch version numbers and syncs `release/csharp/latest` accordingly.
+`release/csharp/latest` always points to the tip of the most recent release branch. It is updated automatically by the `csharp-sync-latest.yml` workflow on every push to `main` that bumps `csharp/Directory.Build.props`. The workflow reads `VersionPrefix`, pushes `main` to the matching `release/csharp/vX.Y.latest` branch, and force-pushes that branch to `release/csharp/latest`.
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary

Replaces the old `csharp-sync-latest.yml` trigger (push to `release/csharp/v*.latest`) with a `main`-based trigger that fires whenever `csharp/Directory.Build.props` changes.

On each version bump to `main`, the workflow automatically:
1. Pushes `main` to `release/csharp/vX.Y.latest` — creating the branch if it is a new major/minor version, fast-forwarding it for a patch
2. Tags the tip as `csharp/vX.Y.Z` (skips if tag already exists)
3. Force-updates `release/csharp/latest`

Works for all bump types:

| Bump type | Example | Branch result |
|-----------|---------|---------------|
| Patch | `1.1.0` → `1.1.1` | Updates existing `release/csharp/v1.1.latest` |
| Minor | `1.1.x` → `1.2.0` | Creates new `release/csharp/v1.2.latest` |
| Major | `1.x` → `2.0.0` | Creates new `release/csharp/v2.0.latest` |

Also updates `csharp/RELEASE_PROCESS.md` to document the new automated flow.

## Before

Manual steps after merging a version bump PR:
```bash
git checkout release/csharp/v1.1.latest && git merge origin/main && git push
git tag csharp/v1.1.1 && git push origin csharp/v1.1.1
```

## After

All of the above happens automatically when the bump PR lands on `main`.

## Test plan

- [ ] Merge a version bump PR and verify all three refs are updated: `release/csharp/vX.Y.latest`, `csharp/vX.Y.Z` tag, `release/csharp/latest`
- [ ] Verify tag-already-exists guard works on re-run (idempotent)
- [ ] Verify a new major/minor bump creates a new branch rather than updating an existing one

🤖 Generated with [Claude Code](https://claude.com/claude-code)