### PR TITLE
feat(csharp): emit telemetry for session/cancel/close (PECO-2991)

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -1054,12 +1054,36 @@ namespace AdbcDrivers.Databricks
         {
             if (disposing)
             {
-                EmitDeleteSessionTelemetry();
+                // Order matters here:
+                // 1. base.Dispose runs the TCloseSessionReq RPC (in HiveServer2Connection.DisposeClient);
+                //    time it so DELETE_SESSION can report real operation_latency_ms.
+                // 2. Emit DELETE_SESSION with the captured latency (telemetry client is still alive).
+                // 3. Flush + release the telemetry client via DisposeTelemetryAsync so the
+                //    queued event is exported before we return.
+                long closeSessionElapsedMs = 0;
+                Exception? closeSessionError = null;
+                var closeStopwatch = Stopwatch.StartNew();
+                try
+                {
+                    base.Dispose(disposing);
+                }
+                catch (Exception ex)
+                {
+                    closeSessionError = ex;
+                    throw;
+                }
+                finally
+                {
+                    closeStopwatch.Stop();
+                    closeSessionElapsedMs = closeStopwatch.ElapsedMilliseconds;
+                    EmitDeleteSessionTelemetry(closeSessionElapsedMs, closeSessionError);
 
-                // Clean up telemetry client
-                // This is synchronous because Dispose() cannot be async
-                // We use GetAwaiter().GetResult() to block, which is acceptable in Dispose
-                DisposeTelemetryAsync().GetAwaiter().GetResult();
+                    // Clean up telemetry client.
+                    // This is synchronous because Dispose() cannot be async; we block on
+                    // GetAwaiter().GetResult(), which is acceptable in Dispose.
+                    DisposeTelemetryAsync().GetAwaiter().GetResult();
+                }
+                return;
             }
 
             base.Dispose(disposing);
@@ -1067,12 +1091,12 @@ namespace AdbcDrivers.Databricks
 
         /// <summary>
         /// Emits the DELETE_SESSION telemetry event when a session was previously opened.
-        /// The actual close RPC happens later in <see cref="SparkHttpConnection"/>'s
-        /// dispose path, so <c>operation_latency_ms</c> is reported as 0 to avoid
-        /// conflating session lifetime with close latency. Idempotent across repeated
-        /// <see cref="Dispose(bool)"/> calls. Internal for test access.
+        /// <paramref name="elapsedMs"/> is the measured duration of <c>base.Dispose</c>,
+        /// which is dominated by the <c>TCloseSessionReq</c> RPC in
+        /// <see cref="AdbcDrivers.HiveServer2.HiveServer2Connection.DisposeClient"/>.
+        /// Idempotent across repeated <see cref="Dispose(bool)"/> calls. Internal for test access.
         /// </summary>
-        internal void EmitDeleteSessionTelemetry()
+        internal void EmitDeleteSessionTelemetry(long elapsedMs = 0, Exception? error = null)
         {
             try
             {
@@ -1083,8 +1107,8 @@ namespace AdbcDrivers.Databricks
                         Telemetry.Proto.Operation.Types.Type.DeleteSession,
                         Telemetry.Proto.Statement.Types.Type.Unspecified,
                         statementId: null,
-                        elapsedMs: 0,
-                        error: null);
+                        elapsedMs: elapsedMs,
+                        error: error);
                 }
             }
             catch (Exception ex)

--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -113,6 +113,12 @@ namespace AdbcDrivers.Databricks
 
         // Telemetry
         private IConnectionTelemetry _telemetry = NoOpConnectionTelemetry.Instance;
+        // Stopwatch covering the connection lifetime; started at construction and used to
+        // measure session-open latency for the CREATE_SESSION telemetry event. The wall-clock
+        // time between construction and HandleOpenSessionResponse encompasses transport setup
+        // and the OpenSession RPC, which is what we want to report.
+        private readonly Stopwatch _connectionLifetimeStopwatch = Stopwatch.StartNew();
+        private bool _sessionOpenTelemetryEmitted;
         internal TelemetrySessionContext? TelemetrySession => _telemetry.Session;
 
         /// <summary>
@@ -655,6 +661,25 @@ namespace AdbcDrivers.Databricks
 
             // Initialize telemetry after successful session creation
             InitializeTelemetry(activity);
+
+            // Emit CREATE_SESSION telemetry now that the session and telemetry client
+            // are wired up. Wrapped in try/catch defensively; telemetry must never fail
+            // the connection open path (PECO-2991).
+            try
+            {
+                long elapsedMs = _connectionLifetimeStopwatch.ElapsedMilliseconds;
+                _telemetry.EmitOperationTelemetry(
+                    Telemetry.Proto.Operation.Types.Type.CreateSession,
+                    Telemetry.Proto.Statement.Types.Type.Unspecified,
+                    statementId: null,
+                    elapsedMs: elapsedMs,
+                    error: null);
+                _sessionOpenTelemetryEmitted = true;
+            }
+            catch
+            {
+                // Telemetry must never impact driver operations.
+            }
         }
 
         /// <summary>
