### PR TITLE
ci(csharp): auto-create test coverage issue when C# source PR merges

### DIFF
--- a/.github/workflows/csharp-test-coverage-agent.yml
+++ b/.github/workflows/csharp-test-coverage-agent.yml
@@ -16,7 +16,15 @@ name: C# Test Coverage Agent
 
 # Analyzes a driver PR, checks existing test coverage in databricks-driver-test,
 # and files a Copilot-assigned issue to add missing tests if needed.
+# Triggers automatically when a PR touching csharp/src/ is merged to main,
+# or manually via workflow_dispatch for any PR number.
 on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+    paths:
+      - 'csharp/src/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -30,6 +38,7 @@ on:
 
 jobs:
   create-test-issue:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,12 +48,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve PR number
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Gather PR context
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER="${{ inputs.pr_number }}"
+          PR_NUMBER="${{ steps.resolve.outputs.pr_number }}"
 
           gh pr view "$PR_NUMBER" --json title,body,url,headRefName > pr_meta.json
 
@@ -68,7 +86,7 @@ jobs:
           PR_URL="${{ steps.pr.outputs.url }}"
           PR_TITLE="${{ steps.pr.outputs.title }}"
           PR_BRANCH="${{ steps.pr.outputs.branch }}"
-          PR_NUMBER="${{ inputs.pr_number }}"
+          PR_NUMBER="${{ steps.resolve.outputs.pr_number }}"
           CUSTOM="${{ inputs.custom_instructions }}"
 
           {
@@ -178,6 +196,6 @@ jobs:
         run: |
           gh issue create \
             --repo databricks/databricks-driver-test \
-            --title "test(csharp): coverage for driver PR #${{ inputs.pr_number }} — ${{ steps.pr.outputs.title }}" \
+            --title "test(csharp): coverage for driver PR #${{ steps.resolve.outputs.pr_number }} — ${{ steps.pr.outputs.title }}" \
             --body-file issue_body.md \
             --assignee copilot

--- a/.github/workflows/csharp-test-coverage-agent.yml
+++ b/.github/workflows/csharp-test-coverage-agent.yml
@@ -163,9 +163,18 @@ jobs:
             fi
           } > issue_body.md
 
+      - name: Generate GitHub App token for databricks-driver-test
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+          owner: databricks
+          repositories: databricks-driver-test
+
       - name: Create issue on databricks-driver-test and assign Copilot
         env:
