### PR TITLE
ci: use TEST_PECO_REYDEN_HTTP_PATH for SEA/REST E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        protocol: ${{ inputs.protocol == 'thrift' && fromJson('["thrift"]') || inputs.protocol == 'rest' && fromJson('["rest"]') || fromJson('["thrift","rest"]') }}
+        protocol: ${{ fromJson(inputs.protocol == 'thrift' && '["thrift"]' || inputs.protocol == 'rest' && '["rest"]' || '["thrift","rest"]') }}
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
       DATABRICKS_HTTP_PATH: ${{ matrix.protocol == 'rest' && secrets.TEST_PECO_REYDEN_HTTP_PATH || secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,7 +51,7 @@ jobs:
         protocol: ${{ inputs.protocol == 'thrift' && fromJson('["thrift"]') || inputs.protocol == 'rest' && fromJson('["rest"]') || fromJson('["thrift","rest"]') }}
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
-      DATABRICKS_HTTP_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
+      DATABRICKS_HTTP_PATH: ${{ matrix.protocol == 'rest' && secrets.TEST_PECO_REYDEN_HTTP_PATH || secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
       DATABRICKS_TEST_CLIENT_ID: ${{ secrets.DATABRICKS_TEST_CLIENT_ID }}
       DATABRICKS_TEST_CLIENT_SECRET: ${{ secrets.DATABRICKS_TEST_CLIENT_SECRET }}
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Check if tests should run
         id: gate
         run: |
+          echo "🔍 inputs.protocol='${{ inputs.protocol }}' event='${{ github.event_name }}'"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             if [[ "${{ github.event.action }}" == "labeled" ]] && [[ "${{ github.event.label.name }}" == "e2e-test" ]]; then
               echo "run=true" >> $GITHUB_OUTPUT && echo "✅ e2e-test label added — running E2E tests"


### PR DESCRIPTION
## Summary
- Routes the REST protocol E2E matrix job to the Reyden warehouse using the new `TEST_PECO_REYDEN_HTTP_PATH` secret
- Thrift protocol job continues using `TEST_PECO_WAREHOUSE_HTTP_PATH` unchanged

## Test plan
- [ ] Trigger E2E tests manually via workflow_dispatch with `protocol: rest` to verify the Reyden warehouse is used
- [ ] Verify `protocol: thrift` still uses the original warehouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)