### PR TITLE
fix(csharp): populate discovery telemetry fields (PECO-2995)

### DIFF
--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -432,7 +432,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             int batchSize = GetBatchSize(properties);
             int asyncPollIntervalMillis = GetAsyncPollIntervalMillis(properties);
 
-            return new Proto.DriverConnectionParameters
+            var connectionParams = new Proto.DriverConnectionParameters
             {
                 HttpPath = httpPath ?? "",
                 Mode = Proto.DriverMode.Types.Type.Thrift,
@@ -454,6 +454,42 @@ namespace AdbcDrivers.Databricks.Telemetry
                 AutoCommit = true,
                 AsyncPollIntervalMillis = asyncPollIntervalMillis,
             };
+
+            // PECO-2995 (TELEM-16): emit discovery_mode_enabled and enable_token_cache so
+            // analysts can distinguish ADBC C# rows (where these features are NOT supported)
+            // from JDBC rows (where they're configurable). The C# driver hardcodes the OIDC
+            // token endpoint to https://{host}/oidc/v1/token (see OAuthClientCredentialsProvider
+            // and TokenExchangeClient) and does not perform .well-known discovery; therefore
+            // discovery_mode_enabled is always false and discovery_url is intentionally left
+            // unset (no value to report). Likewise the driver has no opt-in persistent token
+            // cache (the in-memory dedup dictionaries in TokenRefreshDelegatingHandler /
+            // MandatoryTokenExchangeDelegatingHandler are NOT what JDBC's enableTokenCache
+            // refers to), so enable_token_cache is always false. Each setter is wrapped in
+            // its own try/catch so a future per-field source change cannot kill the whole
+            // telemetry payload.
+            TrySetField(connectionParams, p => p.DiscoveryModeEnabled = false);
+            TrySetField(connectionParams, p => p.EnableTokenCache = false);
+
+            return connectionParams;
+        }
+
+        /// <summary>
+        /// Resilience helper: applies a single proto setter, swallowing any exception so a
+        /// per-field problem cannot break the entire telemetry payload. Mirrors the pattern
+        /// introduced in PECO-2996 for system-configuration fields.
+        /// </summary>
+        private static void TrySetField(
+            Proto.DriverConnectionParameters connectionParams,
+            Action<Proto.DriverConnectionParameters> setter)
+        {
+            try
+            {
+                setter(connectionParams);
+            }
+            catch
+            {
+                // Intentionally swallowed - telemetry must not impact driver operation.
+            }
         }
 
         // PECO-2997: report the async-execution poll interval (in milliseconds) used by

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -455,20 +455,18 @@ namespace AdbcDrivers.Databricks.Telemetry
                 AsyncPollIntervalMillis = asyncPollIntervalMillis,
             };
 
-            // PECO-2995 (TELEM-16): emit discovery_mode_enabled and enable_token_cache so
-            // analysts can distinguish ADBC C# rows (where these features are NOT supported)
-            // from JDBC rows (where they're configurable). The C# driver hardcodes the OIDC
-            // token endpoint to https://{host}/oidc/v1/token (see OAuthClientCredentialsProvider
-            // and TokenExchangeClient) and does not perform .well-known discovery; therefore
-            // discovery_mode_enabled is always false and discovery_url is intentionally left
-            // unset (no value to report). Likewise the driver has no opt-in persistent token
-            // cache (the in-memory dedup dictionaries in TokenRefreshDelegatingHandler /
-            // MandatoryTokenExchangeDelegatingHandler are NOT what JDBC's enableTokenCache
-            // refers to), so enable_token_cache is always false. Each setter is wrapped in
-            // its own try/catch so a future per-field source change cannot kill the whole
-            // telemetry payload.
+            // PECO-2995 (TELEM-16): emit discovery_mode_enabled and enable_token_cache.
+            // The C# driver hardcodes the OIDC token endpoint to https://{host}/oidc/v1/token
+            // (see OAuthClientCredentialsProvider and TokenExchangeClient) and never performs
+            // .well-known discovery, so discovery_mode_enabled is always false and
+            // discovery_url is intentionally left unset (no value to report).
+            // OAuth providers DO cache tokens in memory (see OAuthClientCredentialsProvider's
+            // _cachedToken / GetValidCachedToken), so enable_token_cache is reported as true
+            // whenever any caching is happening — independent of whether JDBC's persistent
+            // disk-cache feature exists in this driver. Each setter is wrapped in its own
+            // try/catch so a future per-field source change cannot kill the whole payload.
             TrySetField(connectionParams, p => p.DiscoveryModeEnabled = false);
-            TrySetField(connectionParams, p => p.EnableTokenCache = false);
+            TrySetField(connectionParams, p => p.EnableTokenCache = true);
 
             return connectionParams;
         }

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -460,13 +460,13 @@ namespace AdbcDrivers.Databricks.Telemetry
             // (see OAuthClientCredentialsProvider and TokenExchangeClient) and never performs
             // .well-known discovery, so discovery_mode_enabled is always false and
             // discovery_url is intentionally left unset (no value to report).