-          GH_TOKEN: ${{ secrets.TEST_REPO_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh issue create \
             --repo databricks/databricks-driver-test \

--- a/.github/workflows/csharp-test-coverage-agent.yml
+++ b/.github/workflows/csharp-test-coverage-agent.yml
@@ -14,8 +14,8 @@
 
 name: C# Test Coverage Agent
 
-# Analyzes a driver PR, checks existing test coverage in databricks-driver-test,
-# and files a Copilot-assigned issue to add missing tests if needed.
+# Notifies databricks-driver-test when a C# source PR merges, so the test
+# coverage agent there can decide whether new tests are needed.
 # Triggers automatically when a PR touching csharp/src/ is merged to main,
 # or manually via workflow_dispatch for any PR number.
 on:
@@ -31,23 +31,15 @@ on:
         description: 'Driver PR number to analyze for test coverage'
         required: true
         type: string
-      custom_instructions:
-        description: 'Additional instructions for the agent (e.g. focus areas, scenarios to prioritize)'
-        required: false
-        type: string
 
 jobs:
-  create-test-issue:
+  notify:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          fetch-depth: 0
-
       - name: Resolve PR number
         id: resolve
         run: |
@@ -56,79 +48,6 @@ jobs:
           else
             echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Gather PR context
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER="${{ steps.resolve.outputs.pr_number }}"
-
-          gh pr view "$PR_NUMBER" --json title,body,url,headRefName > pr_meta.json
-
-          echo "title=$(jq -r '.title'       pr_meta.json)" >> "$GITHUB_OUTPUT"
-          echo "url=$(jq -r '.url'           pr_meta.json)" >> "$GITHUB_OUTPUT"
-          echo "branch=$(jq -r '.headRefName' pr_meta.json)" >> "$GITHUB_OUTPUT"
-
-          # PR description — cap at 2 KB
-          jq -r '.body // ""' pr_meta.json | head -c 2048 > pr_body.txt
-
-          # Changed C# source files only
-          gh pr view "$PR_NUMBER" --json files \
-            --jq '[.files[].path | select(startswith("csharp/src/"))] | join("\n")' \
-            > changed_files.txt
-
-          # Diff of csharp/src/ — cap at 25 KB to stay within GitHub issue limit
-          gh pr diff "$PR_NUMBER" -- 'csharp/src/**' | head -c 25600 > pr_diff.txt
-
-      - name: Build issue body
-        run: |
-          PR_URL="${{ steps.pr.outputs.url }}"
-          PR_TITLE="${{ steps.pr.outputs.title }}"
-          PR_BRANCH="${{ steps.pr.outputs.branch }}"
-          PR_NUMBER="${{ steps.resolve.outputs.pr_number }}"
-          CUSTOM="${{ inputs.custom_instructions }}"
-
-          {
-            echo "## Driver PR"
-            echo ""
-            echo "**PR:** $PR_URL"
-            echo "**Branch:** \`$PR_BRANCH\`"
-            echo "**Title:** $PR_TITLE"
-            echo ""
-            echo "<details>"
-            echo "<summary>PR description</summary>"
-            echo ""
-            cat pr_body.txt
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "## Changed source files (csharp/src/ only)"
-            echo ""
-            echo '```'
-            cat changed_files.txt
-            echo '```'
-            echo ""
-            echo "<details>"
-            echo "<summary>Diff</summary>"
-            echo ""
-            echo '```diff'
-            cat pr_diff.txt
-            echo '```'
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "## Task"
-            echo ""
-            echo "Follow the instructions in this repository (.github/copilot-instructions.md) to classify this change, determine whether test coverage needs to be added or updated, and open a PR if needed."
-
-            if [ -n "$CUSTOM" ]; then
-              echo ""
-              echo "## Additional context"
-              echo ""
-              echo "$CUSTOM"
-            fi
-          } > issue_body.md
 
       - name: Generate GitHub App token for databricks-driver-test
         id: app-token
@@ -139,12 +58,11 @@ jobs:
           owner: databricks
           repositories: databricks-driver-test
 
-      - name: Create issue on databricks-driver-test and assign Copilot
+      - name: Dispatch to databricks-driver-test
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh issue create \
-            --repo databricks/databricks-driver-test \
-            --title "test(csharp): coverage for driver PR #${{ steps.resolve.outputs.pr_number }} — ${{ steps.pr.outputs.title }}" \
-            --body-file issue_body.md \
-            --assignee copilot
+          gh api repos/databricks/databricks-driver-test/dispatches \
+            --method POST \
+            --field event_type=csharp-coverage \
+            --field client_payload='{"pr_number":"${{ steps.resolve.outputs.pr_number }}"}'

--- a/.github/workflows/csharp-test-coverage-agent.yml
+++ b/.github/workflows/csharp-test-coverage-agent.yml
@@ -1,0 +1,174 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: C# Test Coverage Agent
+
+# Analyzes a driver PR, checks existing test coverage in databricks-driver-test,
+# and files a Copilot-assigned issue to add missing tests if needed.
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Driver PR number to analyze for test coverage'
+        required: true
+        type: string
+      custom_instructions:
+        description: 'Additional instructions for the agent (e.g. focus areas, scenarios to prioritize)'
+        required: false
+        type: string
+
+jobs:
+  create-test-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Gather PR context
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ inputs.pr_number }}"
+
+          gh pr view "$PR_NUMBER" --json title,body,url,headRefName > pr_meta.json
+
+          echo "title=$(jq -r '.title'       pr_meta.json)" >> "$GITHUB_OUTPUT"
+          echo "url=$(jq -r '.url'           pr_meta.json)" >> "$GITHUB_OUTPUT"
+          echo "branch=$(jq -r '.headRefName' pr_meta.json)" >> "$GITHUB_OUTPUT"
+
+          # PR description — cap at 2 KB
+          jq -r '.body // ""' pr_meta.json | head -c 2048 > pr_body.txt
+
+          # Changed C# source files only
+          gh pr view "$PR_NUMBER" --json files \
+            --jq '[.files[].path | select(startswith("csharp/src/"))] | join("\n")' \
+            > changed_files.txt
+
+          # Diff of csharp/src/ — cap at 25 KB to stay within GitHub issue limit
+          gh pr diff "$PR_NUMBER" -- 'csharp/src/**' | head -c 25600 > pr_diff.txt
+
+      - name: Build issue body
+        run: |
+          PR_URL="${{ steps.pr.outputs.url }}"
+          PR_TITLE="${{ steps.pr.outputs.title }}"
+          PR_BRANCH="${{ steps.pr.outputs.branch }}"
+          PR_NUMBER="${{ inputs.pr_number }}"
+          CUSTOM="${{ inputs.custom_instructions }}"
+
+          {
+            echo "## Context"
+            echo ""
+            echo "This issue was created automatically to evaluate and add test coverage for a driver PR."
+            echo ""
+            echo "**Driver PR:** $PR_URL"
+            echo "**Branch:** \`$PR_BRANCH\`"
+            echo "**PR title:** $PR_TITLE"
+            echo ""
+            echo "<details>"
+            echo "<summary>PR description</summary>"
+            echo ""
+            cat pr_body.txt
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "## Changed driver source files"
+            echo ""
+            echo '```'
+            cat changed_files.txt
+            echo '```'
+            echo ""
+            echo "<details>"
+            echo "<summary>Diff (csharp/src/ only)</summary>"
+            echo ""
+            echo '```diff'
+            cat pr_diff.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "## Your task"
+            echo ""
+            echo "1. **Read the existing tests** in \`tests/csharp/\` to understand what is already covered."
+            echo "2. **Read the relevant spec YAML files** in \`specs/\` that relate to the changed driver behaviour."
+            echo "3. **Decide**: do the driver changes introduce new observable behaviour that is not yet tested?"
+            echo "   - If everything is already covered, close this issue with a comment explaining why."
+            echo "   - If there are gaps, continue to step 4."
+            echo "4. **Write the missing tests** following the patterns below and open a PR against \`main\`."
+            echo ""
+            echo "## Test writing guidelines"
+            echo ""
+            echo "### File and class selection"
+            echo "- Add tests to the existing \`tests/csharp/<Domain>Tests.cs\` file whose domain matches the change."
+            echo "- Only create a new \`<Domain>Tests.cs\` if there is genuinely no matching file."
+            echo ""
+            echo "### Class and method structure"
+            echo '```csharp'
+            echo '[Collection("ProxyTests")]'
+            echo 'public class <Domain>Tests : ProxyTestBase'
+            echo '{'
+            echo '    /// <summary>'
+            echo '    /// <SPEC-ID>: <Title>'
+            echo '    /// <One-line description of what behaviour is verified.>'
+            echo '    /// </summary>'
+            echo '    [Fact]   // or [SkippableFact] for environment-specific tests'
+            echo '    public async Task <DescriptiveName>()'
+            echo '    {'
+            echo '        // Arrange'
+            echo '        // Act'
+            echo '        // Assert'
+            echo '    }'
+            echo '}'
+            echo '```'
+            echo ""
+            echo "### Spec IDs"
+            echo "- Each test must reference a spec ID from the relevant \`specs/*.yaml\` file (e.g. \`AUTH-013\`)."
+            echo "- If the behaviour is new and not yet in the spec, add a new entry to the YAML first, then reference it."
+            echo ""
+            echo "### Proxy usage"
+            echo "- Use \`CreateProxiedConnection()\` (or \`CreateProxiedConnectionWithParameters()\`) from \`ProxyTestBase\`."
+            echo "- Use \`ControlClient\` to inject failures, count Thrift calls, or verify OAuth token exchanges."
+            echo "- Use \`IsSeaMode\` to branch assertion logic when Thrift and SEA/REST protocols behave differently."
+            echo ""
+            echo "### Validation"
+            echo "- After writing, verify the tests build: \`dotnet build tests/csharp/ProxyTests.csproj -c Release\`"
+            echo "- Do not run the full integration suite (it requires a live Databricks workspace and proxy)."
+            echo ""
+            echo "### PR instructions"
+            echo "- Branch name: \`ai/test-coverage-pr-$PR_NUMBER\`"
+            echo "- PR title: \`test(csharp): add coverage for <short description> (driver PR #$PR_NUMBER)\`"
+            echo "- PR body: list each new test ID and one sentence explaining what it verifies."
+            echo "- Target branch: \`main\`"
+
+            if [ -n "$CUSTOM" ]; then
+              echo ""
+              echo "## Additional instructions"
+              echo ""
+              echo "$CUSTOM"
+            fi
+          } > issue_body.md
+
+      - name: Create issue on databricks-driver-test and assign Copilot
+        env:
+          GH_TOKEN: ${{ secrets.TEST_REPO_PAT }}
+        run: |
+          gh issue create \
+            --repo databricks/databricks-driver-test \
+            --title "test(csharp): coverage for driver PR #${{ inputs.pr_number }} — ${{ steps.pr.outputs.title }}" \
+            --body-file issue_body.md \
+            --assignee copilot