@@ -1002,6 +1027,27 @@ namespace AdbcDrivers.Databricks
         {
             if (disposing)
             {
+                // Emit DELETE_SESSION telemetry before tearing down the telemetry client
+                // so it gets flushed alongside any pending events. Mirrors the
+                // CREATE_SESSION emission in HandleOpenSessionResponse (PECO-2991).
+                try
+                {
+                    if (_sessionOpenTelemetryEmitted)
+                    {
+                        long elapsedMs = _connectionLifetimeStopwatch.ElapsedMilliseconds;
+                        _telemetry.EmitOperationTelemetry(
+                            Telemetry.Proto.Operation.Types.Type.DeleteSession,
+                            Telemetry.Proto.Statement.Types.Type.Unspecified,
+                            statementId: null,
+                            elapsedMs: elapsedMs,
+                            error: null);
+                    }
+                }
+                catch
+                {
+                    // Telemetry must never impact driver operations.
+                }
+
                 // Clean up telemetry client
                 // This is synchronous because Dispose() cannot be async
                 // We use GetAwaiter().GetResult() to block, which is acceptable in Dispose
@@ -1015,6 +1061,26 @@ namespace AdbcDrivers.Databricks
         /// Disposes telemetry client asynchronously.
         /// </summary>
         private Task DisposeTelemetryAsync() => _telemetry.DisposeAsync();
+
+        /// <summary>
+        /// Statement-facing entry point for emitting telemetry for discrete statement
+        /// operations (CANCEL_STATEMENT, CLOSE_STATEMENT) that don't have their own
+        /// execute path. Delegates to the connection's telemetry implementation.
+        /// </summary>
+        internal void EmitStatementOperationTelemetry(
+            Telemetry.Proto.Operation.Types.Type operationType,
+            Telemetry.Proto.Statement.Types.Type statementType,
+            string? statementId,
+            long elapsedMs,
+            Exception? error)
+        {
+            _telemetry.EmitOperationTelemetry(
+                operationType,
+                statementType,
+                statementId,
+                elapsedMs,
+                error);
+        }
 
         /// <summary>
         /// Gets operating system information.

--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -116,9 +116,11 @@ namespace AdbcDrivers.Databricks
         // Stopwatch covering the connection lifetime; started at construction and used to
         // measure session-open latency for the CREATE_SESSION telemetry event. The wall-clock
         // time between construction and HandleOpenSessionResponse encompasses transport setup
-        // and the OpenSession RPC, which is what we want to report.
+        // and the OpenSession RPC. This is wider than the OpenSession RPC alone (which is
+        // what JDBC measures); cross-driver dashboards should account for the difference.
         private readonly Stopwatch _connectionLifetimeStopwatch = Stopwatch.StartNew();
         private bool _sessionOpenTelemetryEmitted;
+        private bool _sessionDeleteTelemetryEmitted;
         internal TelemetrySessionContext? TelemetrySession => _telemetry.Session;
 
         /// <summary>
@@ -662,9 +664,17 @@ namespace AdbcDrivers.Databricks
             // Initialize telemetry after successful session creation
             InitializeTelemetry(activity);
 
-            // Emit CREATE_SESSION telemetry now that the session and telemetry client
-            // are wired up. Wrapped in try/catch defensively; telemetry must never fail
-            // the connection open path (PECO-2991).
+            EmitCreateSessionTelemetry(activity);
+        }
+
+        /// <summary>
+        /// Emits the CREATE_SESSION telemetry event. Internal so unit tests can call this
+        /// directly after injecting a fake <see cref="IConnectionTelemetry"/> via the
+        /// <see cref="TelemetryForTesting"/> seam, without needing to drive a full Thrift
+        /// session-open RPC.
+        /// </summary>
+        internal void EmitCreateSessionTelemetry(Activity? activity = null)
+        {
             try
             {
                 long elapsedMs = _connectionLifetimeStopwatch.ElapsedMilliseconds;
@@ -676,10 +686,27 @@ namespace AdbcDrivers.Databricks
                     error: null);
                 _sessionOpenTelemetryEmitted = true;
             }
-            catch
+            catch (Exception ex)
             {
-                // Telemetry must never impact driver operations.
+                activity?.AddEvent(new ActivityEvent("telemetry.emit.error",
+                    tags: new ActivityTagsCollection
+                    {
+                        { "error.type", ex.GetType().Name },
+                        { "error.message", ex.Message },
+                        { "operation_type", "CREATE_SESSION" }
+                    }));
             }
+        }
+
+        /// <summary>
+        /// Test seam allowing unit tests to substitute a fake <see cref="IConnectionTelemetry"/>
+        /// so they can verify the production code calls <c>EmitOperationTelemetry</c> at the
+        /// right lifecycle hooks. Production code never sets this property.
+        /// </summary>
+        internal IConnectionTelemetry TelemetryForTesting
+        {
+            get => _telemetry;
+            set => _telemetry = value;
         }
 
         /// <summary>
@@ -1027,26 +1054,7 @@ namespace AdbcDrivers.Databricks
         {
             if (disposing)
             {
-                // Emit DELETE_SESSION telemetry before tearing down the telemetry client
-                // so it gets flushed alongside any pending events. Mirrors the
-                // CREATE_SESSION emission in HandleOpenSessionResponse (PECO-2991).
-                try
-                {
-                    if (_sessionOpenTelemetryEmitted)
-                    {
-                        long elapsedMs = _connectionLifetimeStopwatch.ElapsedMilliseconds;
-                        _telemetry.EmitOperationTelemetry(
-                            Telemetry.Proto.Operation.Types.Type.DeleteSession,
-                            Telemetry.Proto.Statement.Types.Type.Unspecified,
-                            statementId: null,
-                            elapsedMs: elapsedMs,
-                            error: null);
-                    }
-                }
-                catch
-                {
-                    // Telemetry must never impact driver operations.
-                }
+                EmitDeleteSessionTelemetry();
 
                 // Clean up telemetry client
                 // This is synchronous because Dispose() cannot be async
@@ -1055,6 +1063,40 @@ namespace AdbcDrivers.Databricks
             }
 
             base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Emits the DELETE_SESSION telemetry event when a session was previously opened.
+        /// The actual close RPC happens later in <see cref="SparkHttpConnection"/>'s
+        /// dispose path, so <c>operation_latency_ms</c> is reported as 0 to avoid
+        /// conflating session lifetime with close latency. Idempotent across repeated
+        /// <see cref="Dispose(bool)"/> calls. Internal for test access.
+        /// </summary>
+        internal void EmitDeleteSessionTelemetry()
+        {
+            try
+            {
+                if (_sessionOpenTelemetryEmitted && !_sessionDeleteTelemetryEmitted)
+                {
+                    _sessionDeleteTelemetryEmitted = true;
+                    _telemetry.EmitOperationTelemetry(
+                        Telemetry.Proto.Operation.Types.Type.DeleteSession,
+                        Telemetry.Proto.Statement.Types.Type.Unspecified,
+                        statementId: null,
+                        elapsedMs: 0,
+                        error: null);
+                }
+            }
+            catch (Exception ex)
+            {
+                Activity.Current?.AddEvent(new ActivityEvent("telemetry.emit.error",
+                    tags: new ActivityTagsCollection
+                    {
+                        { "error.type", ex.GetType().Name },
+                        { "error.message", ex.Message },
+                        { "operation_type", "DELETE_SESSION" }
+                    }));
+            }
         }
 
         /// <summary>

--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -1272,13 +1272,90 @@ namespace AdbcDrivers.Databricks
         /// <param name="disposing">True if disposing managed resources.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && _pendingTelemetryContext != null)
+            if (disposing)
             {
-                // Emit telemetry now that results have been consumed
-                EmitTelemetry(_pendingTelemetryContext);
-                _pendingTelemetryContext = null;
+                if (_pendingTelemetryContext != null)
+                {
+                    // Emit telemetry now that results have been consumed
+                    EmitTelemetry(_pendingTelemetryContext);
+                    _pendingTelemetryContext = null;
+                }
+
+                // Emit a CLOSE_STATEMENT telemetry event for every statement disposal,
+                // independently of any EXECUTE_STATEMENT/metadata event already emitted.
+                // The driver doesn't issue a separate server-side close RPC here (the
+                // base AdbcStatement Dispose just releases local resources), but JDBC
+                // emits CLOSE_STATEMENT for the same lifecycle hook so analysts can
+                // count statement-close events; we match that behaviour (PECO-2991).
+                try
+                {
+                    var session = ((DatabricksConnection)Connection).TelemetrySession;
+                    if (session?.TelemetryClient != null)
+                    {
+                        long elapsedMs = _statementLifetimeStopwatch.ElapsedMilliseconds;
+                        ((DatabricksConnection)Connection).EmitStatementOperationTelemetry(
+                            OperationType.CloseStatement,
+                            Telemetry.Proto.Statement.Types.Type.Unspecified,
+                            StatementId,
+                            elapsedMs,
+                            error: null);
+                    }
+                }
+                catch
+                {
+                    // Telemetry must never impact driver operations.
+                }
             }
             base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Stopwatch covering the lifetime of this statement, started at construction.
+        /// Used to populate operation_latency_ms for CANCEL_STATEMENT and CLOSE_STATEMENT
+        /// telemetry events that don't have their own timing instrumentation.
+        /// </summary>
+        private readonly Stopwatch _statementLifetimeStopwatch = Stopwatch.StartNew();
+
+        /// <inheritdoc/>
+        public override void Cancel()
+        {
+            // Emit CANCEL_STATEMENT telemetry around the base cancel call so we capture
+            // user-initiated cancels even when the cancellation token has already
+            // disposed the execute path's pending telemetry context. The base class
+            // never throws here (it just signals the token source) but we still
+            // protect callers with a try/finally for resilience (PECO-2991).
+            Exception? error = null;
+            long startMs = _statementLifetimeStopwatch.ElapsedMilliseconds;
+            try
+            {
+                base.Cancel();
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+                throw;
+            }
+            finally
+            {
+                try
+                {
+                    var session = ((DatabricksConnection)Connection).TelemetrySession;
+                    if (session?.TelemetryClient != null)
+                    {
+                        long elapsedMs = _statementLifetimeStopwatch.ElapsedMilliseconds - startMs;
+                        ((DatabricksConnection)Connection).EmitStatementOperationTelemetry(
+                            OperationType.CancelStatement,
+                            Telemetry.Proto.Statement.Types.Type.Unspecified,
+                            StatementId,
+                            elapsedMs,
+                            error);
+                    }
+                }
+                catch
+                {
+                    // Telemetry must never impact driver operations.
+                }
+            }
         }
     }
 }

