### PR TITLE
fix(csharp): emit upper-case char_set_encoding to match other drivers

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -319,7 +319,9 @@ namespace AdbcDrivers.Databricks.Telemetry
                 RuntimeVersion = System.Environment.Version.ToString(),
                 RuntimeVendor = "Microsoft",
                 LocaleName = System.Globalization.CultureInfo.CurrentCulture.Name,
-                CharSetEncoding = System.Text.Encoding.Default.WebName,
+                // Normalize to upper-case (e.g. "UTF-8") to match the casing emitted by the
+                // OSS JDBC and DatabricksJDBC drivers; .NET Core / Linux returns "utf-8".
+                CharSetEncoding = System.Text.Encoding.Default.WebName.ToUpperInvariant(),
                 ProcessName = processName,
                 ClientAppName = processName
             };

--- a/csharp/test/E2E/Telemetry/SystemConfigurationTests.cs
+++ b/csharp/test/E2E/Telemetry/SystemConfigurationTests.cs
@@ -138,6 +138,49 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         }
 
         /// <summary>
+        /// Tests that char_set_encoding is emitted in upper-case (e.g. "UTF-8")
+        /// to match the OSS JDBC and DatabricksJDBC drivers. .NET Core / Linux
+        /// returns Encoding.Default.WebName as lower-case "utf-8" by default,
+        /// which breaks exact-string matches across drivers (PECO-2990).
+        /// </summary>
+        [SkippableFact]
+        public async Task SystemConfig_CharSetEncoding_IsUppercase()
+        {
+            CapturingTelemetryExporter exporter = null!;
+            AdbcConnection? connection = null;
+
+            try
+            {
+                var properties = TestEnvironment.GetDriverParameters(TestConfiguration);
+                (connection, exporter) = TelemetryTestHelpers.CreateConnectionWithCapturingTelemetry(properties);
+
+                using var statement = connection.CreateStatement();
+                statement.SqlQuery = "SELECT 1 AS test_value";
+                var result = statement.ExecuteQuery();
+                using var reader = result.Stream;
+
+                statement.Dispose();
+
+                var logs = await TelemetryTestHelpers.WaitForTelemetryEvents(exporter, expectedCount: 1);
+                TelemetryTestHelpers.AssertLogCount(logs, 1);
+
+                var protoLog = TelemetryTestHelpers.GetProtoLog(logs[0]);
+
+                Assert.NotNull(protoLog.SystemConfiguration);
+                string charSet = protoLog.SystemConfiguration.CharSetEncoding;
+                Assert.False(string.IsNullOrEmpty(charSet), "char_set_encoding should be populated");
+                Assert.Equal(charSet.ToUpperInvariant(), charSet);
+
+                OutputHelper?.WriteLine($"✓ char_set_encoding: {charSet}");
+            }
+            finally
+            {
+                connection?.Dispose();
+                TelemetryTestHelpers.ClearExporterOverride();
+            }
+        }
+
+        /// <summary>
         /// Tests that all 12 DriverSystemConfiguration fields are populated (comprehensive check).
         /// This ensures runtime_vendor and client_app_name are included alongside existing fields.
         /// </summary>


### PR DESCRIPTION
## Summary
- Normalize `DriverSystemConfiguration.char_set_encoding` to upper-case so ADBC matches the casing emitted by OSS JDBC and DatabricksJDBC (e.g. `UTF-8` rather than `utf-8`).
- Without this, `System.Text.Encoding.Default.WebName` returns lower-case on .NET Core / Linux for ~100% of populated ADBC rows, breaking exact-string matches across drivers in eng_lumberjack analyses.
- Added an E2E `SystemConfig_CharSetEncoding_IsUppercase` test that captures the telemetry payload and asserts the field equals its `ToUpperInvariant()` form.

## Test plan
- [x] `dotnet build csharp/src/AdbcDrivers.Databricks.csproj`
- [x] `dotnet build csharp/test/AdbcDrivers.Databricks.Tests.csproj`
- [x] `dotnet test --filter SystemConfig_CharSetEncoding_IsUppercase` (passes)
- [x] `dotnet test --filter ~SystemConfig` (8/8 pass, no regressions)

Closes PECO-2990

This pull request and its description were written by Isaac.