### PR TITLE
chore: remove unused header from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
-# Test scenario 1


### PR DESCRIPTION
## What's Changed

I noticed 89544282048384cec2da3e2a0b6a413843cede10 added a header to the
README. I don't think the change was intentional so this PR removes it.