--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -72,10 +72,15 @@ namespace AdbcDrivers.Databricks
         private StatementTelemetryContext? _pendingTelemetryContext; // Telemetry context pending emission on Dispose
 
         // Stopwatch covering the lifetime of this statement, started at construction.
-        // Used to scope CANCEL_STATEMENT timing within the statement's lifetime; CLOSE_STATEMENT
-        // does not record a per-operation latency (the driver issues no server-side close RPC).
+        // Used to scope CANCEL_STATEMENT timing within the statement's lifetime.
         private readonly Stopwatch _statementLifetimeStopwatch = Stopwatch.StartNew();
         private bool _closeStatementTelemetryEmitted;
+
+        // Populated by DatabricksCompositeReader.Dispose when it issues TCloseOperationReq
+        // to the server. Lets us report the actual close-RPC latency in the CLOSE_STATEMENT
+        // telemetry event emitted at statement Dispose, instead of a meaningless 0.
+        internal long? CloseStatementRpcLatencyMs { get; set; }
+        internal Exception? CloseStatementRpcError { get; set; }
 
         public override long BatchSize { get; protected set; } = DatabricksBatchSizeDefault;
 
@@ -1289,10 +1294,12 @@ namespace AdbcDrivers.Databricks
 
                 // Emit a CLOSE_STATEMENT telemetry event once per statement disposal,
                 // independently of any EXECUTE_STATEMENT/metadata event already emitted.
-                // The driver doesn't issue a separate server-side close RPC here (the
-                // base AdbcStatement Dispose just releases local resources), so
-                // operation_latency_ms is reported as 0 — this event is a lifecycle
-                // marker for analysts to count statement closures, matching JDBC.
+                // operation_latency_ms reflects the TCloseOperationReq RPC duration when
+                // the result reader actually closed the operation server-side
+                // (DatabricksCompositeReader stashes that timing here); if no close RPC
+                // was issued (e.g. user disposed the statement without consuming results,
+                // or the operation was already closed by direct-results), elapsedMs is 0
+                // and the event acts purely as a lifecycle marker.
                 // _closeStatementTelemetryEmitted makes the emission idempotent across
                 // repeated Dispose() calls (PECO-2991).
                 try
@@ -1307,8 +1314,8 @@ namespace AdbcDrivers.Databricks
                                 OperationType.CloseStatement,
                                 Telemetry.Proto.Statement.Types.Type.Unspecified,
                                 StatementId,
-                                elapsedMs: 0,
-                                error: null);
+                                elapsedMs: CloseStatementRpcLatencyMs ?? 0,
+                                error: CloseStatementRpcError);
                         }
                     }
                 }

--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -71,6 +71,12 @@ namespace AdbcDrivers.Databricks
         internal bool IsInternalCall { get; set; } // Marks if this is a driver-internal operation (e.g., USE SCHEMA)
         private StatementTelemetryContext? _pendingTelemetryContext; // Telemetry context pending emission on Dispose
 
+        // Stopwatch covering the lifetime of this statement, started at construction.
+        // Used to scope CANCEL_STATEMENT timing within the statement's lifetime; CLOSE_STATEMENT
+        // does not record a per-operation latency (the driver issues no server-side close RPC).
+        private readonly Stopwatch _statementLifetimeStopwatch = Stopwatch.StartNew();
+        private bool _closeStatementTelemetryEmitted;
+
         public override long BatchSize { get; protected set; } = DatabricksBatchSizeDefault;
 
         public DatabricksStatement(DatabricksConnection connection)
@@ -1281,49 +1287,54 @@ namespace AdbcDrivers.Databricks
                     _pendingTelemetryContext = null;
                 }
 
-                // Emit a CLOSE_STATEMENT telemetry event for every statement disposal,
+                // Emit a CLOSE_STATEMENT telemetry event once per statement disposal,
                 // independently of any EXECUTE_STATEMENT/metadata event already emitted.
                 // The driver doesn't issue a separate server-side close RPC here (the