-            // OAuth providers DO cache tokens in memory (see OAuthClientCredentialsProvider's
-            // _cachedToken / GetValidCachedToken), so enable_token_cache is reported as true
-            // whenever any caching is happening — independent of whether JDBC's persistent
-            // disk-cache feature exists in this driver. Each setter is wrapped in its own
-            // try/catch so a future per-field source change cannot kill the whole payload.
+            // enable_token_cache is set to false: the in-memory dictionaries in
+            // TokenRefreshDelegatingHandler and MandatoryTokenExchangeDelegatingHandler are
+            // NOT what JDBC's enableTokenCache refers to (JDBC's feature is a U2M browser-flow
+            // on-disk cache, which this driver does not support). Each setter is wrapped in its
+            // own try/catch so a future per-field source change cannot kill the whole payload.
             TrySetField(connectionParams, p => p.DiscoveryModeEnabled = false);
-            TrySetField(connectionParams, p => p.EnableTokenCache = true);
+            TrySetField(connectionParams, p => p.EnableTokenCache = false);
 
             return connectionParams;
         }

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
@@ -1,0 +1,130 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using AdbcDrivers.Databricks.Telemetry;
+using AdbcDrivers.HiveServer2.Spark;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Regression tests for PECO-2995 (TELEM-16): the proto fields
+    /// <c>discovery_mode_enabled</c>, <c>discovery_url</c>, and
+    /// <c>enable_token_cache</c> existed in the telemetry schema but were never
+    /// populated by the C# driver, leaving them indistinguishable from "unset"
+    /// in the lakehouse.
+    ///
+    /// This driver does not support OIDC discovery (the OAuth token endpoint is
+    /// hardcoded to <c>https://{host}/oidc/v1/token</c> in
+    /// <c>OAuthClientCredentialsProvider</c> and <c>TokenExchangeClient</c>) and
+    /// does not support a persistent on-disk token cache (the in-memory dedup
+    /// dictionaries in the delegating handlers are not what JDBC's
+    /// <c>enableTokenCache</c> refers to). We therefore explicitly emit
+    /// <c>discovery_mode_enabled=false</c> and <c>enable_token_cache=false</c>
+    /// for every connection so analysts can distinguish C# rows from JDBC rows.
+    /// <c>discovery_url</c> is intentionally left unset (no value to report).
+    /// </summary>
+    public class ConnectionTelemetryDiscoveryFieldsTests
+    {
+        private const string Host = "test.databricks.com";
+        private const int DefaultTimeoutMs = 30_000;
+
+        private static Dictionary<string, string> BaseProperties() => new()
+        {
+            { SparkParameters.Path, "/sql/1.0/warehouses/abc123" },
+        };
+
+        [Fact]
+        public void DiscoveryModeEnabled_AlwaysFalse_PatAuth()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.Token;
+            properties[SparkParameters.Token] = "dapi-redacted";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.True(connParams.HasDiscoveryModeEnabled);
+            Assert.False(connParams.DiscoveryModeEnabled);
+        }
+
+        [Fact]
+        public void DiscoveryModeEnabled_AlwaysFalse_OAuthClientCredentials()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
+            properties[DatabricksParameters.OAuthGrantType] =
+                DatabricksConstants.OAuthGrantTypes.ClientCredentials;
+            properties[DatabricksParameters.OAuthClientId] = "client-id";
+            properties[DatabricksParameters.OAuthClientSecret] = "client-secret";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.True(connParams.HasDiscoveryModeEnabled);
+            Assert.False(connParams.DiscoveryModeEnabled);
+        }
+
+        [Fact]
+        public void DiscoveryUrl_LeftUnset_NoDiscoverySupported()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
+            properties[DatabricksParameters.OAuthGrantType] =
+                DatabricksConstants.OAuthGrantTypes.ClientCredentials;
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            // The C# driver hardcodes the OIDC token endpoint and never performs
+            // .well-known discovery, so there is no URL to report. Leaving the
+            // optional field unset is the honest signal.
+            Assert.False(connParams.HasDiscoveryUrl);
+        }
+
+        [Fact]
+        public void EnableTokenCache_AlwaysFalse_PatAuth()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.Token;
+            properties[SparkParameters.Token] = "dapi-redacted";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.True(connParams.HasEnableTokenCache);
+            Assert.False(connParams.EnableTokenCache);
+        }
+
+        [Fact]
+        public void EnableTokenCache_AlwaysFalse_OAuthClientCredentials()
+        {
+            var properties = BaseProperties();
+            properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
+            properties[DatabricksParameters.OAuthGrantType] =
+                DatabricksConstants.OAuthGrantTypes.ClientCredentials;
+            properties[DatabricksParameters.OAuthClientId] = "client-id";
+            properties[DatabricksParameters.OAuthClientSecret] = "client-secret";
+
+            var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
+                properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+
+            Assert.True(connParams.HasEnableTokenCache);
+            Assert.False(connParams.EnableTokenCache);
+        }
+    }
+}

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
@@ -97,7 +97,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
         }
 
         [Fact]
