### PR TITLE
fix(csharp): make telemetry init resilient and consolidate auth-type derivation

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -339,7 +339,7 @@ namespace AdbcDrivers.Databricks.Telemetry
                 return new Proto.DriverSystemConfiguration
                 {
                     DriverVersion = assemblyVersion ?? string.Empty,
-                    DriverName = "Databricks ADBC Driver",
+                    DriverName = DatabricksConnection.DatabricksDriverName,
                     RuntimeVendor = "Microsoft"
                 };
             }
@@ -420,7 +420,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             var config = new Proto.DriverSystemConfiguration
             {
                 DriverVersion = assemblyVersion ?? string.Empty,
-                DriverName = "Databricks ADBC Driver",
+                DriverName = DatabricksConnection.DatabricksDriverName,
                 // runtime_vendor is a process-wide constant for .NET — always emit it so the
                 // 110-row gap reported in PECO-2996 closes regardless of which other lookup
                 // throws.

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -103,16 +103,29 @@ namespace AdbcDrivers.Databricks.Telemetry
                     true,
                     telemetryConfig);
 
+                // PECO-2998 / PECO-2996: build each session field defensively. Previously a single
+                // exception inside BuildSystemConfiguration / BuildDriverConnectionParams would
+                // either propagate to the outer catch (yielding NoOp telemetry) or — depending
+                // on the build order — leave a partially-populated session. Both nested
+                // auth_mech/auth_flow and the top-level auth_type must always agree, so we derive
+                // them from a single helper that can never drop one without the other.
+                Proto.DriverSystemConfiguration systemConfiguration =
+                    SafeBuildSystemConfiguration(assemblyVersion, activity);
+                Proto.DriverConnectionParameters driverConnectionParams =
+                    SafeBuildDriverConnectionParams(
+                        properties, host, enableDirectResults, useDescTableExtended,
+                        connectTimeoutMilliseconds, activity);
+                string authType = SafeDetermineAuthType(properties, activity);
+
                 var session = new TelemetrySessionContext
                 {
                     SessionId = sessionHandle?.SessionId?.Guid != null
                         ? new System.Guid(sessionHandle.SessionId.Guid).ToString()
                         : null,
                     TelemetryClient = telemetryClient,
-                    SystemConfiguration = BuildSystemConfiguration(assemblyVersion),
-                    DriverConnectionParams = BuildDriverConnectionParams(
-                        properties, host, enableDirectResults, useDescTableExtended, connectTimeoutMilliseconds),
-                    AuthType = DetermineAuthType(properties)
+                    SystemConfiguration = systemConfiguration,
+                    DriverConnectionParams = driverConnectionParams,
+                    AuthType = authType
                 };
 
                 activity?.AddEvent(new ActivityEvent("telemetry.initialization.success",
@@ -300,31 +313,161 @@ namespace AdbcDrivers.Databricks.Telemetry
                 () => CreateSystemConfiguration(assemblyVersion))!;
         }
 