-                // base AdbcStatement Dispose just releases local resources), but JDBC
-                // emits CLOSE_STATEMENT for the same lifecycle hook so analysts can
-                // count statement-close events; we match that behaviour (PECO-2991).
+                // base AdbcStatement Dispose just releases local resources), so
+                // operation_latency_ms is reported as 0 — this event is a lifecycle
+                // marker for analysts to count statement closures, matching JDBC.
+                // _closeStatementTelemetryEmitted makes the emission idempotent across
+                // repeated Dispose() calls (PECO-2991).
                 try
                 {
-                    var session = ((DatabricksConnection)Connection).TelemetrySession;
-                    if (session?.TelemetryClient != null)
+                    if (!_closeStatementTelemetryEmitted)
                     {
-                        long elapsedMs = _statementLifetimeStopwatch.ElapsedMilliseconds;
-                        ((DatabricksConnection)Connection).EmitStatementOperationTelemetry(
-                            OperationType.CloseStatement,
-                            Telemetry.Proto.Statement.Types.Type.Unspecified,
-                            StatementId,
-                            elapsedMs,
-                            error: null);
+                        var session = ((DatabricksConnection)Connection).TelemetrySession;
+                        if (session?.TelemetryClient != null)
+                        {
+                            _closeStatementTelemetryEmitted = true;
+                            ((DatabricksConnection)Connection).EmitStatementOperationTelemetry(
+                                OperationType.CloseStatement,
+                                Telemetry.Proto.Statement.Types.Type.Unspecified,
+                                StatementId,
+                                elapsedMs: 0,
+                                error: null);
+                        }
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Telemetry must never impact driver operations.
+                    Activity.Current?.AddEvent(new ActivityEvent("telemetry.emit.error",
+                        tags: new ActivityTagsCollection
+                        {
+                            { "error.type", ex.GetType().Name },
+                            { "error.message", ex.Message },
+                            { "operation_type", "CLOSE_STATEMENT" }
+                        }));
                 }
             }
             base.Dispose(disposing);
         }
-
-        /// <summary>
-        /// Stopwatch covering the lifetime of this statement, started at construction.
-        /// Used to populate operation_latency_ms for CANCEL_STATEMENT and CLOSE_STATEMENT
-        /// telemetry events that don't have their own timing instrumentation.
-        /// </summary>
-        private readonly Stopwatch _statementLifetimeStopwatch = Stopwatch.StartNew();
 
         /// <inheritdoc/>
         public override void Cancel()
         {
             // Emit CANCEL_STATEMENT telemetry around the base cancel call so we capture
             // user-initiated cancels even when the cancellation token has already
-            // disposed the execute path's pending telemetry context. The base class
-            // never throws here (it just signals the token source) but we still
-            // protect callers with a try/finally for resilience (PECO-2991).
+            // disposed the execute path's pending telemetry context. base.Cancel()
+            // signals the cancellation token source and is idempotent across repeats
+            // (PECO-2991). Each invocation emits its own event so analysts can see
+            // duplicate user-initiated cancels.
             Exception? error = null;
             long startMs = _statementLifetimeStopwatch.ElapsedMilliseconds;
             try
@@ -1351,9 +1362,15 @@ namespace AdbcDrivers.Databricks
                             error);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Telemetry must never impact driver operations.
+                    Activity.Current?.AddEvent(new ActivityEvent("telemetry.emit.error",
+                        tags: new ActivityTagsCollection
+                        {
+                            { "error.type", ex.GetType().Name },
+                            { "error.message", ex.Message },
+                            { "operation_type", "CANCEL_STATEMENT" }
+                        }));
                 }
             }
         }

--- a/csharp/src/Reader/DatabricksCompositeReader.cs
+++ b/csharp/src/Reader/DatabricksCompositeReader.cs
@@ -241,8 +241,30 @@ namespace AdbcDrivers.Databricks.Reader
                             // CloudFetchReader is protocol-agnostic and does not send CloseOperation,
                             // so we must not rely on the contained reader to do it.
                             activity?.AddEvent("composite_reader.close_operation");
-                            _ = HiveServer2Reader.CloseOperationAsync(_statement, _response)
-                                .ConfigureAwait(false).GetAwaiter().GetResult();
+                            // Time the TCloseOperationReq RPC so CLOSE_STATEMENT telemetry
+                            // emitted later from DatabricksStatement.Dispose can report the
+                            // actual server-side close latency (PECO-2991).
+                            var closeStopwatch = Stopwatch.StartNew();
+                            Exception? closeError = null;
+                            try
+                            {
+                                _ = HiveServer2Reader.CloseOperationAsync(_statement, _response)
+                                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                            }
+                            catch (Exception ex)
+                            {
+                                closeError = ex;
+                                throw;
+                            }
+                            finally
+                            {
+                                closeStopwatch.Stop();
+                                if (_statement is DatabricksStatement dbxStatement)
+                                {
+                                    dbxStatement.CloseStatementRpcLatencyMs = closeStopwatch.ElapsedMilliseconds;
+                                    dbxStatement.CloseStatementRpcError = closeError;
+                                }
+                            }
                             if (_activeReader != null)
                             {
                                 activity?.AddEvent("composite_reader.disposing_active_reader", [

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -270,15 +270,12 @@ namespace AdbcDrivers.Databricks.Telemetry
                 if (error != null)
                 {
                     ctx.HasError = true;
-                    try
-                    {
-                        ctx.ErrorName = error.GetType().Name;
-                        ctx.ErrorMessage = error.Message;
-                    }
-                    catch
-                    {
-                        // Some pathological exceptions can throw from .Message - swallow.
-                    }
+                    ctx.ErrorName = error.GetType().Name;
+                    // Note: error.Message is intentionally not captured. The proto's
+                    // DriverErrorInfo only emits error_name today (error_message field 3
+                    // is pending LPP review per sql_driver_telemetry.proto). When the
+                    // proto field lands, capture .Message here behind a try/catch
+                    // (some exceptions throw from their .Message property).
                 }
 
                 Proto.OssSqlDriverTelemetryLog log = ctx.BuildTelemetryLog();
@@ -303,9 +300,15 @@ namespace AdbcDrivers.Databricks.Telemetry
 
                 client.Enqueue(frontendLog);
             }
-            catch
+            catch (Exception ex)
             {
-                // Telemetry must never impact driver operations.
+                Activity.Current?.AddEvent(new ActivityEvent("telemetry.emit.error",
+                    tags: new ActivityTagsCollection
+                    {
+                        { "error.type", ex.GetType().Name },
+                        { "error.message", ex.Message },
+                        { "operation_type", operationType.ToString() }
+                    }));
             }
         }
 

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -45,7 +45,9 @@ namespace AdbcDrivers.Databricks.Telemetry
 
         public TelemetrySessionContext? Session { get; }
 
-        private ConnectionTelemetry(
+        // Internal so unit tests can construct an instance with a mock ITelemetryClient
+        // (the public Create() factory always wires up the real TelemetryClientManager).
+        internal ConnectionTelemetry(
             string host,
             ITelemetryClient telemetryClient,
             TelemetrySessionContext session)
@@ -228,6 +230,83 @@ namespace AdbcDrivers.Databricks.Telemetry
             }
 
             return result;
+        }
+
+        public void EmitOperationTelemetry(
+            Proto.Operation.Types.Type operationType,
+            Proto.Statement.Types.Type statementType,
+            string? statementId,
+            long elapsedMs,
+            Exception? error)
+        {
+            // Defensive: never throw into driver paths. Every step is wrapped because the
+            // session context could be partially populated (e.g. CREATE_SESSION fires before
+            // SessionId is set on the proto path) and proto-building must not fail callers.
+            try
+            {
+                ITelemetryClient? client = _telemetryClient;
+                if (client == null || Session == null)
+                {
+                    return;
+                }
+
+                StatementTelemetryContext ctx;
+                try
+                {
+                    ctx = new StatementTelemetryContext(Session)
+                    {
+                        OperationType = operationType,
+                        StatementType = statementType,
+                        StatementId = statementId,
+                        ResultFormat = Proto.ExecutionResult.Types.Format.InlineArrow,
+                        IsCompressed = false,
+                    };
+                }
+                catch
+                {
+                    return;
+                }
+
+                if (error != null)
+                {
+                    ctx.HasError = true;
+                    try
+                    {
+                        ctx.ErrorName = error.GetType().Name;
+                        ctx.ErrorMessage = error.Message;
+                    }
+                    catch
+                    {
+                        // Some pathological exceptions can throw from .Message - swallow.
+                    }
+                }
+
+                Proto.OssSqlDriverTelemetryLog log = ctx.BuildTelemetryLog();
+                // Override the Stopwatch-derived latency with the caller-provided elapsed
+                // time so the recorded latency reflects the actual operation, not the
+                // negligible time spent inside this helper.
+                log.OperationLatencyMs = elapsedMs;
+
+                var frontendLog = new TelemetryFrontendLog
+                {
+                    WorkspaceId = ctx.WorkspaceId,
+                    FrontendLogEventId = System.Guid.NewGuid().ToString(),
+                    Context = new FrontendLogContext
+                    {
+                        TimestampMillis = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    },
+                    Entry = new FrontendLogEntry
+                    {
+                        SqlDriverLog = log,
+                    },
+                };
+
+                client.Enqueue(frontendLog);
+            }
+            catch
+            {
+                // Telemetry must never impact driver operations.
+            }
         }
 
         public async Task DisposeAsync()

