### PR TITLE
fix(csharp): populate async_poll_interval_millis in connection telemetry

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -428,6 +428,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             }
 
             int batchSize = GetBatchSize(properties);
+            int asyncPollIntervalMillis = GetAsyncPollIntervalMillis(properties);
 
             return new Proto.DriverConnectionParameters
             {
@@ -449,7 +450,22 @@ namespace AdbcDrivers.Databricks.Telemetry
                 EnableDirectResults = enableDirectResults,
                 EnableComplexDatatypeSupport = useDescTableExtended,
                 AutoCommit = true,
+                AsyncPollIntervalMillis = asyncPollIntervalMillis,
             };
+        }
+
+        // PECO-2997: report the async-execution poll interval (in milliseconds) used by
+        // DatabricksStatement when polling for query completion. The driver overrides
+        // the Apache base default (500ms) with DefaultAsyncExecPollIntervalMs (100ms);
+        // callers can override via ApacheParameters.PollTimeMilliseconds.
+        private static int GetAsyncPollIntervalMillis(IReadOnlyDictionary<string, string> properties)
+        {
+            if (properties.TryGetValue(ApacheParameters.PollTimeMilliseconds, out string? pollTimeStr) &&
+                int.TryParse(pollTimeStr, out int pollTime) && pollTime > 0)
+            {
+                return pollTime;
+            }
+            return DatabricksConstants.DefaultAsyncExecPollIntervalMs;
         }
 
         private static string DetermineAuthType(IReadOnlyDictionary<string, string> properties)

--- a/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
+++ b/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
@@ -495,6 +495,102 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         }
 
         /// <summary>
+        /// Regression test for PECO-2997 (TELEM-15): driver_connection_params.async_poll_interval_millis
+        /// was 0 for 100% of ADBC rows because <c>BuildDriverConnectionParams</c> never set the field,
+        /// even though DatabricksStatement overrides the Apache base default with 100ms via
+        /// <see cref="DatabricksConstants.DefaultAsyncExecPollIntervalMs"/>. With no override the
+        /// captured telemetry must report the 100ms canonical default.
+        /// </summary>
+        [SkippableFact]
+        public async Task ConnectionParams_AsyncPollIntervalMillis_DefaultsTo100Ms()
+        {
+            CapturingTelemetryExporter exporter = null!;
+            AdbcConnection? connection = null;
+
+            try
+            {
+                var properties = TestEnvironment.GetDriverParameters(TestConfiguration);
+
+                // Ensure no override is present so we exercise the default path.
+                properties.Remove(ApacheParameters.PollTimeMilliseconds);
+
+                (connection, exporter) = TelemetryTestHelpers.CreateConnectionWithCapturingTelemetry(properties);
+
+                using var statement = connection.CreateStatement();
+                statement.SqlQuery = "SELECT 1 AS test_value";
+                var result = statement.ExecuteQuery();
+                using var reader = result.Stream;
+
+                statement.Dispose();
+
+                var logs = await TelemetryTestHelpers.WaitForTelemetryEvents(exporter, expectedCount: 1);
+                TelemetryTestHelpers.AssertLogCount(logs, 1);
+
+                var protoLog = TelemetryTestHelpers.GetProtoLog(logs[0]);
+
+                Assert.NotNull(protoLog.DriverConnectionParams);
+                Assert.Equal(
+                    DatabricksConstants.DefaultAsyncExecPollIntervalMs,
+                    protoLog.DriverConnectionParams.AsyncPollIntervalMillis);
+
+                OutputHelper?.WriteLine(
+                    $"✓ async_poll_interval_millis (default): {protoLog.DriverConnectionParams.AsyncPollIntervalMillis}");
+            }
+            finally
+            {
+                connection?.Dispose();
+                TelemetryTestHelpers.ClearExporterOverride();
+            }
+        }
+
+        /// <summary>
+        /// PECO-2997 (TELEM-15): when the caller overrides
+        /// <see cref="ApacheParameters.PollTimeMilliseconds"/>, the captured telemetry must reflect
+        /// the override so analysts can correlate polling behavior with query latency.
+        /// </summary>
+        [SkippableFact]
+        public async Task ConnectionParams_AsyncPollIntervalMillis_ReflectsOverride()
+        {
+            CapturingTelemetryExporter exporter = null!;
+            AdbcConnection? connection = null;
+
+            try
+            {
+                var properties = TestEnvironment.GetDriverParameters(TestConfiguration);
+
+                const int customPollIntervalMs = 250;
+                properties[ApacheParameters.PollTimeMilliseconds] = customPollIntervalMs.ToString();
+
+                (connection, exporter) = TelemetryTestHelpers.CreateConnectionWithCapturingTelemetry(properties);
+
+                using var statement = connection.CreateStatement();
+                statement.SqlQuery = "SELECT 1 AS test_value";
+                var result = statement.ExecuteQuery();
+                using var reader = result.Stream;
+
+                statement.Dispose();
+
+                var logs = await TelemetryTestHelpers.WaitForTelemetryEvents(exporter, expectedCount: 1);
+                TelemetryTestHelpers.AssertLogCount(logs, 1);
+
+                var protoLog = TelemetryTestHelpers.GetProtoLog(logs[0]);
+
+                Assert.NotNull(protoLog.DriverConnectionParams);
+                Assert.Equal(
+                    customPollIntervalMs,
+                    protoLog.DriverConnectionParams.AsyncPollIntervalMillis);
+
+                OutputHelper?.WriteLine(
+                    $"✓ async_poll_interval_millis (override): {protoLog.DriverConnectionParams.AsyncPollIntervalMillis}");
+            }
+            finally
+            {
+                connection?.Dispose();
+                TelemetryTestHelpers.ClearExporterOverride();
+            }
+        }
+
+        /// <summary>
         /// Tests that all extended connection parameter fields are non-default (comprehensive check).
         /// This ensures enable_arrow, rows_fetched_per_block, socket_timeout,
         /// enable_direct_results, enable_complex_datatype_support, and auto_commit are all populated.


### PR DESCRIPTION
## Summary
- `driver_connection_params.async_poll_interval_millis` was 0 for 100% of ADBC rows because `BuildDriverConnectionParams` never set the field. Analysts could not detect overridden polling intervals or correlate polling behavior with query latency.
- Now reads `ApacheParameters.PollTimeMilliseconds` (default `DatabricksConstants.DefaultAsyncExecPollIntervalMs = 100ms`, the same value `DatabricksStatement` uses to override the Apache base default) and assigns it to the proto field.
- Two new E2E tests cover the default and override paths.

## Test plan
- [x] `dotnet build csharp/src/AdbcDrivers.Databricks.csproj` (0 warn / 0 err)
- [x] `dotnet build csharp/test/AdbcDrivers.Databricks.Tests.csproj`
- [x] `ConnectionParams_AsyncPollIntervalMillis_DefaultsTo100Ms` and `ConnectionParams_AsyncPollIntervalMillis_ReflectsOverride` both pass (2/2).

Note: edits the same `BuildDriverConnectionParams` initializer block as PECO-2994; trivially mechanical merge expected on whichever lands second.

Closes PECO-2997

This pull request and its description were written by Isaac.