+        // ── PECO-2998 / PECO-2996: Safe wrappers used by Create() ────────────────────────
+        // Each wrapper either returns the real builder's output or a best-effort fallback
+        // proto that still populates the always-derivable fields (driver_name,
+        // runtime_vendor, the constant connection-param flags, and an "unknown" auth_type
+        // string). This keeps the session non-null on partial-init failures so that the
+        // first row from the connection still reports identifying data instead of being
+        // dropped via the outer NoOp fallback.
+
+        internal static Proto.DriverSystemConfiguration SafeBuildSystemConfiguration(
+            string assemblyVersion, Activity? activity)
+        {
+            try
+            {
+                return BuildSystemConfiguration(assemblyVersion);
+            }
+            catch (Exception ex)
+            {
+                activity?.AddEvent(new ActivityEvent("telemetry.system_configuration.fallback",
+                    tags: new ActivityTagsCollection
+                    {
+                        { "error.type", ex.GetType().Name },
+                        { "error.message", ex.Message }
+                    }));
+                return new Proto.DriverSystemConfiguration
+                {
+                    DriverVersion = assemblyVersion ?? string.Empty,
+                    DriverName = "Databricks ADBC Driver",
+                    RuntimeVendor = "Microsoft"
+                };
+            }
+        }
+
+        internal static Proto.DriverConnectionParameters SafeBuildDriverConnectionParams(
+            IReadOnlyDictionary<string, string> properties,
+            string host,
+            bool enableDirectResults,
+            bool useDescTableExtended,
+            int connectTimeoutMilliseconds,
+            Activity? activity)
+        {
+            try
+            {
+                return BuildDriverConnectionParams(
+                    properties, host, enableDirectResults, useDescTableExtended,
+                    connectTimeoutMilliseconds);
+            }
+            catch (Exception ex)
+            {
+                activity?.AddEvent(new ActivityEvent("telemetry.driver_connection_params.fallback",
+                    tags: new ActivityTagsCollection
+                    {
+                        { "error.type", ex.GetType().Name },
+                        { "error.message", ex.Message }
+                    }));
+
+                // Fallback that still surfaces the always-derivable, driver-side constants.
+                // Auth descriptors fall back to Unspecified rather than guessing.
+                return new Proto.DriverConnectionParameters
+                {
+                    HttpPath = string.Empty,
+                    Mode = Proto.DriverMode.Types.Type.Thrift,
+                    HostInfo = new Proto.HostDetails
+                    {
+                        HostUrl = host ?? string.Empty,
+                        Port = DefaultHttpsPort
+                    },
+                    AuthMech = Proto.DriverAuthMech.Types.Type.Unspecified,
+                    AuthFlow = Proto.DriverAuthFlow.Types.Type.Unspecified,
+                    EnableArrow = true,
+                    EnableDirectResults = enableDirectResults,
+                    SocketTimeout = connectTimeoutMilliseconds > 0 ? connectTimeoutMilliseconds / 1000 : 0,
+                    EnableComplexDatatypeSupport = useDescTableExtended,
+                    AutoCommit = true,
+                };
+            }
+        }
+
+        internal static string SafeDetermineAuthType(
+            IReadOnlyDictionary<string, string> properties, Activity? activity)
+        {
+            try
+            {
+                return DetermineAuthType(properties);
+            }
+            catch (Exception ex)
+            {
+                activity?.AddEvent(new ActivityEvent("telemetry.auth_type.fallback",
+                    tags: new ActivityTagsCollection
+                    {
+                        { "error.type", ex.GetType().Name },
+                        { "error.message", ex.Message }
+                    }));
+                return "other";
+            }
+        }
+
         private static Proto.DriverSystemConfiguration CreateSystemConfiguration(string assemblyVersion)
         {
-            var osVersion = System.Environment.OSVersion;
+            // PECO-2996: build the proto field-by-field with each value wrapped in a safe-getter.
+            // Previously a single throw inside e.g. RuntimeInformation.OSArchitecture would
+            // propagate to ConnectionTelemetry.Create's outer catch and discard ALL telemetry
+            // for that connection. Now any individual field that fails simply falls back to
+            // empty / a sensible default, so always-derivable fields (driver_name,
+            // runtime_vendor) are populated even on partially-failing init paths.
+            var config = new Proto.DriverSystemConfiguration
+            {
+                DriverVersion = assemblyVersion ?? string.Empty,
+                DriverName = "Databricks ADBC Driver",
+                // runtime_vendor is a process-wide constant for .NET — always emit it so the
+                // 110-row gap reported in PECO-2996 closes regardless of which other lookup
+                // throws.
+                RuntimeVendor = "Microsoft",
+            };
+
+            TrySet(() => config.OsName = System.Environment.OSVersion.Platform.ToString());
+            TrySet(() => config.OsVersion = GetOsVersion());
+            TrySet(() => config.OsArch = RuntimeInformation.OSArchitecture.ToString());
+            TrySet(() => config.RuntimeName = RuntimeInformation.FrameworkDescription);
+            TrySet(() => config.RuntimeVersion = System.Environment.Version.ToString());
+            TrySet(() => config.LocaleName = System.Globalization.CultureInfo.CurrentCulture.Name);
+            // Normalize to upper-case (e.g. "UTF-8") to match the casing emitted by the
+            // OSS JDBC and DatabricksJDBC drivers; .NET Core / Linux returns "utf-8".
+            TrySet(() => config.CharSetEncoding = System.Text.Encoding.Default.WebName.ToUpperInvariant());
+
             // Prefer the entry assembly name so process_name reflects the actual application
             // (e.g. "MyApp") rather than the .NET host executable name ("dotnet"). Fall back
             // to the OS process name when there is no entry assembly (e.g. unmanaged hosts).
-            var processName = Assembly.GetEntryAssembly()?.GetName().Name
-                ?? Process.GetCurrentProcess().ProcessName;
-            return new Proto.DriverSystemConfiguration
+            string? processName = null;
+            TrySet(() => processName = Assembly.GetEntryAssembly()?.GetName().Name);
+            if (string.IsNullOrEmpty(processName))
             {
-                DriverVersion = assemblyVersion,
-                DriverName = "Databricks ADBC Driver",
-                OsName = osVersion.Platform.ToString(),
-                OsVersion = GetOsVersion(),
-                OsArch = RuntimeInformation.OSArchitecture.ToString(),
-                RuntimeName = RuntimeInformation.FrameworkDescription,
-                RuntimeVersion = System.Environment.Version.ToString(),
-                RuntimeVendor = "Microsoft",
-                LocaleName = System.Globalization.CultureInfo.CurrentCulture.Name,
-                // Normalize to upper-case (e.g. "UTF-8") to match the casing emitted by the
-                // OSS JDBC and DatabricksJDBC drivers; .NET Core / Linux returns "utf-8".
-                CharSetEncoding = System.Text.Encoding.Default.WebName.ToUpperInvariant(),
-                ProcessName = processName,
-                ClientAppName = processName
-            };
+                TrySet(() => processName = Process.GetCurrentProcess().ProcessName);
+            }
+            if (!string.IsNullOrEmpty(processName))
+            {
+                config.ProcessName = processName!;
+                config.ClientAppName = processName!;
+            }
+
+            return config;
+        }
+
+        // Run an action and swallow any exception. Used to keep CreateSystemConfiguration
+        // resilient on a per-field basis without polluting it with try/catch boilerplate.
+        // Telemetry must never impact driver operations.
+        private static void TrySet(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch
+            {
+                // Intentionally swallowed.
+            }
         }
 
         // Returns a human-readable OS version string, preferring the distro "PRETTY_NAME"