--- a/csharp/src/Telemetry/IConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/IConnectionTelemetry.cs
@@ -41,6 +41,25 @@ namespace AdbcDrivers.Databricks.Telemetry
             Activity? activity);
 
         /// <summary>
+        /// Emits a single telemetry log for a discrete operation that has no separate
+        /// execution body to wrap (e.g. CREATE_SESSION, DELETE_SESSION, CANCEL_STATEMENT,
+        /// CLOSE_STATEMENT). Used when the work is already done and we just need to
+        /// record that it happened.
+        /// </summary>
+        /// <param name="operationType">The operation type to record.</param>
+        /// <param name="statementType">The statement type. Use TYPE_UNSPECIFIED for
+        /// session lifecycle events that aren't tied to a specific statement.</param>
+        /// <param name="statementId">Optional server-assigned statement id, when applicable.</param>
+        /// <param name="elapsedMs">Elapsed wall-clock time of the operation in milliseconds.</param>
+        /// <param name="error">Exception thrown by the operation, or null on success.</param>
+        void EmitOperationTelemetry(
+            Proto.Operation.Types.Type operationType,
+            Proto.Statement.Types.Type statementType,
+            string? statementId,
+            long elapsedMs,
+            Exception? error);
+
+        /// <summary>
         /// Flushes pending events and releases the telemetry client.
         /// Safe to call multiple times.
         /// </summary>

--- a/csharp/src/Telemetry/NoOpConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/NoOpConnectionTelemetry.cs
@@ -37,6 +37,16 @@ namespace AdbcDrivers.Databricks.Telemetry
             return operation();
         }
 
+        public void EmitOperationTelemetry(
+            Proto.Operation.Types.Type operationType,
+            Proto.Statement.Types.Type statementType,
+            string? statementId,
+            long elapsedMs,
+            Exception? error)
+        {
+            // No-op
+        }
+
         public Task DisposeAsync() => Task.CompletedTask;
     }
 }

--- a/csharp/test/E2E/Telemetry/CapturingTelemetryExporter.cs
+++ b/csharp/test/E2E/Telemetry/CapturingTelemetryExporter.cs
@@ -20,20 +20,36 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Telemetry;
 using AdbcDrivers.Databricks.Telemetry.Models;
+using AdbcDrivers.Databricks.Telemetry.Proto;
 
 namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
 {
     /// <summary>
-    /// A telemetry exporter that captures all exported logs for test assertions.
+    /// A telemetry exporter that captures exported logs for test assertions.
     /// Thread-safe for concurrent export calls.
     /// </summary>
+    /// <remarks>
+    /// By default the exporter excludes the PECO-2991 lifecycle events
+    /// (CREATE_SESSION, DELETE_SESSION, CANCEL_STATEMENT, CLOSE_STATEMENT) so
+    /// existing tests written against EXECUTE_STATEMENT / metadata events keep
+    /// using <c>logs[0]</c> and <c>AssertLogCount(logs, 1)</c> unchanged. Tests
+    /// that need to observe lifecycle events should set
+    /// <see cref="CaptureLifecycleEvents"/> to <c>true</c>.
+    /// </remarks>
     internal sealed class CapturingTelemetryExporter : ITelemetryExporter
     {
         private readonly ConcurrentBag<TelemetryFrontendLog> _exportedLogs = new ConcurrentBag<TelemetryFrontendLog>();
         private int _exportCallCount;
 
         /// <summary>
-        /// Gets all captured telemetry logs.
+        /// When false (default), session/statement lifecycle events
+        /// (CREATE_SESSION, DELETE_SESSION, CANCEL_STATEMENT, CLOSE_STATEMENT)
+        /// are silently dropped at export time. Set to true to capture every log.
+        /// </summary>
+        public bool CaptureLifecycleEvents { get; set; }
+
+        /// <summary>
+        /// Gets all captured telemetry logs (after lifecycle filtering, if enabled).
         /// </summary>
         public IReadOnlyCollection<TelemetryFrontendLog> ExportedLogs => _exportedLogs;
 
@@ -50,6 +66,10 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
             {
                 foreach (var log in logs)
                 {
+                    if (!CaptureLifecycleEvents && IsLifecycleEvent(log))
+                    {
+                        continue;
+                    }
                     _exportedLogs.Add(log);
                 }
             }
@@ -64,6 +84,15 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         {
             while (_exportedLogs.TryTake(out _)) { }
             Interlocked.Exchange(ref _exportCallCount, 0);
+        }
+
+        private static bool IsLifecycleEvent(TelemetryFrontendLog log)
+        {
+            var opType = log.Entry?.SqlDriverLog?.SqlOperation?.OperationDetail?.OperationType;
+            return opType == Operation.Types.Type.CreateSession
+                || opType == Operation.Types.Type.DeleteSession
+                || opType == Operation.Types.Type.CloseStatement
+                || opType == Operation.Types.Type.CancelStatement;
         }
     }
 }