--- a/.github/workflows/csharp-test-coverage-agent.yml
+++ b/.github/workflows/csharp-test-coverage-agent.yml
@@ -90,13 +90,11 @@ jobs:
           CUSTOM="${{ inputs.custom_instructions }}"
 
           {
-            echo "## Context"
+            echo "## Driver PR"
             echo ""
-            echo "This issue was created automatically to evaluate and add test coverage for a driver PR."
-            echo ""
-            echo "**Driver PR:** $PR_URL"
+            echo "**PR:** $PR_URL"
             echo "**Branch:** \`$PR_BRANCH\`"
-            echo "**PR title:** $PR_TITLE"
+            echo "**Title:** $PR_TITLE"
             echo ""
             echo "<details>"
             echo "<summary>PR description</summary>"
@@ -105,14 +103,14 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
-            echo "## Changed driver source files"
+            echo "## Changed source files (csharp/src/ only)"
             echo ""
             echo '```'
             cat changed_files.txt
             echo '```'
             echo ""
             echo "<details>"
-            echo "<summary>Diff (csharp/src/ only)</summary>"
+            echo "<summary>Diff</summary>"
             echo ""
             echo '```diff'
             cat pr_diff.txt
@@ -120,62 +118,13 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
-            echo "## Your task"
+            echo "## Task"
             echo ""
-            echo "1. **Read the existing tests** in \`tests/csharp/\` to understand what is already covered."
-            echo "2. **Read the relevant spec YAML files** in \`specs/\` that relate to the changed driver behaviour."
-            echo "3. **Decide**: do the driver changes introduce new observable behaviour that is not yet tested?"
-            echo "   - If everything is already covered, close this issue with a comment explaining why."
-            echo "   - If there are gaps, continue to step 4."
-            echo "4. **Write the missing tests** following the patterns below and open a PR against \`main\`."
-            echo ""
-            echo "## Test writing guidelines"
-            echo ""
-            echo "### File and class selection"
-            echo "- Add tests to the existing \`tests/csharp/<Domain>Tests.cs\` file whose domain matches the change."
-            echo "- Only create a new \`<Domain>Tests.cs\` if there is genuinely no matching file."
-            echo ""
-            echo "### Class and method structure"
-            echo '```csharp'
-            echo '[Collection("ProxyTests")]'
-            echo 'public class <Domain>Tests : ProxyTestBase'
-            echo '{'
-            echo '    /// <summary>'
-            echo '    /// <SPEC-ID>: <Title>'
-            echo '    /// <One-line description of what behaviour is verified.>'
-            echo '    /// </summary>'
-            echo '    [Fact]   // or [SkippableFact] for environment-specific tests'
-            echo '    public async Task <DescriptiveName>()'
-            echo '    {'
-            echo '        // Arrange'
-            echo '        // Act'
-            echo '        // Assert'
-            echo '    }'
-            echo '}'
-            echo '```'
-            echo ""
-            echo "### Spec IDs"
-            echo "- Each test must reference a spec ID from the relevant \`specs/*.yaml\` file (e.g. \`AUTH-013\`)."
-            echo "- If the behaviour is new and not yet in the spec, add a new entry to the YAML first, then reference it."
-            echo ""
-            echo "### Proxy usage"
-            echo "- Use \`CreateProxiedConnection()\` (or \`CreateProxiedConnectionWithParameters()\`) from \`ProxyTestBase\`."
-            echo "- Use \`ControlClient\` to inject failures, count Thrift calls, or verify OAuth token exchanges."
-            echo "- Use \`IsSeaMode\` to branch assertion logic when Thrift and SEA/REST protocols behave differently."
-            echo ""
-            echo "### Validation"
-            echo "- After writing, verify the tests build: \`dotnet build tests/csharp/ProxyTests.csproj -c Release\`"
-            echo "- Do not run the full integration suite (it requires a live Databricks workspace and proxy)."
-            echo ""
-            echo "### PR instructions"
-            echo "- Branch name: \`ai/test-coverage-pr-$PR_NUMBER\`"
-            echo "- PR title: \`test(csharp): add coverage for <short description> (driver PR #$PR_NUMBER)\`"
-            echo "- PR body: list each new test ID and one sentence explaining what it verifies."
-            echo "- Target branch: \`main\`"
+            echo "Follow the instructions in this repository (.github/copilot-instructions.md) to classify this change, determine whether test coverage needs to be added or updated, and open a PR if needed."
 
             if [ -n "$CUSTOM" ]; then
               echo ""
-              echo "## Additional instructions"
+              echo "## Additional context"
               echo ""
               echo "$CUSTOM"
             fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/csharp-test-coverage-agent.yml` that fires when a PR touching `csharp/src/**` merges to `main` (or via `workflow_dispatch` for any PR number)
- Gathers PR title, description, changed files, and diff (capped at 25KB), then creates an issue on `databricks/databricks-driver-test` assigned to the Copilot coding agent
- Uses the **Driver Integration Test** GitHub App token (`INTEGRATION_TEST_APP_ID` / `INTEGRATION_TEST_PRIVATE_KEY`) to create the issue cross-repo
- Issue body points the agent to `.github/copilot-instructions.md` in the test repo for full instructions (classify → gap analysis → spec → test → CI loop → PR)

## Test plan
- [ ] Trigger manually via `workflow_dispatch` with a past PR number (e.g. `402`)
- [ ] Verify issue is created on `databricks/databricks-driver-test` assigned to `copilot`
- [ ] Merge a C# source PR and confirm the workflow fires automatically