### PR TITLE
fix(csharp): key CloudFetchDownloader.downloadTasks by ChunkIndex

### DIFF
--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -286,8 +286,11 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
 
                 try
                 {
-                    // Keep track of active download tasks
-                    var downloadTasks = new ConcurrentDictionary<Task, IDownloadResult>();
+                    // Keep track of active download tasks keyed by ChunkIndex.
+                    // Keying by Task itself is unsafe here: the value stored is the continuation
+                    // task, but the continuation's lambda parameter `t` is the antecedent, so
+                    // TryRemove(t, ...) never matches and entries accumulate until method exit.
+                    var downloadTasks = new ConcurrentDictionary<long, Task>();
                     var downloadTaskCompletionSource = new TaskCompletionSource<bool>();
 
                     // Process items from the download queue until it's completed
@@ -320,7 +323,7 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                             {
                                 try
                                 {
-                                    await Task.WhenAll(downloadTasks.Keys).ConfigureAwait(false);
+                                    await Task.WhenAll(downloadTasks.Values).ConfigureAwait(false);
                                 }
                                 catch (Exception ex)
                                 {
@@ -375,6 +378,7 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                         ]);
 
                         // Start the download task
+                        long chunkIndex = downloadResult.ChunkIndex;
                         Task downloadTask = DownloadFileAsync(downloadResult, cancellationToken)
                             .ContinueWith(t =>
                             {
@@ -382,7 +386,7 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                                 _downloadSemaphore.Release();
 
                                 // Remove the task from the dictionary
-                                downloadTasks.TryRemove(t, out _);
+                                downloadTasks.TryRemove(chunkIndex, out _);
 
                                 // Handle any exceptions
                                 if (t.IsFaulted)
@@ -413,7 +417,7 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                             }, cancellationToken);
 
                         // Add the task to the dictionary
-                        downloadTasks[downloadTask] = downloadResult;
+                        downloadTasks[chunkIndex] = downloadTask;
 
                         // Add the result to the result queue add the result here to assure the download sequence.
                         _resultQueue.Add(downloadResult, cancellationToken);


### PR DESCRIPTION
## Summary

Re-keys the active-downloads bookkeeping dictionary in `CloudFetchDownloader.DownloadFilesAsync` from `<Task, IDownloadResult>` to `<long, Task>` so the continuation's `TryRemove` actually removes its own entry.

## Background

The dict was declared as:

```csharp
var downloadTasks = new ConcurrentDictionary<Task, IDownloadResult>();
```

…and populated with `downloadTasks[downloadTask] = downloadResult`, where `downloadTask` is the **continuation** returned by `DownloadFileAsync(...).ContinueWith(t => { ... })`.

Inside the continuation lambda, however, `t` is the **antecedent** task (the `DownloadFileAsync` task itself), not the continuation. So:

```csharp
.ContinueWith(t =>
{
    ...
    downloadTasks.TryRemove(t, out _);  // never matches; entries accumulate
});
```

Entries are never removed. The dict grows entry-by-entry for every chunk in a query and is only freed when `DownloadFilesAsync` returns (the variable goes out of scope). `Task.WhenAll(downloadTasks.Keys)` at the end-of-results guard ends up awaiting every download started in the query, including the ones that finished hours earlier — harmless because awaiting completed tasks is essentially free, but wasteful and the code's claim that the dict tracks _active_ downloads is wrong.

## Fix

- Key the dict by `downloadResult.ChunkIndex` (a `long`, already unique per chunk in a query).
- Capture `chunkIndex` before the lambda so the closure can use it for `TryRemove`.
- Update `Task.WhenAll` to use `.Values` (the tasks now live as values, not keys).
- Drop the `IDownloadResult` value type — verified by reading every reference that the value was never read out of the dict (only assigned, removed without being read, or ignored via `out _`); the `IDownloadResult` referenced inside the continuation comes from the foreach loop variable via closure capture, not from a dict lookup.

## Why a separate PR

This came up during review of #183 (straggler download mitigation). It's not straggler-related — the bug pre-existed in the generic CloudFetch download loop. Splitting it out so it can be reviewed on its own merits.

## Test plan

- [x] `dotnet build` succeeds with 0 warnings, 0 errors
- [x] All 693 unit tests pass (`dotnet test --filter "FullyQualifiedName~Unit"`)
- [ ] CloudFetch E2E tests against a live workspace (requires endpoint config — local run failed all 21 in 1ms each on connection setup; not caused by this change)

This pull request and its description were written by Isaac.