--- a/csharp/test/E2E/Telemetry/TelemetryTestHelpers.cs
+++ b/csharp/test/E2E/Telemetry/TelemetryTestHelpers.cs
@@ -121,6 +121,36 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
         }
 
         /// <summary>
+        /// Finds the first captured proto log whose operation type matches
+        /// <paramref name="operationType"/>. Use this in preference to <c>logs[0]</c>
+        /// when other lifecycle events (CREATE_SESSION, DELETE_SESSION, CLOSE_STATEMENT)
+        /// may also be in the buffer (PECO-2991).
+        /// </summary>
+        public static OssSqlDriverTelemetryLog GetProtoLogByOperation(
+            IEnumerable<TelemetryFrontendLog> logs,
+            Operation.Types.Type operationType)
+        {
+            foreach (var log in logs)
+            {
+                if (log.Entry?.SqlDriverLog?.SqlOperation?.OperationDetail?.OperationType == operationType)
+                {
+                    return log.Entry.SqlDriverLog;
+                }
+            }
+            Assert.Fail($"No telemetry log found with operation type {operationType}");
+            return null!; // unreachable
+        }
+
+        /// <summary>
+        /// Convenience wrapper for the common case of asserting on the EXECUTE_STATEMENT
+        /// log, which used to be <c>logs[0]</c> before PECO-2991 added the surrounding
+        /// CREATE_SESSION / CLOSE_STATEMENT lifecycle events to the captured buffer.
+        /// </summary>
+        public static OssSqlDriverTelemetryLog GetExecuteStatementLog(
+            IEnumerable<TelemetryFrontendLog> logs)
+            => GetProtoLogByOperation(logs, Operation.Types.Type.ExecuteStatement);
+
+        /// <summary>
         /// Asserts that basic session-level fields are populated correctly.
         /// </summary>
         public static void AssertSessionFieldsPopulated(OssSqlDriverTelemetryLog protoLog)

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryOperationEmissionTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryOperationEmissionTests.cs
@@ -1,0 +1,194 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.Telemetry;
+using AdbcDrivers.Databricks.Telemetry.Models;
+using OperationType = AdbcDrivers.Databricks.Telemetry.Proto.Operation.Types.Type;
+using StatementType = AdbcDrivers.Databricks.Telemetry.Proto.Statement.Types.Type;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Unit tests covering PECO-2991: ADBC must emit telemetry for the operation types
+    /// that were silent before this change — CREATE_SESSION, DELETE_SESSION,
+    /// CANCEL_STATEMENT, and CLOSE_STATEMENT — through the new
+    /// <see cref="IConnectionTelemetry.EmitOperationTelemetry"/> entry point.
+    /// </summary>
+    public class ConnectionTelemetryOperationEmissionTests
+    {
+        /// <summary>
+        /// Test-only ITelemetryClient that records every Enqueue call so tests can
+        /// assert the exact proto fields the driver tried to emit.
+        /// </summary>
+        private sealed class CapturingTelemetryClient : ITelemetryClient
+        {
+            public List<TelemetryFrontendLog> Logs { get; } = new List<TelemetryFrontendLog>();
+
+            public void Enqueue(TelemetryFrontendLog log) => Logs.Add(log);
+
+            public Task FlushAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+            public Task CloseAsync() => Task.CompletedTask;
+
+            public ValueTask DisposeAsync() => default;
+        }
+
+        private static (ConnectionTelemetry telemetry, CapturingTelemetryClient client) CreateTelemetry()
+        {
+            var client = new CapturingTelemetryClient();
+            var session = new TelemetrySessionContext
+            {
+                SessionId = "test-session",
+                WorkspaceId = 999L,
+                TelemetryClient = client,
+                AuthType = "pat",
+            };
+            var telemetry = new ConnectionTelemetry("test.databricks.com", client, session);
+            return (telemetry, client);
+        }
+
+        [Fact]
+        public void EmitOperationTelemetry_CreateSession_EnqueuesLogWithOperationType()
+        {
+            var (telemetry, client) = CreateTelemetry();
+
+            telemetry.EmitOperationTelemetry(
+                OperationType.CreateSession,
+                StatementType.Unspecified,
+                statementId: null,
+                elapsedMs: 42,
+                error: null);
+
+            Assert.Single(client.Logs);
+            var log = client.Logs[0].Entry.SqlDriverLog;
+            Assert.Equal("test-session", log.SessionId);
+            Assert.Equal(42, log.OperationLatencyMs);
+            Assert.NotNull(log.SqlOperation);
+            Assert.NotNull(log.SqlOperation.OperationDetail);
+            Assert.Equal(OperationType.CreateSession, log.SqlOperation.OperationDetail.OperationType);
+            Assert.Equal(StatementType.Unspecified, log.SqlOperation.StatementType);
+            Assert.Null(log.ErrorInfo);
+        }
+
+        [Fact]
+        public void EmitOperationTelemetry_DeleteSession_EnqueuesLog()
+        {
+            var (telemetry, client) = CreateTelemetry();
+
+            telemetry.EmitOperationTelemetry(
+                OperationType.DeleteSession,
+                StatementType.Unspecified,
+                statementId: null,
+                elapsedMs: 1234,
+                error: null);
+
+            Assert.Single(client.Logs);
+            var log = client.Logs[0].Entry.SqlDriverLog;
+            Assert.Equal(1234, log.OperationLatencyMs);
+            Assert.Equal(OperationType.DeleteSession, log.SqlOperation.OperationDetail.OperationType);
+        }
+
+        [Fact]
+        public void EmitOperationTelemetry_CancelStatement_PopulatesStatementId()
+        {
+            var (telemetry, client) = CreateTelemetry();
+
+            telemetry.EmitOperationTelemetry(
+                OperationType.CancelStatement,
+                StatementType.Unspecified,
+                statementId: "stmt-cancel-1",
+                elapsedMs: 10,
+                error: null);
+
+            Assert.Single(client.Logs);
+            var log = client.Logs[0].Entry.SqlDriverLog;
+            Assert.Equal("stmt-cancel-1", log.SqlStatementId);
+            Assert.Equal(OperationType.CancelStatement, log.SqlOperation.OperationDetail.OperationType);
+        }
+
+        [Fact]
+        public void EmitOperationTelemetry_CloseStatement_PopulatesStatementId()
+        {
+            var (telemetry, client) = CreateTelemetry();
+
+            telemetry.EmitOperationTelemetry(
+                OperationType.CloseStatement,
+                StatementType.Unspecified,
+                statementId: "stmt-close-1",
+                elapsedMs: 5,
+                error: null);
+
+            Assert.Single(client.Logs);
+            var log = client.Logs[0].Entry.SqlDriverLog;
+            Assert.Equal("stmt-close-1", log.SqlStatementId);
+            Assert.Equal(OperationType.CloseStatement, log.SqlOperation.OperationDetail.OperationType);
+        }
+
+        [Fact]
+        public void EmitOperationTelemetry_WithError_PopulatesErrorInfo()
+        {
+            var (telemetry, client) = CreateTelemetry();
+
+            telemetry.EmitOperationTelemetry(
+                OperationType.CancelStatement,
+                StatementType.Unspecified,
+                statementId: "stmt-err",
+                elapsedMs: 7,
+                error: new InvalidOperationException("boom"));
+
+            Assert.Single(client.Logs);
+            var log = client.Logs[0].Entry.SqlDriverLog;
+            Assert.NotNull(log.ErrorInfo);
+            Assert.Equal("InvalidOperationException", log.ErrorInfo.ErrorName);
+        }
+
+        [Fact]
+        public void EmitOperationTelemetry_DoesNotThrow_WhenStatementIdIsNull()
+        {
+            var (telemetry, _) = CreateTelemetry();
+
+            // No exception should escape this call.
+            telemetry.EmitOperationTelemetry(
+                OperationType.CreateSession,
+                StatementType.Unspecified,
+                statementId: null,
+                elapsedMs: 0,
+                error: null);
+        }
+
+        [Fact]
+        public void NoOpConnectionTelemetry_EmitOperationTelemetry_DoesNothing()
+        {
+            // Given a no-op telemetry implementation, EmitOperationTelemetry must be safe
+            // and have no observable effect — the driver always falls back to no-op when
+            // telemetry is disabled or initialisation fails.
+            IConnectionTelemetry telemetry = NoOpConnectionTelemetry.Instance;
+
+            // No exception, no side effects observable.
+            telemetry.EmitOperationTelemetry(
+                OperationType.CreateSession,
+                StatementType.Unspecified,
+                statementId: "x",
+                elapsedMs: 1,
+                error: new Exception("boom"));
+        }
+    }
+}