-        public void EnableTokenCache_AlwaysFalse_PatAuth()
+        public void EnableTokenCache_AlwaysTrue_PatAuth()
         {
             var properties = BaseProperties();
             properties[SparkParameters.AuthType] = SparkAuthTypeConstants.Token;
@@ -107,11 +107,11 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasEnableTokenCache);
-            Assert.False(connParams.EnableTokenCache);
+            Assert.True(connParams.EnableTokenCache);
         }
 
         [Fact]
-        public void EnableTokenCache_AlwaysFalse_OAuthClientCredentials()
+        public void EnableTokenCache_AlwaysTrue_OAuthClientCredentials()
         {
             var properties = BaseProperties();
             properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
@@ -124,7 +124,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasEnableTokenCache);
-            Assert.False(connParams.EnableTokenCache);
+            Assert.True(connParams.EnableTokenCache);
         }
     }
 }

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
@@ -31,9 +31,10 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
     /// This driver does not support OIDC discovery (the OAuth token endpoint is
     /// hardcoded to <c>https://{host}/oidc/v1/token</c> in
     /// <c>OAuthClientCredentialsProvider</c> and <c>TokenExchangeClient</c>) and
-    /// does not support a persistent on-disk token cache (the in-memory dedup
-    /// dictionaries in the delegating handlers are not what JDBC's
-    /// <c>enableTokenCache</c> refers to). We therefore explicitly emit
+    /// does not support a persistent on-disk token cache (JDBC's
+    /// <c>enableTokenCache</c> refers to a U2M browser-flow disk cache, which this
+    /// driver does not support; the in-memory dedup dictionaries in the delegating
+    /// handlers are a different mechanism). We therefore explicitly emit
     /// <c>discovery_mode_enabled=false</c> and <c>enable_token_cache=false</c>
     /// for every connection so analysts can distinguish C# rows from JDBC rows.
     /// <c>discovery_url</c> is intentionally left unset (no value to report).
@@ -97,7 +98,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
         }
 
         [Fact]
-        public void EnableTokenCache_AlwaysTrue_PatAuth()
+        public void EnableTokenCache_AlwaysFalse_PatAuth()
         {
             var properties = BaseProperties();
             properties[SparkParameters.AuthType] = SparkAuthTypeConstants.Token;
@@ -107,11 +108,11 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasEnableTokenCache);
-            Assert.True(connParams.EnableTokenCache);
+            Assert.False(connParams.EnableTokenCache);
         }
 
         [Fact]
-        public void EnableTokenCache_AlwaysTrue_OAuthClientCredentials()
+        public void EnableTokenCache_AlwaysFalse_OAuthClientCredentials()
         {
             var properties = BaseProperties();
             properties[SparkParameters.AuthType] = SparkAuthTypeConstants.OAuth;
@@ -124,7 +125,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 properties, Host, enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasEnableTokenCache);
-            Assert.True(connParams.EnableTokenCache);
+            Assert.False(connParams.EnableTokenCache);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Three `driver_connection_params` proto fields (`discovery_mode_enabled`, `discovery_url`, `enable_token_cache`) existed in the telemetry schema but were never populated by the C# driver, leaving them indistinguishable from "unset" and breaking cross-driver analytics that compare against JDBC.
- This driver does not currently support either feature, so per the ticket's "do NOT invent a value" guidance we set what is verifiable from the code and leave the rest unset:

| Field | Value | Source / reason |
| --- | --- | --- |
| `discovery_mode_enabled` | `false` | Driver hardcodes the OIDC token endpoint to `https://{host}/oidc/v1/token` (see `OAuthClientCredentialsProvider`, `TokenExchangeClient`); no `.well-known` discovery is performed |
| `discovery_url` | unset | No discovery URL exists to report — leaving the optional field unset is the honest signal |
| `enable_token_cache` | `false` | No opt-in persistent token cache is supported. The in-memory dedup `_tokenCache` dictionaries in `TokenRefreshDelegatingHandler` / `MandatoryTokenExchangeDelegatingHandler` are NOT what JDBC's `enableTokenCache` refers to (that's a U2M browser-flow on-disk cache, which this driver also does not support) |

- Each setter is wrapped in a small `TrySetField` helper (mirroring the resilience pattern introduced in PECO-2996) so a future per-field source change cannot break the whole telemetry payload.

## Test plan
- [x] Build clean (`dotnet build AdbcDrivers.Databricks.csproj`)
- [x] Unit test: properties → proto fields populated (`ConnectionTelemetryDiscoveryFieldsTests`, 5 tests covering PAT + OAuth client-credentials)
- [x] All telemetry tests pass (377 passed, 0 failed)

Closes PECO-2995

This pull request and its description were written by Isaac.