@@ -406,28 +549,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             properties.TryGetValue(SparkParameters.Path, out string? httpPath);
             int port = ResolvePort(properties);
 
-            var authMech = Proto.DriverAuthMech.Types.Type.Unspecified;
-            var authFlow = Proto.DriverAuthFlow.Types.Type.Unspecified;
-
-            properties.TryGetValue(SparkParameters.AuthType, out string? authType);
-            properties.TryGetValue(DatabricksParameters.OAuthGrantType, out string? grantType);
-
-            bool isOAuth = SparkAuthTypeParser.TryParse(authType, out SparkAuthType authTypeValue)
-                && authTypeValue == SparkAuthType.OAuth;
-
-            if (isOAuth)
-            {
-                authMech = Proto.DriverAuthMech.Types.Type.Oauth;
-                authFlow = !string.IsNullOrEmpty(grantType) &&
-                           grantType == DatabricksConstants.OAuthGrantTypes.ClientCredentials
-                    ? Proto.DriverAuthFlow.Types.Type.ClientCredentials
-                    : Proto.DriverAuthFlow.Types.Type.TokenPassthrough;
-            }
-            else
-            {
-                authMech = Proto.DriverAuthMech.Types.Type.Pat;
-                authFlow = Proto.DriverAuthFlow.Types.Type.TokenPassthrough;
-            }
+            AuthDescriptors auth = DetermineAuthDescriptors(properties);
 
             int batchSize = GetBatchSize(properties);
             int asyncPollIntervalMillis = GetAsyncPollIntervalMillis(properties);
@@ -441,14 +563,17 @@ namespace AdbcDrivers.Databricks.Telemetry
                     // Bare hostname, matching JDBC. Scheme is implicit (always https) and
                     // port is reported in the sibling Port field, so including them here
                     // was redundant and forced analysts to normalize across drivers.
-                    HostUrl = host,
+                    HostUrl = host ?? string.Empty,
                     Port = port
                 },
