### PR TITLE
feat(csharp): add statement-level query tags support for SEA protocol

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionModels.cs
+++ b/csharp/src/StatementExecution/StatementExecutionModels.cs
@@ -94,6 +94,18 @@ namespace AdbcDrivers.Databricks.StatementExecution
     }
 
     /// <summary>
+    /// A query tag key-value pair sent in the SEA execute request body.
+    /// </summary>
+    public class QueryTag
+    {
+        [JsonPropertyName("key")]
+        public string Key { get; set; } = string.Empty;
+
+        [JsonPropertyName("value")]
+        public string? Value { get; set; }
+    }
+
+    /// <summary>
     /// Request to execute a SQL statement.
     /// </summary>
     public class ExecuteStatementRequest
@@ -184,6 +196,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// </summary>
         [JsonPropertyName("byte_limit")]
         public long? ByteLimit { get; set; }
+
+        /// <summary>
+        /// Query tags as an array of {key, value} objects.
+        /// </summary>
+        [JsonPropertyName("query_tags")]
+        public List<QueryTag>? QueryTags { get; set; }
     }
 
     /// <summary>

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -87,6 +87,64 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string? _metadataForeignCatalogName;
         private string? _metadataForeignSchemaName;
         private string? _metadataForeignTableName;
+        private string? _queryTags;
+
+        /// <summary>
+        /// Parses "key1:val1,key2:val2" into a list of QueryTag objects.
+        /// Keys cannot contain : or , so first : is always the key-value separator.
+        /// Values may contain escaped commas (\,) which are preserved.
+        /// </summary>
+        internal static List<QueryTag>? ParseQueryTags(string? queryTags)
+        {
+            if (string.IsNullOrEmpty(queryTags))
+                return null;
+
+            var tags = new List<QueryTag>();
+
+            // Split on unescaped commas — values may contain \,
+            var current = new System.Text.StringBuilder();
+            var tokens = new List<string>();
+            for (int i = 0; i < queryTags.Length; i++)
+            {
+                if (queryTags[i] == '\\' && i + 1 < queryTags.Length)
+                {
+                    current.Append(queryTags[i]);
+                    current.Append(queryTags[++i]);
+                }
+                else if (queryTags[i] == ',')
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                }
+                else
+                {
+                    current.Append(queryTags[i]);
+                }
+            }
+            tokens.Add(current.ToString());
+
+            foreach (var token in tokens)
+            {
+                var trimmed = token.Trim();
+                if (trimmed.Length == 0) continue;
+
+                // Keys can't contain ':', so first ':' is always the delimiter
+                var colonIndex = trimmed.IndexOf(':');
+                if (colonIndex >= 0)
+                {
+                    tags.Add(new QueryTag
+                    {
+                        Key = trimmed.Substring(0, colonIndex),
+                        Value = trimmed.Substring(colonIndex + 1)
+                    });
+                }
+                else
+                {
+                    tags.Add(new QueryTag { Key = trimmed, Value = null });
+                }
+            }
+            return tags.Count > 0 ? tags : null;
+        }
 
         public StatementExecutionStatement(
             IStatementExecutionClient client,
@@ -183,11 +241,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 case ApacheParameters.QueryTimeoutSeconds:
                     break;
 
-                // DatabricksStatement-specific options: accept but ignore for now.
-                // TODO(PECOBLR-2259): Implement query_tags support for SEA. The SEA API uses a
-                // JSON array of {key, value} objects in the executestatement request body,
-                // unlike Thrift which sends a string in confOverlay.
                 case DatabricksParameters.QueryTags:
+                    _queryTags = value;
+                    break;
+
+                // DatabricksStatement-specific options: accept but ignore for now.
                 case DatabricksParameters.UseCloudFetch:
                 case DatabricksParameters.CanDecompressLz4:
                 case DatabricksParameters.MaxBytesPerFile:
@@ -254,7 +312,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 ResultCompression = _resultCompression,
                 WaitTimeout = $"{_waitTimeoutSeconds}s",
                 OnWaitTimeout = "CONTINUE",
-                IsMetadata = isMetadataExecution
+                IsMetadata = isMetadataExecution,
+                QueryTags = ParseQueryTags(_queryTags)
             };
 
             // Execute the statement
@@ -605,7 +664,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 ResultCompression = _resultCompression,
                 WaitTimeout = $"{_waitTimeoutSeconds}s",
                 OnWaitTimeout = "CONTINUE",
-                IsMetadata = false
+                IsMetadata = false,
+                QueryTags = ParseQueryTags(_queryTags)
             };
 
             // Execute the statement

--- a/csharp/test/Unit/StatementExecution/ParseQueryTagsTests.cs
+++ b/csharp/test/Unit/StatementExecution/ParseQueryTagsTests.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
 using System.Text.Json;
 using AdbcDrivers.Databricks.StatementExecution;
 using Xunit;
