### PR TITLE
ci(csharp): use app token for sync workflow to bypass branch protection

### DIFF
--- a/.github/workflows/csharp-sync-latest.yml
+++ b/.github/workflows/csharp-sync-latest.yml
@@ -33,9 +33,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse version and derive names
         id: ver


### PR DESCRIPTION
## Summary

- The `csharp-sync-latest` workflow pushes directly to `release/csharp/v*.latest` branches, which are protected with a "require PR" rule
- The default `GITHUB_TOKEN` (GitHub Actions bot) cannot be added as a bypass actor in the ruleset UI
- Fix: generate a token from the existing `INTEGRATION_TEST_APP_ID` app (already used in `skip-checks-reporter.yml` and `trigger-integration-tests.yml`) and pass it to `actions/checkout`, so the git remote authenticates as the app for all subsequent pushes

**Note:** the app also needs to be added as a bypass actor in the branch ruleset for `release/csharp/v*.latest` for this to take effect.

## Test plan
- [ ] Add the app as a bypass actor in the ruleset for `release/csharp/v*.latest`
- [ ] Merge this PR, then trigger the workflow by bumping the version in `csharp/Directory.Build.props`
- [ ] Verify the sync job completes without GH006

🤖 Generated with [Claude Code](https://claude.com/claude-code)