-                AuthMech = authMech,
-                AuthFlow = authFlow,
+                AuthMech = auth.AuthMech,
+                AuthFlow = auth.AuthFlow,
+                // PECO-2996: these flags are best-effort constants and must always be populated,
+                // even on partial-init paths. They reflect driver-side behavior that doesn't
+                // depend on any backend negotiation.
                 EnableArrow = true,
                 RowsFetchedPerBlock = batchSize,
-                SocketTimeout = connectTimeoutMilliseconds / 1000,
+                SocketTimeout = connectTimeoutMilliseconds > 0 ? connectTimeoutMilliseconds / 1000 : 0,
                 EnableDirectResults = enableDirectResults,
                 EnableComplexDatatypeSupport = useDescTableExtended,
                 AutoCommit = true,
@@ -470,22 +595,79 @@ namespace AdbcDrivers.Databricks.Telemetry
             return DatabricksConstants.DefaultAsyncExecPollIntervalMs;
         }
 
-        private static string DetermineAuthType(IReadOnlyDictionary<string, string> properties)
+        /// <summary>
+        /// Derives the nested <c>auth_mech</c>/<c>auth_flow</c> and the top-level
+        /// <c>auth_type</c> string together so they cannot drift.
+        /// </summary>
+        /// <remarks>
+        /// PECO-2998: prior to this consolidation, <see cref="BuildDriverConnectionParams"/>
+        /// keyed off <c>SparkParameters.AuthType</c> while <c>DetermineAuthType</c> keyed off
+        /// <c>OAuthGrantType</c> alone, so dashboards saw mismatches such as
+        /// <c>auth_mech=OAUTH</c> with <c>auth_type=NULL</c> (or worse, <c>auth_type=pat</c>
+        /// for OAuth U2M token passthrough). Both fields are now derived from a single
+        /// branching decision.
+        /// </remarks>
+        private static AuthDescriptors DetermineAuthDescriptors(IReadOnlyDictionary<string, string> properties)
         {
+            properties.TryGetValue(SparkParameters.AuthType, out string? authType);
             properties.TryGetValue(DatabricksParameters.OAuthGrantType, out string? grantType);
 
-            if (!string.IsNullOrEmpty(grantType))
+            bool isOAuth = SparkAuthTypeParser.TryParse(authType, out SparkAuthType authTypeValue)
+                && authTypeValue == SparkAuthType.OAuth;
+
+            if (isOAuth)
             {
-                return $"oauth-{grantType}";
+                bool isClientCredentials = !string.IsNullOrEmpty(grantType) &&
+                    grantType == DatabricksConstants.OAuthGrantTypes.ClientCredentials;
+
+                return new AuthDescriptors(
+                    Proto.DriverAuthMech.Types.Type.Oauth,
+                    isClientCredentials
+                        ? Proto.DriverAuthFlow.Types.Type.ClientCredentials
+                        : Proto.DriverAuthFlow.Types.Type.TokenPassthrough,
+                    // Top-level auth_type must reflect the actual OAuth shape, not just the
+                    // optional grant_type property. When grant_type is absent (U2M access-token
+                    // passthrough) the previous code returned "pat" or "other" even though
+                    // auth_mech=OAUTH — that is the 90-row drift fixed by PECO-2998.
+                    !string.IsNullOrEmpty(grantType)
+                        ? $"oauth-{grantType}"
+                        : "oauth-access_token");
             }
 
+            // PAT / token-based or unspecified.
             properties.TryGetValue(SparkParameters.Token, out string? token);
-            if (!string.IsNullOrEmpty(token))
+            string topLevelAuthType = !string.IsNullOrEmpty(token) ? "pat" : "other";
+            return new AuthDescriptors(
+                Proto.DriverAuthMech.Types.Type.Pat,
+                Proto.DriverAuthFlow.Types.Type.TokenPassthrough,
+                topLevelAuthType);
+        }
+
+        /// <summary>
+        /// Determines the top-level <c>auth_type</c> string consistently with
+        /// <see cref="BuildDriverConnectionParams"/>. Exposed as <c>internal</c> so the
+        /// telemetry init path and unit tests can call it directly.
+        /// </summary>
+        internal static string DetermineAuthType(IReadOnlyDictionary<string, string> properties)
+        {
+            return DetermineAuthDescriptors(properties).AuthType;
+        }
+
+        private readonly struct AuthDescriptors
+        {
+            public AuthDescriptors(
+                Proto.DriverAuthMech.Types.Type authMech,
+                Proto.DriverAuthFlow.Types.Type authFlow,
+                string authType)
             {
-                return "pat";
+                AuthMech = authMech;
+                AuthFlow = authFlow;
+                AuthType = authType;
             }
 
-            return "other";
+            public Proto.DriverAuthMech.Types.Type AuthMech { get; }
+            public Proto.DriverAuthFlow.Types.Type AuthFlow { get; }
+            public string AuthType { get; }
         }
 
         private static int GetBatchSize(IReadOnlyDictionary<string, string> properties)

