### PR TITLE
fix(csharp): default use_desc_table_extended to true for SEA/REST protocol

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -203,7 +203,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Connection feature flags — parse before catalog/schema loading that depends on them
             _enablePKFK = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnablePKFK, true);
             _enableMultipleCatalogSupport = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableMultipleCatalogSupport, true);
-            _useDescTableExtended = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseDescTableExtended, false);
+            _useDescTableExtended = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseDescTableExtended, true);
 
             // Session configuration
             // Only supply catalog from connection properties when EnableMultipleCatalogSupport is true.

--- a/csharp/src/readme.md
+++ b/csharp/src/readme.md
@@ -131,7 +131,7 @@ CloudFetch is Databricks' high-performance result retrieval system that download
 | `adbc.databricks.ssp_*` | Server-side properties prefix. Properties with this prefix will be passed to the server by executing "set key=value" queries | |
 | `adbc.databricks.enable_multiple_catalog_support` | Whether to use multiple catalogs | `true` |
 | `adbc.databricks.enable_pk_fk` | Whether to enable primary key foreign key metadata calls | `true` |
-| `adbc.databricks.use_desc_table_extended` | Whether to use DESC TABLE EXTENDED to get extended column metadata when supported by DBR | `true` |
+| `adbc.databricks.use_desc_table_extended` | Whether to use DESC TABLE EXTENDED to get extended column metadata when supported by DBR | `true` (SEA/REST), `false` (Thrift) |
 | `adbc.databricks.enable_run_async_thrift` | Whether to enable RunAsync flag in Thrift operations | `true` |
 | `adbc.databricks.driver_config_take_precedence` | Whether driver configuration overrides passed-in properties during configuration merging | `false` |
 | `adbc.apache.statement.batch_size` | Sets the maximum number of rows to retrieve in a single batch request | `2000000` |


### PR DESCRIPTION
Reyden does not support Show columns, it can only use describe table extended.

## Summary
- `adbc.databricks.use_desc_table_extended` now defaults to `true` for the SEA/REST protocol (`StatementExecutionConnection`)
- Thrift protocol (`DatabricksConnection`) default remains `false` (unchanged)
- Updated readme to document the protocol-specific defaults

## Test plan
- [ ] Verify SEA connections use `DESC TABLE EXTENDED` by default without setting the flag explicitly
- [ ] Verify Thrift connections are unaffected (still default `false`)
- [ ] Verify explicitly setting `adbc.databricks.use_desc_table_extended=false` on SEA overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)