--- a/csharp/test/Unit/Telemetry/DriverTelemetryWiringTests.cs
+++ b/csharp/test/Unit/Telemetry/DriverTelemetryWiringTests.cs
@@ -146,6 +146,26 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void EmitDeleteSessionTelemetry_ForwardsLatencyAndError()
+        {
+            // Production code times base.Dispose (which runs TCloseSessionReq) and passes
+            // the elapsed ms + any thrown exception to EmitDeleteSessionTelemetry. Verify
+            // both flow through to the captured telemetry call.
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            connection.EmitCreateSessionTelemetry();
+            var rpcError = new InvalidOperationException("close session failed");
+            connection.EmitDeleteSessionTelemetry(elapsedMs: 73, error: rpcError);
+
+            int deleteIdx = fake.Calls.IndexOf(OperationType.DeleteSession);
+            Assert.True(deleteIdx >= 0);
+            Assert.Equal(73, fake.LatenciesByOp[OperationType.DeleteSession]);
+            Assert.Same(rpcError, fake.Errors[deleteIdx]);
+        }
+
+        [Fact]
         public void Dispose_CalledTwice_FiresDeleteSessionOnlyOnce()
         {
             var connection = CreateConnection();

--- a/csharp/test/Unit/Telemetry/DriverTelemetryWiringTests.cs
+++ b/csharp/test/Unit/Telemetry/DriverTelemetryWiringTests.cs
@@ -59,6 +59,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
             public List<OperationType> Calls { get; } = new();
             public List<Exception?> Errors { get; } = new();
             public List<string?> StatementIds { get; } = new();
+            public Dictionary<OperationType, long> LatenciesByOp { get; } = new();
             public TelemetrySessionContext? Session { get; }
                 = new TelemetrySessionContext
                 {
@@ -82,6 +83,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 Calls.Add(operationType);
                 Errors.Add(error);
                 StatementIds.Add(statementId);
+                LatenciesByOp[operationType] = elapsedMs;
             }
 
             public Task DisposeAsync()
@@ -173,6 +175,41 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
             statement.Dispose();
 
             Assert.Contains(OperationType.CloseStatement, fake.Calls);
+        }
+
+        [Fact]
+        public void StatementDispose_PassesCapturedRpcLatencyToTelemetry()
+        {
+            // DatabricksCompositeReader stashes the TCloseOperationReq RPC latency on the
+            // statement; statement Dispose should forward it as operation_latency_ms.
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            var statement = new DatabricksStatement(connection);
+            statement.CloseStatementRpcLatencyMs = 42;
+            statement.Dispose();
+
+            Assert.Contains(OperationType.CloseStatement, fake.Calls);
+            Assert.Equal(42, fake.LatenciesByOp[OperationType.CloseStatement]);
+        }
+
+        [Fact]
+        public void StatementDispose_ForwardsCapturedRpcError()
+        {
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            var statement = new DatabricksStatement(connection);
+            var rpcError = new InvalidOperationException("close failed");
+            statement.CloseStatementRpcLatencyMs = 5;
+            statement.CloseStatementRpcError = rpcError;
+            statement.Dispose();
+
+            int closeIdx = fake.Calls.IndexOf(OperationType.CloseStatement);
+            Assert.True(closeIdx >= 0);
+            Assert.Same(rpcError, fake.Errors[closeIdx]);
         }
 
         [Fact]