--- a/csharp/test/E2E/Telemetry/ClientTelemetryE2ETests.cs
+++ b/csharp/test/E2E/Telemetry/ClientTelemetryE2ETests.cs
@@ -253,7 +253,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
                         OperationLatencyMs = 150,
                         SystemConfiguration = new DriverSystemConfiguration
                         {
-                            DriverName = "Databricks ADBC Driver",
+                            DriverName = DatabricksConnection.DatabricksDriverName,
                             DriverVersion = "1.0.0-test",
                             OsName = Environment.OSVersion.Platform.ToString(),
                             OsVersion = Environment.OSVersion.Version.ToString(),

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryPartialInitTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryPartialInitTests.cs
@@ -158,7 +158,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
         {
             var config = ConnectionTelemetry.BuildSystemConfiguration("1.2.3");
 
-            Assert.Equal("Databricks ADBC Driver", config.DriverName);
+            Assert.Equal(DatabricksConnection.DatabricksDriverName, config.DriverName);
         }
 
         [Fact]
@@ -202,7 +202,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
             var config = ConnectionTelemetry.SafeBuildSystemConfiguration(string.Empty, activity: null);
 
             Assert.NotNull(config);
-            Assert.Equal("Databricks ADBC Driver", config.DriverName);
+            Assert.Equal(DatabricksConnection.DatabricksDriverName, config.DriverName);
             Assert.Equal("Microsoft", config.RuntimeVendor);
         }
 

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryPartialInitTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryPartialInitTests.cs
@@ -1,0 +1,285 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using AdbcDrivers.Databricks.Telemetry;
+using AdbcDrivers.HiveServer2.Spark;
+using DriverAuthFlowType = AdbcDrivers.Databricks.Telemetry.Proto.DriverAuthFlow.Types.Type;
+using DriverAuthMechType = AdbcDrivers.Databricks.Telemetry.Proto.DriverAuthMech.Types.Type;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Regression tests for PECO-2998 (TELEM-17) and PECO-2996 (TELEM-18).
+    ///
+    /// PECO-2998 — top-level <c>auth_type</c> was missing on ~90 OAuth+ClientCredentials rows
+    /// even though the nested <c>auth_mech=OAUTH</c>/<c>auth_flow=CLIENT_CREDENTIALS</c> were
+    /// populated. Root cause: <see cref="ConnectionTelemetry.BuildDriverConnectionParams"/>
+    /// keyed off <c>SparkParameters.AuthType</c> while <c>DetermineAuthType</c> keyed off
+    /// <c>OAuthGrantType</c> alone, so the two could disagree. Both are now derived from a
+    /// single helper.
+    ///
+    /// PECO-2996 — the same ~110-row gap appeared in <c>runtime_vendor</c>, <c>os_arch</c>,
+    /// <c>enable_arrow</c>, <c>enable_direct_results</c>, <c>socket_timeout</c>, and
+    /// <c>auto_commit</c>. Root cause: a single throw inside the system-configuration or
+    /// connection-parameters builder propagated to the outer NoOp catch and dropped all
+    /// telemetry for the connection, while always-derivable constants like
+    /// <c>runtime_vendor="Microsoft"</c> should still have been emitted.
+    /// </summary>
+    public class ConnectionTelemetryPartialInitTests
+    {
+        private const string Host = "test.databricks.com";
+        private const int DefaultTimeoutMs = 30_000;
+
+        // ── PECO-2998: top-level auth_type and nested auth_mech/auth_flow agree ────────────
+
+        [Fact]
+        public void AuthType_AndAuthMech_Consistent_OauthClientCredentials()
+        {
+            // The 90-row drift case: oauth + client_credentials grant.
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.AuthType, SparkAuthTypeConstants.OAuth },
+                { DatabricksParameters.OAuthGrantType, DatabricksConstants.OAuthGrantTypes.ClientCredentials },
+                { DatabricksParameters.OAuthClientId, "client-id" },
+                { DatabricksParameters.OAuthClientSecret, "client-secret" },
+            };
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+            string authType = ConnectionTelemetry.DetermineAuthType(properties);
+
+            Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.ClientCredentials, connParams.AuthFlow);
+            Assert.Equal("oauth-client_credentials", authType);
+        }
+
+        [Fact]
+        public void AuthType_AndAuthMech_Consistent_OauthAccessTokenWithGrantType()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.AuthType, SparkAuthTypeConstants.OAuth },
+                { DatabricksParameters.OAuthGrantType, DatabricksConstants.OAuthGrantTypes.AccessToken },
+                { SparkParameters.AccessToken, "oauth-access-token-redacted" },
+            };
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+            string authType = ConnectionTelemetry.DetermineAuthType(properties);
+
+            Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+            Assert.Equal("oauth-access_token", authType);
+        }
+
+        [Fact]
+        public void AuthType_AndAuthMech_Consistent_OauthAccessTokenPassthrough_NoGrantType()
+        {
+            // OAuth U2M token passthrough with no grant_type set. Pre-PECO-2998 the top-level
+            // auth_type came back as "pat" (because Token might be present) or "other", which
+            // disagreed with auth_mech=OAUTH. The fix derives auth_type from the same branch
+            // as auth_mech, so when auth_type=oauth the top-level field is "oauth-*".
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.AuthType, SparkAuthTypeConstants.OAuth },
+                { SparkParameters.AccessToken, "oauth-access-token-redacted" },
+            };
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+            string authType = ConnectionTelemetry.DetermineAuthType(properties);
+
+            Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+            Assert.StartsWith("oauth-", authType);
+        }
+
+        [Fact]
+        public void AuthType_AndAuthMech_Consistent_PatToken()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.AuthType, SparkAuthTypeConstants.Token },
+                { SparkParameters.Token, "dapi-redacted" },
+            };
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+            string authType = ConnectionTelemetry.DetermineAuthType(properties);
+
+            Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+            Assert.Equal("pat", authType);
+        }
+
+        [Fact]
+        public void AuthType_AndAuthMech_Consistent_NoAuth()
+        {
+            var properties = new Dictionary<string, string>();
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+            string authType = ConnectionTelemetry.DetermineAuthType(properties);
+
+            Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
+            Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
+            Assert.Equal("other", authType);
+        }
+
+        // ── PECO-2996: always-derivable system_configuration fields are populated ──────────
+
+        [Fact]
+        public void SystemConfiguration_RuntimeVendor_AlwaysPopulated()
+        {
+            var config = ConnectionTelemetry.BuildSystemConfiguration("1.2.3");
+
+            // runtime_vendor is a process-wide constant for .NET, never platform-dependent.
+            // It must always be "Microsoft" so the field is never absent in telemetry rows.
+            Assert.Equal("Microsoft", config.RuntimeVendor);
+        }
+
+        [Fact]
+        public void SystemConfiguration_DriverName_AlwaysPopulated()
+        {
+            var config = ConnectionTelemetry.BuildSystemConfiguration("1.2.3");
+
+            Assert.Equal("Databricks ADBC Driver", config.DriverName);
+        }
+
+        [Fact]
+        public void SystemConfiguration_DriverVersion_AlwaysPopulated()
+        {
+            var config = ConnectionTelemetry.BuildSystemConfiguration("1.2.3");
+
+            // DriverVersion is the cached value from the first invocation in the process; it
+            // may not equal "1.2.3" in a test run that already populated the cache, but it
+            // must never be null/empty.
+            Assert.False(string.IsNullOrEmpty(config.DriverVersion));
+        }
+
+        // ── PECO-2996: connection-param constants are populated independent of negotiation ─
+
+        [Fact]
+        public void DriverConnectionParams_ConstantFlags_AlwaysPopulated()
+        {
+            // These flags reflect driver-side behavior and never depend on a backend round
+            // trip, so they should always be set even when other parts of init have failed.
+            // The 110-row gap reported in PECO-2996 had all four absent.
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123" },
+            };
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.True(connParams.EnableArrow);
+            Assert.True(connParams.EnableDirectResults);
+            Assert.True(connParams.AutoCommit);
+            Assert.Equal(DefaultTimeoutMs / 1000, connParams.SocketTimeout);
+        }
+
+        // ── PECO-2996: Safe* wrappers fall back to best-effort defaults on partial init ────
+
+        [Fact]
+        public void SafeBuildSystemConfiguration_ReturnsBestEffort_WhenAssemblyVersionIsEmpty()
+        {
+            var config = ConnectionTelemetry.SafeBuildSystemConfiguration(string.Empty, activity: null);
+
+            Assert.NotNull(config);
+            Assert.Equal("Databricks ADBC Driver", config.DriverName);
+            Assert.Equal("Microsoft", config.RuntimeVendor);
+        }
+
+        [Fact]
+        public void SafeBuildDriverConnectionParams_ReturnsBestEffort_WithMinimalProperties()
+        {
+            // Even with no properties at all, the always-derivable connection-param flags
+            // must be present in the returned proto so dashboards see them populated.
+            var properties = new Dictionary<string, string>();
+
+            var connParams = ConnectionTelemetry.SafeBuildDriverConnectionParams(
+                properties, Host,
+                enableDirectResults: true, useDescTableExtended: false,
+                connectTimeoutMilliseconds: DefaultTimeoutMs, activity: null);
+
+            Assert.NotNull(connParams);
+            Assert.True(connParams.EnableArrow);
+            Assert.True(connParams.EnableDirectResults);
+            Assert.True(connParams.AutoCommit);
+            Assert.Equal(DefaultTimeoutMs / 1000, connParams.SocketTimeout);
+            Assert.NotNull(connParams.HostInfo);
+            Assert.Equal(Host, connParams.HostInfo.HostUrl);
+        }
+
+        [Fact]
+        public void SafeDetermineAuthType_ReturnsValidString_WithEmptyProperties()
+        {
+            var authType = ConnectionTelemetry.SafeDetermineAuthType(
+                new Dictionary<string, string>(), activity: null);
+
+            Assert.False(string.IsNullOrEmpty(authType));
+        }
+
+        // ── PECO-2998 + PECO-2996 combined: a session built end-to-end on a minimal
+        //   property bag still has all "always-derivable" fields populated. This is the
+        //   regression test for the partial-init shape that produced the 110-row gap.
+
+        [Fact]
+        public void EndToEnd_MinimalProperties_AllAlwaysDerivableFieldsPopulated()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { SparkParameters.AuthType, SparkAuthTypeConstants.OAuth },
+                { DatabricksParameters.OAuthGrantType, DatabricksConstants.OAuthGrantTypes.ClientCredentials },
+            };
+
+            var systemConfig = ConnectionTelemetry.SafeBuildSystemConfiguration(
+                "1.2.3", activity: null);
+            var connParams = ConnectionTelemetry.SafeBuildDriverConnectionParams(
+                properties, Host,
+                enableDirectResults: true, useDescTableExtended: true,
+                connectTimeoutMilliseconds: DefaultTimeoutMs, activity: null);
+            string authType = ConnectionTelemetry.SafeDetermineAuthType(properties, activity: null);
+
+            // Assemble a session as Create() would, then sanity-check the seven fields the
+            // ticket flagged as missing on the partial-init path.
+            var session = new TelemetrySessionContext
+            {
+                SystemConfiguration = systemConfig,
+                DriverConnectionParams = connParams,
+                AuthType = authType
+            };
+
+            // PECO-2998: top-level auth_type populated and consistent with nested mech/flow.
+            Assert.Equal("oauth-client_credentials", session.AuthType);
+            Assert.Equal(DriverAuthMechType.Oauth, session.DriverConnectionParams!.AuthMech);
+            Assert.Equal(DriverAuthFlowType.ClientCredentials, session.DriverConnectionParams.AuthFlow);
+
+            // PECO-2996: system_configuration.runtime_vendor and os_arch present.
+            Assert.Equal("Microsoft", session.SystemConfiguration!.RuntimeVendor);
+            Assert.False(string.IsNullOrEmpty(session.SystemConfiguration.OsArch));
+
+            // PECO-2996: connection-param constants present.
+            Assert.True(session.DriverConnectionParams.EnableDirectResults);
+            Assert.True(session.DriverConnectionParams.EnableArrow);
+            Assert.True(session.DriverConnectionParams.AutoCommit);
+            Assert.Equal(DefaultTimeoutMs / 1000, session.DriverConnectionParams.SocketTimeout);
+        }
+    }
+}

