### PR TITLE
fix(csharp): skip Thrift-specific type assertion tests for SEA protocol

### DIFF
--- a/csharp/test/E2E/DatabricksConnectionTest.cs
+++ b/csharp/test/E2E/DatabricksConnectionTest.cs
@@ -412,6 +412,7 @@ namespace AdbcDrivers.Databricks.Tests
             // Skip if default catalog or schema is not configured
             Skip.If(string.IsNullOrEmpty(TestConfiguration.Catalog), "Default catalog not configured");
             Skip.If(string.IsNullOrEmpty(TestConfiguration.DbSchema), "Default schema not configured");
+            Skip.If(TestConfiguration.Protocol == "rest", "DefaultNamespace is Thrift-only; SEA uses StatementExecutionConnection");
 
             // Act
             using var connection = NewConnection();
@@ -508,6 +509,7 @@ namespace AdbcDrivers.Databricks.Tests
         [InlineData("False", "custom-header", "True")]
         public void TracePropagationConfigurationTest(string tracePropagationEnabled, string traceParentHeaderName, string traceStateEnabled)
         {
+            Skip.If(TestConfiguration.Protocol == "rest", "TracePropagation configuration is Thrift-only; SEA uses StatementExecutionConnection");
             // Arrange
             var testConfig = (DatabricksTestConfiguration)TestConfiguration.Clone();
             testConfig.TracePropagationEnabled = tracePropagationEnabled;

--- a/csharp/test/E2E/DatabricksTestConfiguration.cs
+++ b/csharp/test/E2E/DatabricksTestConfiguration.cs
@@ -72,5 +72,8 @@ namespace AdbcDrivers.Databricks.Tests
 
         [JsonPropertyName("maxBytesPerFetchRequest"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string MaxBytesPerFetchRequest { get; set; } = string.Empty;
+
+        [JsonPropertyName("protocol"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string Protocol { get; set; } = string.Empty;
     }
 }

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -1157,7 +1157,7 @@ namespace AdbcDrivers.Databricks.Tests
             Assert.True(expectedNullable == field.IsNullable, $"Field {index} nullability mismatch");
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(false, "main", true)]
         [InlineData(true, "", true)]
         [InlineData(true, "SPARK", true)]
@@ -1165,6 +1165,7 @@ namespace AdbcDrivers.Databricks.Tests
         [InlineData(true, "main", false)]
         public void ShouldReturnEmptyPkFkResult_WorksAsExpected(bool enablePKFK, string? catalogName, bool expected)
         {
+            Skip.If(TestConfiguration.Protocol == "rest", "ShouldReturnEmptyPkFkResult is Thrift-only; SEA uses StatementExecutionStatement");
             // Arrange: create test configuration and connection
             var testConfig = (DatabricksTestConfiguration)TestConfiguration.Clone();
             var connectionParams = new Dictionary<string, string>


### PR DESCRIPTION
## Summary
- `DefaultNamespaceStoredInConnection`, `TracePropagationConfigurationTest`, and `ShouldReturnEmptyPkFkResult_WorksAsExpected` hard-cast to `DatabricksConnection`/`DatabricksStatement` which only exist for Thrift
- Added `Skip.If(TestConfiguration.Protocol == "rest", ...)` guards so these tests are skipped when running against SEA

## Jira
Fixes PECO-3009

## Test plan
- [ ] Tests should be skipped (not fail) when running with `protocol=rest`
- [ ] Tests should still pass with Thrift protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)