@@ -184,6 +183,32 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
             Assert.Contains(@"""value"":""eng""", json);
             Assert.Contains(@"""key"":""env""", json);
             Assert.Contains(@"""value"":""prod""", json);
+        }
+
+        [Fact]
+        public void HandlesAutoQueryTagWithDoubleAtPrefix()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags(@"@@powerbi_activity_id:abc123,team:eng");
+            Assert.NotNull(tags);
+            Assert.Equal(2, tags.Count);
+            Assert.Equal("@@powerbi_activity_id", tags[0].Key);
+            Assert.Equal("abc123", tags[0].Value);
+            Assert.Equal("team", tags[1].Key);
+            Assert.Equal("eng", tags[1].Value);
+        }
+
+        [Fact]
+        public void HandlesMultipleAutoQueryTags()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags(@"@@powerbi_activity_id:abc123,@@powerbi_dataset_id:ds456,team:eng");
+            Assert.NotNull(tags);
+            Assert.Equal(3, tags.Count);
+            Assert.Equal("@@powerbi_activity_id", tags[0].Key);
+            Assert.Equal("abc123", tags[0].Value);
+            Assert.Equal("@@powerbi_dataset_id", tags[1].Key);
+            Assert.Equal("ds456", tags[1].Value);
+            Assert.Equal("team", tags[2].Key);
+            Assert.Equal("eng", tags[2].Value);
         }
 
         [Fact]