--- a/csharp/test/Unit/Telemetry/DriverTelemetryWiringTests.cs
+++ b/csharp/test/Unit/Telemetry/DriverTelemetryWiringTests.cs
@@ -1,0 +1,232 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.Telemetry;
+using AdbcDrivers.Databricks.Telemetry.Models;
+using AdbcDrivers.HiveServer2.Spark;
+using OperationType = AdbcDrivers.Databricks.Telemetry.Proto.Operation.Types.Type;
+using StatementType = AdbcDrivers.Databricks.Telemetry.Proto.Statement.Types.Type;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Tests that the four PECO-2991 lifecycle hooks
+    /// (CREATE_SESSION / DELETE_SESSION / CANCEL_STATEMENT / CLOSE_STATEMENT) actually
+    /// invoke <see cref="IConnectionTelemetry.EmitOperationTelemetry"/> from the production
+    /// call sites. <see cref="ConnectionTelemetryOperationEmissionTests"/> covers the
+    /// emit method itself; this file covers the wiring around it.
+    /// </summary>
+    public class DriverTelemetryWiringTests
+    {
+        /// <summary>
+        /// No-op <see cref="ITelemetryClient"/> used to satisfy the
+        /// <c>session?.TelemetryClient != null</c> gate in <c>DatabricksStatement</c>'s
+        /// Cancel/Dispose paths so the wiring tests can observe the
+        /// <see cref="RecordingTelemetry"/> calls.
+        /// </summary>
+        private sealed class StubTelemetryClient : ITelemetryClient
+        {
+            public void Enqueue(TelemetryFrontendLog log) { }
+            public Task FlushAsync(CancellationToken ct = default) => Task.CompletedTask;
+            public Task CloseAsync() => Task.CompletedTask;
+            public ValueTask DisposeAsync() => default;
+        }
+
+        /// <summary>
+        /// Records every <c>EmitOperationTelemetry</c> call so tests can assert which
+        /// operation types fired and in what order.
+        /// </summary>
+        private sealed class RecordingTelemetry : IConnectionTelemetry
+        {
+            public List<OperationType> Calls { get; } = new();
+            public List<Exception?> Errors { get; } = new();
+            public List<string?> StatementIds { get; } = new();
+            public TelemetrySessionContext? Session { get; }
+                = new TelemetrySessionContext
+                {
+                    SessionId = "test-session",
+                    TelemetryClient = new StubTelemetryClient(),
+                };
+            public int DisposeCount { get; private set; }
+
+            public T ExecuteWithMetadataTelemetry<T>(
+                OperationType operationType,
+                Func<T> operation,
+                System.Diagnostics.Activity? activity) => operation();
+
+            public void EmitOperationTelemetry(
+                OperationType operationType,
+                StatementType statementType,
+                string? statementId,
+                long elapsedMs,
+                Exception? error)
+            {
+                Calls.Add(operationType);
+                Errors.Add(error);
+                StatementIds.Add(statementId);
+            }
+
+            public Task DisposeAsync()
+            {
+                DisposeCount++;
+                return Task.CompletedTask;
+            }
+        }
+
+        private static DatabricksConnection CreateConnection()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "test.databricks.com",
+                [SparkParameters.Token] = "test-token",
+            };
+            return new DatabricksConnection(properties);
+        }
+
+        [Fact]
+        public void EmitCreateSessionTelemetry_FiresCreateSession()
+        {
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            connection.EmitCreateSessionTelemetry();
+
+            Assert.Equal(new[] { OperationType.CreateSession }, fake.Calls);
+            Assert.Null(fake.Errors[0]);
+            Assert.Null(fake.StatementIds[0]);
+        }
+
+        [Fact]
+        public void Dispose_AfterCreateSession_FiresDeleteSession()
+        {
+            var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            connection.EmitCreateSessionTelemetry();
+            connection.Dispose();
+
+            Assert.Equal(
+                new[] { OperationType.CreateSession, OperationType.DeleteSession },
+                fake.Calls);
+        }
+
+        [Fact]
+        public void Dispose_WithoutCreateSession_DoesNotFireDeleteSession()
+        {
+            var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            // Skip CREATE_SESSION — this models a connection that failed to open a session.
+            connection.Dispose();
+
+            Assert.DoesNotContain(OperationType.DeleteSession, fake.Calls);
+        }
+
+        [Fact]
+        public void Dispose_CalledTwice_FiresDeleteSessionOnlyOnce()
+        {
+            var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            connection.EmitCreateSessionTelemetry();
+            connection.Dispose();
+            connection.Dispose();
+
+            int deleteCount = 0;
+            foreach (var call in fake.Calls)
+            {
+                if (call == OperationType.DeleteSession) deleteCount++;
+            }
+            Assert.Equal(1, deleteCount);
+        }
+
+        [Fact]
+        public void StatementDispose_FiresCloseStatement()
+        {
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            var statement = new DatabricksStatement(connection);
+            statement.Dispose();
+
+            Assert.Contains(OperationType.CloseStatement, fake.Calls);
+        }
+
+        [Fact]
+        public void StatementDispose_CalledTwice_FiresCloseStatementOnlyOnce()
+        {
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            var statement = new DatabricksStatement(connection);
+            statement.Dispose();
+            statement.Dispose();
+
+            int closeCount = 0;
+            foreach (var call in fake.Calls)
+            {
+                if (call == OperationType.CloseStatement) closeCount++;
+            }
+            Assert.Equal(1, closeCount);
+        }
+
+        [Fact]
+        public void StatementCancel_FiresCancelStatement()
+        {
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            using var statement = new DatabricksStatement(connection);
+            statement.Cancel();
+
+            Assert.Contains(OperationType.CancelStatement, fake.Calls);
+        }
+
+        [Fact]
+        public void StatementCancel_CalledMultipleTimes_FiresOnePerInvocation()
+        {
+            // base.Cancel() is idempotent (just signals the token source) but each user
+            // invocation is a deliberate action, so we emit one CANCEL_STATEMENT per call.
+            using var connection = CreateConnection();
+            var fake = new RecordingTelemetry();
+            connection.TelemetryForTesting = fake;
+
+            using var statement = new DatabricksStatement(connection);
+            statement.Cancel();
+            statement.Cancel();
+            statement.Cancel();
+
+            int cancelCount = 0;
+            foreach (var call in fake.Calls)
+            {
+                if (call == OperationType.CancelStatement) cancelCount++;
+            }
+            Assert.Equal(3, cancelCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Previously ADBC C# only emitted client telemetry for QUERY/EXECUTE_STATEMENT and the metadata operations already wired through `ExecuteWithMetadataTelemetry`. This PR fills in the remaining gaps so the operation types below now appear in `prod_frontend_log_sql_driver_log`:

- `CREATE_SESSION` — emitted at the end of `DatabricksConnection.HandleOpenSessionResponse` once the telemetry client is wired up. Latency reflects the time from connection construction through OpenSession + response handling.
- `DELETE_SESSION` — emitted at the start of `DatabricksConnection.Dispose`, before the telemetry client is flushed and torn down. Only emitted when `CREATE_SESSION` succeeded so we don't fire spurious deletes for connections that never got a session.
- `CANCEL_STATEMENT` — emitted from a `DatabricksStatement.Cancel` override around the base cancel call. Captures user-initiated cancels even when the execute path's pending telemetry context has already been emitted/cleared.
- `CLOSE_STATEMENT` — emitted from `DatabricksStatement.Dispose`, in addition to (not in place of) any pending EXECUTE_STATEMENT/metadata event. Matches JDBC's behaviour so analysts can count statement-close events.

A single new entry point `IConnectionTelemetry.EmitOperationTelemetry(operationType, statementType, statementId, elapsedMs, error)` handles all four. `NoOpConnectionTelemetry` remains a true no-op when telemetry is disabled.

All emission paths are wrapped in `try/catch` — telemetry must never impact driver operations, matching the PECO-2996 resilience pattern already in `ConnectionTelemetry`.

Closes PECO-2991

## Test plan
- [x] Build clean (`dotnet build` for `AdbcDrivers.Databricks.csproj`)
- [x] 7 new unit tests in `ConnectionTelemetryOperationEmissionTests` cover each operation type plus error info plus no-op behaviour — all pass
- [x] Full `Unit` test suite (700 tests) still green
- [x] All 284 telemetry unit tests still green

This pull request and its description were written by Isaac.