--- a/csharp/test/Unit/Telemetry/Models/TelemetryFrontendLogTests.cs
+++ b/csharp/test/Unit/Telemetry/Models/TelemetryFrontendLogTests.cs
@@ -178,7 +178,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry.Models
                         OperationLatencyMs = 150,
                         SystemConfiguration = new DriverSystemConfiguration
                         {
-                            DriverName = "Databricks ADBC Driver",
+                            DriverName = DatabricksConnection.DatabricksDriverName,
                             DriverVersion = "1.0.0",
                             OsName = "Windows",
                             RuntimeName = ".NET",


### PR DESCRIPTION
## Summary
Bundled fix for two related telemetry bugs that share the partial-init code path.

### PECO-2998 (TELEM-17) — top-level `auth_type` inconsistent with `auth_mech`
`BuildDriverConnectionParams` derived `auth_mech` from `SparkParameters.AuthType`, while `DetermineAuthType` keyed off `OAuthGrantType` alone — so OAuth U2M token-passthrough (no `grant_type`) emitted `auth_mech=OAUTH` paired with `auth_type="pat"` or `"other"`. Consolidated into a single `DetermineAuthDescriptors` helper that returns all three values (`AuthType`, `AuthMech`, `AuthFlow`) together so the trio is always consistent.

> **Behavior note:** OAuth U2M no-grant-type now reports top-level `auth_type="oauth-access_token"` (previously `"pat"` / `"other"`). This aligns with the existing E2E expectation in `AuthType_OAuthAccessToken_SetsToOAuthAccessToken`. Worth confirming downstream dashboard SQL handles `"oauth-access_token"` for that sub-case — it was already canonical for the with-grant-type case.

### PECO-2996 (TELEM-18) — `runtime_vendor` and 6 other fields missing on ~110/574 rows
Any throw inside `CreateSystemConfiguration` or `BuildDriverConnectionParams` propagated to `Create`'s outer catch and returned NoOp telemetry — but always-derivable constants (e.g. `runtime_vendor="Microsoft"`, `enable_arrow=true`, `auto_commit=true`, `socket_timeout`, `enable_direct_results`) should still emit. Two layers of resilience:
1. `CreateSystemConfiguration` now sets identity fields (driver_name, driver_version, runtime_vendor) up front and wraps each platform-dependent field in `TrySet`.
2. Three sub-builders are wrapped in `SafeBuild*` wrappers that fall back to a best-effort proto carrying always-derivable fields.

**Now resilient:** `runtime_vendor`, `driver_name`, `driver_version`, `enable_arrow`, `enable_direct_results`, `socket_timeout`, `auto_commit`, plus top-level `auth_type` whenever `auth_mech` is set.

**Still input-dependent:** `http_path`, `host_info.port`, `session_id`, `workspace_id`. `auth_mech`/`auth_flow` fall back to `Unspecified` (instead of guessing) when properties cannot be parsed.

### Investigation note
Production currently has only ONE init path — `ConnectionTelemetry.Create` → `TelemetrySessionContext`. The 110-row gap is most likely from older driver versions running before recent proto-field work landed. The fix is forward-looking; the 13 new tests assert the consistency invariants that would catch a regression of either ticket.

## Test plan
- [x] `dotnet build` driver and tests, 0 warn / 0 err
- [x] 13 new `ConnectionTelemetryPartialInitTests` pass
- [x] Full unit suite: 706/706 pass
- [ ] E2E not run (requires live workspace)

Closes PECO-2998
Closes PECO-2996

This pull request and its description were written by Isaac.