--- a/csharp/test/Unit/StatementExecution/ParseQueryTagsTests.cs
+++ b/csharp/test/Unit/StatementExecution/ParseQueryTagsTests.cs
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Text.Json;
+using AdbcDrivers.Databricks.StatementExecution;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
+{
+    public class ParseQueryTagsTests
+    {
+        [Fact]
+        public void ReturnsNull_WhenInputIsNull()
+        {
+            Assert.Null(StatementExecutionStatement.ParseQueryTags(null));
+        }
+
+        [Fact]
+        public void ReturnsNull_WhenInputIsEmpty()
+        {
+            Assert.Null(StatementExecutionStatement.ParseQueryTags(""));
+        }
+
+        [Fact]
+        public void ReturnsNull_WhenInputIsWhitespace()
+        {
+            Assert.Null(StatementExecutionStatement.ParseQueryTags("   "));
+        }
+
+        [Fact]
+        public void ParsesSingleTag()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("team:eng");
+            Assert.NotNull(tags);
+            Assert.Single(tags);
+            Assert.Equal("team", tags[0].Key);
+            Assert.Equal("eng", tags[0].Value);
+        }
+
+        [Fact]
+        public void ParsesMultipleTags()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("team:eng,env:prod,app:myapp");
+            Assert.NotNull(tags);
+            Assert.Equal(3, tags.Count);
+            Assert.Equal("team", tags[0].Key);
+            Assert.Equal("eng", tags[0].Value);
+            Assert.Equal("env", tags[1].Key);
+            Assert.Equal("prod", tags[1].Value);
+            Assert.Equal("app", tags[2].Key);
+            Assert.Equal("myapp", tags[2].Value);
+        }
+
+        [Fact]
+        public void ParsesKeyOnlyTag()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("exp");
+            Assert.NotNull(tags);
+            Assert.Single(tags);
+            Assert.Equal("exp", tags[0].Key);
+            Assert.Null(tags[0].Value);
+        }
+
+        [Fact]
+        public void ParsesMixOfKeyValueAndKeyOnly()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("team:eng,exp,env:prod");
+            Assert.NotNull(tags);
+            Assert.Equal(3, tags.Count);
+            Assert.Equal("team", tags[0].Key);
+            Assert.Equal("eng", tags[0].Value);
+            Assert.Equal("exp", tags[1].Key);
+            Assert.Null(tags[1].Value);
+            Assert.Equal("env", tags[2].Key);
+            Assert.Equal("prod", tags[2].Value);
+        }
+
+        [Fact]
+        public void PreservesEscapedCommaInValue()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags(@"metadata:foo\,bar");
+            Assert.NotNull(tags);
+            Assert.Single(tags);
+            Assert.Equal("metadata", tags[0].Key);
+            Assert.Equal(@"foo\,bar", tags[0].Value);
+        }
+
+        [Fact]
+        public void PreservesEscapedColonInValue()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags(@"metadata:{""foo""\: ""bar""}");
+            Assert.NotNull(tags);
+            Assert.Single(tags);
+            Assert.Equal("metadata", tags[0].Key);
+            Assert.Equal(@"{""foo""\: ""bar""}", tags[0].Value);
+        }
+
+        [Fact]
+        public void PreservesEscapedBackslashInValue()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags(@"path:C\\temp");
+            Assert.NotNull(tags);
+            Assert.Single(tags);
+            Assert.Equal("path", tags[0].Key);
+            Assert.Equal(@"C\\temp", tags[0].Value);
+        }
+
+        [Fact]
+        public void HandlesEscapedCommaWithMultipleTags()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags(@"data:a\,b,team:eng");
+            Assert.NotNull(tags);
+            Assert.Equal(2, tags.Count);
+            Assert.Equal("data", tags[0].Key);
+            Assert.Equal(@"a\,b", tags[0].Value);
+            Assert.Equal("team", tags[1].Key);
+            Assert.Equal("eng", tags[1].Value);
+        }
+
+        [Fact]
+        public void TrimsWhitespaceAroundTokens()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("  team:eng , env:prod  ");
+            Assert.NotNull(tags);
+            Assert.Equal(2, tags.Count);
+            Assert.Equal("team", tags[0].Key);
+            Assert.Equal("eng", tags[0].Value);
+            Assert.Equal("env", tags[1].Key);
+            Assert.Equal("prod", tags[1].Value);
+        }
+
+        [Fact]
+        public void SkipsEmptyTokensBetweenCommas()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("team:eng,,env:prod");
+            Assert.NotNull(tags);
+            Assert.Equal(2, tags.Count);
+            Assert.Equal("team", tags[0].Key);
+            Assert.Equal("eng", tags[0].Value);
+            Assert.Equal("env", tags[1].Key);
+            Assert.Equal("prod", tags[1].Value);
+        }
+
+        [Fact]
+        public void HandlesValueWithMultipleColons()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("url:https://example.com:8080/path");
+            Assert.NotNull(tags);
+            Assert.Single(tags);
+            Assert.Equal("url", tags[0].Key);
+            Assert.Equal("https://example.com:8080/path", tags[0].Value);
+        }
+
+        [Fact]
+        public void HandlesEmptyValue()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("team:");
+            Assert.NotNull(tags);
+            Assert.Single(tags);
+            Assert.Equal("team", tags[0].Key);
+            Assert.Equal("", tags[0].Value);
+        }
+
+        [Fact]
+        public void SerializesToExpectedJsonFormat()
+        {
+            var tags = StatementExecutionStatement.ParseQueryTags("team:eng,env:prod");
+            var json = JsonSerializer.Serialize(tags);
+            Assert.Contains(@"""key"":""team""", json);
+            Assert.Contains(@"""value"":""eng""", json);
+            Assert.Contains(@"""key"":""env""", json);
+            Assert.Contains(@"""value"":""prod""", json);
+        }
+
+        [Fact]
+        public void NullQueryTags_OmittedFromRequestJson()
+        {
+            var request = new ExecuteStatementRequest
+            {
+                Statement = "SELECT 1",
+                WarehouseId = "abc",
+                QueryTags = null
+            };
+            var options = new JsonSerializerOptions { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull };
+            var json = JsonSerializer.Serialize(request, options);
+            Assert.DoesNotContain("query_tags", json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add statement-level query tags support for the SEA (Statement Execution API) protocol
- Previously, query tags set via `SetOption(DatabricksParameters.QueryTags, ...)` were silently dropped for SEA statements (PECOBLR-2259)
- Parse the `"key1:val1,key2:val2"` string format into `[{"key":"k","value":"v"}]` JSON array in the SEA execute request body, matching the Python/Go/Node driver behavior

### Changes
- **StatementExecutionModels.cs**: New `QueryTag` class + `QueryTags` property on `ExecuteStatementRequest`
- **StatementExecutionStatement.cs**: Store `_queryTags` from `SetOption`, add `ParseQueryTags()` method, wire to both request-building sites
- **ParseQueryTagsTests.cs**: 17 unit tests covering all parsing edge cases

### Parser behavior
The parser follows the [Databricks query tags spec](https://docs.google.com/document/d/1TZwnvG0mjSukrrp1MizlQE1f6QNKZ45MqE7huPWSjME):
- Split on unescaped commas (values may contain `\,`)
- Split each pair on first `:` (keys cannot contain `:` per spec)
- Key-only tags (no colon) get `null` value
- Escape sequences in values are preserved as-is for the server to interpret
- Empty/null input returns null (no `query_tags` field in request JSON)

### Query tags status across all 4 flows (tested against real warehouse)

| Flow | Protocol | Level | Status |
|---|---|---|---|
| Connection-level + Thrift | Thrift | Connection | Working (SSP via OpenSession Configuration map) |
| Connection-level + SEA | SEA | Connection | Working (SSP via session_confs) |
| Statement-level + Thrift | Thrift | Statement | Working (confOverlay) |
| Statement-level + SEA | SEA | Statement | **Working with this change** |

## Test plan

- [x] 17 unit tests for `ParseQueryTags` covering: null, empty, whitespace, single tag, multiple tags, key-only, mixed key-value and key-only, escaped comma in value, escaped colon in value, escaped backslash in value, escaped comma with multiple tags, whitespace trimming, empty tokens between commas, value with multiple colons, empty value, JSON serialization format, null omission from request JSON
- [x] Manual E2E test against real Databricks SQL warehouse confirming tags appear in query history
- [x] Tested with escaped characters in values (e.g., `key1:val\ue`)

This pull request and its description were written by Isaac.