### PR TITLE
fix(csharp): align INTERVAL and complex type columns to strings on SEA path (PECO-3015, PECO-3016) [SEA]

### DIFF
--- a/csharp/src/ComplexTypeSerializingStream.cs
+++ b/csharp/src/ComplexTypeSerializingStream.cs
@@ -31,14 +31,30 @@ namespace AdbcDrivers.Databricks
     /// Wraps an <see cref="IArrowArrayStream"/> and converts ARRAY, MAP, and STRUCT columns
     /// into STRING columns containing their JSON representation.
     ///
-    /// This is applied when EnableComplexDatatypeSupport=false (the default), so that SEA
+    /// <para>
+    /// Applied when <c>EnableComplexDatatypeSupport=false</c> (the default) so that SEA
     /// results match the legacy Thrift behavior of returning JSON strings for complex types.
+    /// </para>
     ///
-    /// Column detection uses the <c>Spark:DataType:SqlName</c> field metadata set by
-    /// <c>TryGetSchemaFromManifest</c>, so the inner stream must already report the
-    /// manifest schema (which all three result paths — inline, CloudFetch, empty — do).
-    /// The schema exposed to callers is the inner stream's schema unchanged; it already
-    /// has <see cref="StringType"/> for complex columns.
+    /// <para><strong>Why both schema and data must be converted:</strong>
+    /// Arrow streaming is strongly typed: the <see cref="Schema"/> and the arrays inside each
+    /// <see cref="RecordBatch"/> must agree on the column type. The manifest schema (built by
+    /// <c>TryGetSchemaFromManifest</c>) already declares complex columns as
+    /// <see cref="StringType"/>, so this stream only needs to convert the native Arrow arrays
+    /// (<c>ListArray</c>, <c>StructArray</c>, etc.) to <see cref="StringArray"/> at read time.
+    /// The schema it exposes to callers is the inner stream's schema unchanged.
+    /// </para>
+    ///
+    /// <para><strong>Column detection:</strong>
+    /// Complex columns are identified by the <c>Spark:DataType:SqlName</c> field metadata
+    /// (<see cref="ColumnMetadataHelper.ArrowMetadataKey"/>) that
+    /// <c>TryGetSchemaFromManifest</c> embeds when building the manifest schema. This is
+    /// the same key the Databricks server embeds in Arrow IPC field metadata for Thrift results
+    /// (and that the JDBC driver reads as <c>ARROW_METADATA_KEY</c>). Detecting via this
+    /// metadata — rather than by inspecting the Arrow field type — is necessary because the
+    /// manifest schema already uses <see cref="StringType"/> for complex columns, making
+    /// Arrow-type-based detection always return false.
+    /// </para>
     /// </summary>
     internal sealed class ComplexTypeSerializingStream : IArrowArrayStream
     {

--- a/csharp/src/ComplexTypeSerializingStream.cs
+++ b/csharp/src/ComplexTypeSerializingStream.cs
@@ -27,23 +27,60 @@ using Apache.Arrow.Types;
 namespace AdbcDrivers.Databricks
 {
     /// <summary>
-    /// Wraps an <see cref="IArrowArrayStream"/> and converts columns of complex Arrow types
-    /// (LIST, MAP represented as LIST of STRUCTs, STRUCT) into STRING columns containing
-    /// their JSON representation.
+    /// Wraps an <see cref="IArrowArrayStream"/> and converts columns that carry
+    /// native Arrow types that must be serialized to strings into STRING columns:
     ///
-    /// This is applied when EnableComplexDatatypeSupport=false (the default), so that SEA
-    /// results match the legacy Thrift behavior of returning JSON strings for complex types.
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///       Complex types (LIST, MAP represented as LIST of STRUCTs, STRUCT) are
+    ///       converted into STRING columns containing their JSON representation.
+    ///       Applied when EnableComplexDatatypeSupport=false (the default) so that SEA
+    ///       results match the legacy Thrift behavior of returning JSON strings for complex types.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///       <see cref="ArrowTypeId.Interval"/> with <see cref="IntervalUnit.YearMonth"/>
+    ///       (<c>YearMonthIntervalArray</c>) → "Y-M" string,
+    ///       e.g. 30 months → "2-6" (2 years, 6 months).
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///       <see cref="ArrowTypeId.Duration"/> (<c>DurationArray</c>) → "D HH:MM:SS.nnnnnnnnn"
+    ///       string, e.g. 3 days + 12 h + 30 min + 15 s → "3 12:30:15.000000000".
+    ///       The conversion respects the <see cref="DurationType.Unit"/> of the column.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    ///
+    /// The schema reported to callers is rewritten so that converted columns have
+    /// <see cref="StringType"/> instead of the native type, exactly mirroring what
+    /// the Thrift protocol returns.
     /// </summary>
     internal sealed class ComplexTypeSerializingStream : IArrowArrayStream
     {
         private readonly IArrowArrayStream _inner;
         private readonly Schema _schema;
         private readonly HashSet<int> _complexColumnIndices;
+        // For interval/duration columns we need to know the original type to pick the right formatter
+        private readonly Dictionary<int, IArrowType> _intervalColumnOriginalTypes;
 
-        public ComplexTypeSerializingStream(IArrowArrayStream inner)
+        /// <summary>
+        /// Initializes a new instance of <see cref="ComplexTypeSerializingStream"/>.
+        /// </summary>
+        /// <param name="inner">The underlying Arrow stream to wrap.</param>
+        /// <param name="serializeComplexTypes">
+        /// When <c>true</c> (the default), LIST/MAP/STRUCT columns are serialized to JSON strings.
+        /// Set to <c>false</c> when EnableComplexDatatypeSupport=true so that complex columns are
+        /// passed through as native Arrow types. Interval/duration columns are always converted to
+        /// strings regardless of this flag.
+        /// </param>
+        public ComplexTypeSerializingStream(IArrowArrayStream inner, bool serializeComplexTypes = true)
         {
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-            (_schema, _complexColumnIndices) = BuildStringSchema(inner.Schema);
+            (_schema, _complexColumnIndices, _intervalColumnOriginalTypes) = BuildStringSchema(inner.Schema, serializeComplexTypes);
         }
 
         public Schema Schema => _schema;
@@ -54,25 +91,30 @@ namespace AdbcDrivers.Databricks
             if (batch == null)
                 return null;
 
-            if (_complexColumnIndices.Count == 0)
+            if (_complexColumnIndices.Count == 0 && _intervalColumnOriginalTypes.Count == 0)
                 return batch;
 
-            return ConvertComplexColumns(batch);
+            return ConvertColumns(batch);
         }
 
         public void Dispose() => _inner.Dispose();
 
-        private RecordBatch ConvertComplexColumns(RecordBatch batch)
+        private RecordBatch ConvertColumns(RecordBatch batch)
         {
             IArrowArray[] arrays = new IArrowArray[batch.ColumnCount];
             for (int i = 0; i < batch.ColumnCount; i++)
             {
-                arrays[i] = _complexColumnIndices.Contains(i) ? SerializeToStringArray(batch.Column(i)) : batch.Column(i);
+                if (_complexColumnIndices.Contains(i))
+                    arrays[i] = SerializeComplexToStringArray(batch.Column(i));
+                else if (_intervalColumnOriginalTypes.TryGetValue(i, out IArrowType? originalType))
+                    arrays[i] = SerializeIntervalToStringArray(batch.Column(i), originalType);
+                else
+                    arrays[i] = batch.Column(i);
             }
             return new RecordBatch(_schema, arrays, batch.Length);
         }
 
-        private static StringArray SerializeToStringArray(IArrowArray array)
+        private static StringArray SerializeComplexToStringArray(IArrowArray array)
         {
             StringArray.Builder builder = new StringArray.Builder();
             for (int i = 0; i < array.Length; i++)
@@ -85,22 +127,62 @@ namespace AdbcDrivers.Databricks
             return builder.Build();
         }
 
+        private static StringArray SerializeIntervalToStringArray(IArrowArray array, IArrowType originalType)
+        {
+            StringArray.Builder builder = new StringArray.Builder();
+            for (int i = 0; i < array.Length; i++)
+            {
+                if (array.IsNull(i))
+                {
+                    builder.AppendNull();
+                }
+                else if (originalType is IntervalType intervalType &&
+                         intervalType.Unit == IntervalUnit.YearMonth)
+                {
+                    YearMonthIntervalArray ymArray = (YearMonthIntervalArray)array;
+                    var value = ymArray.GetValue(i);
+                    builder.Append(value.HasValue
+                        ? FormatYearMonth(value.Value.Months)
+                        : null);
+                }
+                else if (originalType is DurationType durationType)
+                {
+                    DurationArray durationArray = (DurationArray)array;
+                    long? rawValue = durationArray.GetValue(i);
+                    builder.Append(rawValue.HasValue
+                        ? FormatDuration(rawValue.Value, durationType.Unit)
+                        : null);
+                }
+                else
+                {
+                    builder.AppendNull();
+                }
+            }
+            return builder.Build();
+        }
+
         /// <summary>
-        /// Builds a new schema where all complex-type fields are replaced with StringType,
-        /// and returns the set of column indices that were converted.
+        /// Builds a new schema where all converted-type fields are replaced with StringType,
+        /// and returns the sets of column indices that were converted.
         /// </summary>
-        private static (Schema schema, HashSet<int> complexIndices) BuildStringSchema(Schema original)
+        private static (Schema schema, HashSet<int> complexIndices, Dictionary<int, IArrowType> intervalColumns) BuildStringSchema(Schema original, bool serializeComplexTypes)
         {
             List<Field> fields = new List<Field>(original.FieldsList.Count);
-            HashSet<int> indices = new HashSet<int>();
+            HashSet<int> complexIndices = new HashSet<int>();
+            Dictionary<int, IArrowType> intervalColumns = new Dictionary<int, IArrowType>();
 
             for (int i = 0; i < original.FieldsList.Count; i++)
             {
                 Field field = original.FieldsList[i];
-                if (IsComplexType(field.DataType))
+                if (serializeComplexTypes && IsComplexType(field.DataType))
                 {
                     fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
-                    indices.Add(i);
+                    complexIndices.Add(i);
+                }
+                else if (IsIntervalOrDurationType(field.DataType))
+                {
+                    fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
+                    intervalColumns[i] = field.DataType;
                 }
                 else
                 {
@@ -108,11 +190,73 @@ namespace AdbcDrivers.Databricks
                 }
             }
 
-            return (new Schema(fields, original.Metadata), indices);
+            return (new Schema(fields, original.Metadata), complexIndices, intervalColumns);
         }
 
         private static bool IsComplexType(IArrowType type) =>
             type is ListType || type is MapType || type is StructType;
+
+        private static bool IsIntervalOrDurationType(IArrowType type) =>
+            (type is IntervalType intervalType && intervalType.Unit == IntervalUnit.YearMonth) ||
+            type is DurationType;
+
+        // --- Interval/duration formatting helpers ---
+
+        /// <summary>
+        /// Formats a year-month interval (total months) as "Y-M", matching the Thrift output.
+        /// Example: 30 months → "2-6"
+        /// </summary>
+        internal static string FormatYearMonth(int totalMonths)
+        {
+            int years = totalMonths / 12;
+            int months = totalMonths % 12;
+            return $"{years}-{months}";
+        }
+
+        /// <summary>
+        /// Formats a duration value as "D HH:MM:SS.nnnnnnnnn", matching the Thrift output.
+        /// Example: 3 days + 12 h + 30 min + 15 s 500 ms → "3 12:30:15.500000000"
+        /// The <paramref name="unit"/> determines how to interpret <paramref name="rawValue"/>.
+        /// </summary>
+        internal static string FormatDuration(long rawValue, TimeUnit unit)
+        {
+            // Convert to nanoseconds first for uniform handling
+            long nanoseconds = unit switch
+            {
+                TimeUnit.Second => rawValue * 1_000_000_000L,
+                TimeUnit.Millisecond => rawValue * 1_000_000L,
+                TimeUnit.Microsecond => rawValue * 1_000L,
+                TimeUnit.Nanosecond => rawValue,
+                _ => rawValue * 1_000L // default to microseconds
+            };
+
+            // Separate the nanosecond sub-second part from whole seconds
+            long wholeSeconds = nanoseconds / 1_000_000_000L;
+            long subNanos = nanoseconds % 1_000_000_000L;
+
+            // Handle negative values: keep subNanos non-negative
+            if (subNanos < 0)
+            {
+                wholeSeconds -= 1;
+                subNanos += 1_000_000_000L;
+            }
+
+            long days = wholeSeconds / 86400L;
+            long remainderSeconds = wholeSeconds % 86400L;
+
+            // Handle negative days: ensure remainderSeconds is non-negative
+            if (remainderSeconds < 0)
+            {
+                days -= 1;
+                remainderSeconds += 86400L;
+            }
+
+            int hours = (int)(remainderSeconds / 3600L);
+            int minutes = (int)((remainderSeconds % 3600L) / 60L);
+            int seconds = (int)(remainderSeconds % 60L);
+
+            return $"{days} {hours:D2}:{minutes:D2}:{seconds:D2}.{subNanos:D9}";
+        }
 
         // --- JSON serialization helpers ---
 

--- a/csharp/src/ComplexTypeSerializingStream.cs
+++ b/csharp/src/ComplexTypeSerializingStream.cs
@@ -23,6 +23,7 @@ using Apache.Arrow;
 using Apache.Arrow.Adbc.Extensions;
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Types;
+using AdbcDrivers.Databricks.StatementExecution;
 
 namespace AdbcDrivers.Databricks
 {
@@ -41,8 +42,6 @@ namespace AdbcDrivers.Databricks
     /// </summary>
     internal sealed class ComplexTypeSerializingStream : IArrowArrayStream
     {
-        private const string SparkSqlNameKey = "Spark:DataType:SqlName";
-
         private readonly IArrowArrayStream _inner;
         private readonly Schema _schema;
         private readonly HashSet<int> _complexColumnIndices;
@@ -105,7 +104,7 @@ namespace AdbcDrivers.Databricks
             {
                 Field field = schema.FieldsList[i];
                 if (field.Metadata != null &&
-                    field.Metadata.TryGetValue(SparkSqlNameKey, out string? sqlName) &&
+                    field.Metadata.TryGetValue(ColumnMetadataHelper.ArrowMetadataKey, out string? sqlName) &&
                     sqlName != null &&
                     (sqlName.Equals("ARRAY", StringComparison.OrdinalIgnoreCase) ||
                      sqlName.Equals("MAP", StringComparison.OrdinalIgnoreCase) ||

--- a/csharp/src/ComplexTypeSerializingStream.cs
+++ b/csharp/src/ComplexTypeSerializingStream.cs
@@ -122,9 +122,9 @@ namespace AdbcDrivers.Databricks
                 if (field.Metadata != null &&
                     field.Metadata.TryGetValue(ColumnMetadataHelper.ArrowMetadataKey, out string? sqlName) &&
                     sqlName != null &&
-                    (sqlName.Equals("ARRAY", StringComparison.OrdinalIgnoreCase) ||
-                     sqlName.Equals("MAP", StringComparison.OrdinalIgnoreCase) ||
-                     sqlName.Equals("STRUCT", StringComparison.OrdinalIgnoreCase)))
+                    (sqlName.StartsWith("ARRAY", StringComparison.OrdinalIgnoreCase) ||
+                     sqlName.StartsWith("MAP", StringComparison.OrdinalIgnoreCase) ||
+                     sqlName.StartsWith("STRUCT", StringComparison.OrdinalIgnoreCase)))
                 {
                     indices.Add(i);
                 }

--- a/csharp/src/ComplexTypeSerializingStream.cs
+++ b/csharp/src/ComplexTypeSerializingStream.cs
@@ -27,15 +27,22 @@ using Apache.Arrow.Types;
 namespace AdbcDrivers.Databricks
 {
     /// <summary>
-    /// Wraps an <see cref="IArrowArrayStream"/> and converts columns of complex Arrow types
-    /// (LIST, MAP represented as LIST of STRUCTs, STRUCT) into STRING columns containing
-    /// their JSON representation.
+    /// Wraps an <see cref="IArrowArrayStream"/> and converts ARRAY, MAP, and STRUCT columns
+    /// into STRING columns containing their JSON representation.
     ///
     /// This is applied when EnableComplexDatatypeSupport=false (the default), so that SEA
     /// results match the legacy Thrift behavior of returning JSON strings for complex types.
+    ///
+    /// Column detection uses the <c>Spark:DataType:SqlName</c> field metadata set by
+    /// <c>TryGetSchemaFromManifest</c>, so the inner stream must already report the
+    /// manifest schema (which all three result paths — inline, CloudFetch, empty — do).
+    /// The schema exposed to callers is the inner stream's schema unchanged; it already
+    /// has <see cref="StringType"/> for complex columns.
     /// </summary>
     internal sealed class ComplexTypeSerializingStream : IArrowArrayStream
     {
+        private const string SparkSqlNameKey = "Spark:DataType:SqlName";
+
         private readonly IArrowArrayStream _inner;
         private readonly Schema _schema;
         private readonly HashSet<int> _complexColumnIndices;
@@ -43,7 +50,8 @@ namespace AdbcDrivers.Databricks
         public ComplexTypeSerializingStream(IArrowArrayStream inner)
         {
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-            (_schema, _complexColumnIndices) = BuildStringSchema(inner.Schema);
+            _schema = inner.Schema;
+            _complexColumnIndices = DetectComplexColumns(_schema);
         }
 
         public Schema Schema => _schema;
@@ -86,33 +94,28 @@ namespace AdbcDrivers.Databricks
         }
 
         /// <summary>
-        /// Builds a new schema where all complex-type fields are replaced with StringType,
-        /// and returns the set of column indices that were converted.
+        /// Detects complex columns by inspecting the <c>Spark:DataType:SqlName</c> metadata
+        /// on each field. This works for all result paths because they all expose the manifest
+        /// schema, which carries that metadata and already types complex columns as StringType.
         /// </summary>
-        private static (Schema schema, HashSet<int> complexIndices) BuildStringSchema(Schema original)
+        private static HashSet<int> DetectComplexColumns(Schema schema)
         {
-            List<Field> fields = new List<Field>(original.FieldsList.Count);
             HashSet<int> indices = new HashSet<int>();
-
-            for (int i = 0; i < original.FieldsList.Count; i++)
+            for (int i = 0; i < schema.FieldsList.Count; i++)
             {
-                Field field = original.FieldsList[i];
-                if (IsComplexType(field.DataType))
+                Field field = schema.FieldsList[i];
+                if (field.Metadata != null &&
+                    field.Metadata.TryGetValue(SparkSqlNameKey, out string? sqlName) &&
+                    sqlName != null &&
+                    (sqlName.Equals("ARRAY", StringComparison.OrdinalIgnoreCase) ||
+                     sqlName.Equals("MAP", StringComparison.OrdinalIgnoreCase) ||
+                     sqlName.Equals("STRUCT", StringComparison.OrdinalIgnoreCase)))
                 {
-                    fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
                     indices.Add(i);
                 }
-                else
-                {
-                    fields.Add(field);
-                }
             }
-
-            return (new Schema(fields, original.Metadata), indices);
+            return indices;
         }
-
-        private static bool IsComplexType(IArrowType type) =>
-            type is ListType || type is MapType || type is StructType;
 
         // --- JSON serialization helpers ---
 

--- a/csharp/src/ComplexTypeSerializingStream.cs
+++ b/csharp/src/ComplexTypeSerializingStream.cs
@@ -27,60 +27,23 @@ using Apache.Arrow.Types;
 namespace AdbcDrivers.Databricks
 {
     /// <summary>
-    /// Wraps an <see cref="IArrowArrayStream"/> and converts columns that carry
-    /// native Arrow types that must be serialized to strings into STRING columns:
+    /// Wraps an <see cref="IArrowArrayStream"/> and converts columns of complex Arrow types
+    /// (LIST, MAP represented as LIST of STRUCTs, STRUCT) into STRING columns containing
+    /// their JSON representation.
     ///
-    /// <list type="bullet">
-    ///   <item>
-    ///     <description>
-    ///       Complex types (LIST, MAP represented as LIST of STRUCTs, STRUCT) are
-    ///       converted into STRING columns containing their JSON representation.
-    ///       Applied when EnableComplexDatatypeSupport=false (the default) so that SEA
-    ///       results match the legacy Thrift behavior of returning JSON strings for complex types.
-    ///     </description>
-    ///   </item>
-    ///   <item>
-    ///     <description>
-    ///       <see cref="ArrowTypeId.Interval"/> with <see cref="IntervalUnit.YearMonth"/>
-    ///       (<c>YearMonthIntervalArray</c>) → "Y-M" string,
-    ///       e.g. 30 months → "2-6" (2 years, 6 months).
-    ///     </description>
-    ///   </item>
-    ///   <item>
-    ///     <description>
-    ///       <see cref="ArrowTypeId.Duration"/> (<c>DurationArray</c>) → "D HH:MM:SS.nnnnnnnnn"
-    ///       string, e.g. 3 days + 12 h + 30 min + 15 s → "3 12:30:15.000000000".
-    ///       The conversion respects the <see cref="DurationType.Unit"/> of the column.
-    ///     </description>
-    ///   </item>
-    /// </list>
-    ///
-    /// The schema reported to callers is rewritten so that converted columns have
-    /// <see cref="StringType"/> instead of the native type, exactly mirroring what
-    /// the Thrift protocol returns.
+    /// This is applied when EnableComplexDatatypeSupport=false (the default), so that SEA
+    /// results match the legacy Thrift behavior of returning JSON strings for complex types.
     /// </summary>
     internal sealed class ComplexTypeSerializingStream : IArrowArrayStream
     {
         private readonly IArrowArrayStream _inner;
         private readonly Schema _schema;
         private readonly HashSet<int> _complexColumnIndices;
-        // For interval/duration columns we need to know the original type to pick the right formatter
-        private readonly Dictionary<int, IArrowType> _intervalColumnOriginalTypes;
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="ComplexTypeSerializingStream"/>.
-        /// </summary>
-        /// <param name="inner">The underlying Arrow stream to wrap.</param>
-        /// <param name="serializeComplexTypes">
-        /// When <c>true</c> (the default), LIST/MAP/STRUCT columns are serialized to JSON strings.
-        /// Set to <c>false</c> when EnableComplexDatatypeSupport=true so that complex columns are
-        /// passed through as native Arrow types. Interval/duration columns are always converted to
-        /// strings regardless of this flag.
-        /// </param>
-        public ComplexTypeSerializingStream(IArrowArrayStream inner, bool serializeComplexTypes = true)
+        public ComplexTypeSerializingStream(IArrowArrayStream inner)
         {
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-            (_schema, _complexColumnIndices, _intervalColumnOriginalTypes) = BuildStringSchema(inner.Schema, serializeComplexTypes);
+            (_schema, _complexColumnIndices) = BuildStringSchema(inner.Schema);
         }
 
         public Schema Schema => _schema;
@@ -91,30 +54,25 @@ namespace AdbcDrivers.Databricks
             if (batch == null)
                 return null;
 
-            if (_complexColumnIndices.Count == 0 && _intervalColumnOriginalTypes.Count == 0)
+            if (_complexColumnIndices.Count == 0)
                 return batch;
 
-            return ConvertColumns(batch);
+            return ConvertComplexColumns(batch);
         }
 
         public void Dispose() => _inner.Dispose();
 
-        private RecordBatch ConvertColumns(RecordBatch batch)
+        private RecordBatch ConvertComplexColumns(RecordBatch batch)
         {
             IArrowArray[] arrays = new IArrowArray[batch.ColumnCount];
             for (int i = 0; i < batch.ColumnCount; i++)
             {
-                if (_complexColumnIndices.Contains(i))
-                    arrays[i] = SerializeComplexToStringArray(batch.Column(i));
-                else if (_intervalColumnOriginalTypes.TryGetValue(i, out IArrowType? originalType))
-                    arrays[i] = SerializeIntervalToStringArray(batch.Column(i), originalType);
-                else
-                    arrays[i] = batch.Column(i);
+                arrays[i] = _complexColumnIndices.Contains(i) ? SerializeToStringArray(batch.Column(i)) : batch.Column(i);
             }
             return new RecordBatch(_schema, arrays, batch.Length);
         }
 
-        private static StringArray SerializeComplexToStringArray(IArrowArray array)
+        private static StringArray SerializeToStringArray(IArrowArray array)
         {
             StringArray.Builder builder = new StringArray.Builder();
             for (int i = 0; i < array.Length; i++)
@@ -127,62 +85,22 @@ namespace AdbcDrivers.Databricks
             return builder.Build();
         }
 
-        private static StringArray SerializeIntervalToStringArray(IArrowArray array, IArrowType originalType)
-        {
-            StringArray.Builder builder = new StringArray.Builder();
-            for (int i = 0; i < array.Length; i++)
-            {
-                if (array.IsNull(i))
-                {
-                    builder.AppendNull();
-                }
-                else if (originalType is IntervalType intervalType &&
-                         intervalType.Unit == IntervalUnit.YearMonth)
-                {
-                    YearMonthIntervalArray ymArray = (YearMonthIntervalArray)array;
-                    var value = ymArray.GetValue(i);
-                    builder.Append(value.HasValue
-                        ? FormatYearMonth(value.Value.Months)
-                        : null);
-                }
-                else if (originalType is DurationType durationType)
-                {
-                    DurationArray durationArray = (DurationArray)array;
-                    long? rawValue = durationArray.GetValue(i);
-                    builder.Append(rawValue.HasValue
-                        ? FormatDuration(rawValue.Value, durationType.Unit)
-                        : null);
-                }
-                else
-                {
-                    builder.AppendNull();
-                }
-            }
-            return builder.Build();
-        }
-
         /// <summary>
-        /// Builds a new schema where all converted-type fields are replaced with StringType,
-        /// and returns the sets of column indices that were converted.
+        /// Builds a new schema where all complex-type fields are replaced with StringType,
+        /// and returns the set of column indices that were converted.
         /// </summary>
-        private static (Schema schema, HashSet<int> complexIndices, Dictionary<int, IArrowType> intervalColumns) BuildStringSchema(Schema original, bool serializeComplexTypes)
+        private static (Schema schema, HashSet<int> complexIndices) BuildStringSchema(Schema original)
         {
             List<Field> fields = new List<Field>(original.FieldsList.Count);
-            HashSet<int> complexIndices = new HashSet<int>();
-            Dictionary<int, IArrowType> intervalColumns = new Dictionary<int, IArrowType>();
+            HashSet<int> indices = new HashSet<int>();
 
             for (int i = 0; i < original.FieldsList.Count; i++)
             {
                 Field field = original.FieldsList[i];
-                if (serializeComplexTypes && IsComplexType(field.DataType))
+                if (IsComplexType(field.DataType))
                 {
                     fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
-                    complexIndices.Add(i);
-                }
-                else if (IsIntervalOrDurationType(field.DataType))
-                {
-                    fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
-                    intervalColumns[i] = field.DataType;
+                    indices.Add(i);
                 }
                 else
                 {
@@ -190,73 +108,11 @@ namespace AdbcDrivers.Databricks
                 }
             }
 
-            return (new Schema(fields, original.Metadata), complexIndices, intervalColumns);
+            return (new Schema(fields, original.Metadata), indices);
         }
 
         private static bool IsComplexType(IArrowType type) =>
             type is ListType || type is MapType || type is StructType;
-
-        private static bool IsIntervalOrDurationType(IArrowType type) =>
-            (type is IntervalType intervalType && intervalType.Unit == IntervalUnit.YearMonth) ||
-            type is DurationType;
-
-        // --- Interval/duration formatting helpers ---
-
-        /// <summary>
-        /// Formats a year-month interval (total months) as "Y-M", matching the Thrift output.
-        /// Example: 30 months → "2-6"
-        /// </summary>
-        internal static string FormatYearMonth(int totalMonths)
-        {
-            int years = totalMonths / 12;
-            int months = totalMonths % 12;
-            return $"{years}-{months}";
-        }
-
-        /// <summary>
-        /// Formats a duration value as "D HH:MM:SS.nnnnnnnnn", matching the Thrift output.
-        /// Example: 3 days + 12 h + 30 min + 15 s 500 ms → "3 12:30:15.500000000"
-        /// The <paramref name="unit"/> determines how to interpret <paramref name="rawValue"/>.
-        /// </summary>
-        internal static string FormatDuration(long rawValue, TimeUnit unit)
-        {
-            // Convert to nanoseconds first for uniform handling
-            long nanoseconds = unit switch
-            {
-                TimeUnit.Second => rawValue * 1_000_000_000L,
-                TimeUnit.Millisecond => rawValue * 1_000_000L,
-                TimeUnit.Microsecond => rawValue * 1_000L,
-                TimeUnit.Nanosecond => rawValue,
-                _ => rawValue * 1_000L // default to microseconds
-            };
-
-            // Separate the nanosecond sub-second part from whole seconds
-            long wholeSeconds = nanoseconds / 1_000_000_000L;
-            long subNanos = nanoseconds % 1_000_000_000L;
-
-            // Handle negative values: keep subNanos non-negative
-            if (subNanos < 0)
-            {
-                wholeSeconds -= 1;
-                subNanos += 1_000_000_000L;
-            }
-
-            long days = wholeSeconds / 86400L;
-            long remainderSeconds = wholeSeconds % 86400L;
-
-            // Handle negative days: ensure remainderSeconds is non-negative
-            if (remainderSeconds < 0)
-            {
-                days -= 1;
-                remainderSeconds += 86400L;
-            }
-
-            int hours = (int)(remainderSeconds / 3600L);
-            int minutes = (int)((remainderSeconds % 3600L) / 60L);
-            int seconds = (int)(remainderSeconds % 60L);
-
-            return $"{days} {hours:D2}:{minutes:D2}:{seconds:D2}.{subNanos:D9}";
-        }
 
         // --- JSON serialization helpers ---
 

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -188,24 +188,34 @@ namespace AdbcDrivers.Databricks
         /// </summary>
         internal static string FormatDuration(long rawValue, TimeUnit unit)
         {
-            long nanoseconds = unit switch
+            // Derive (wholeSeconds, subNanos) directly in the source unit to avoid intermediate
+            // nanosecond overflow. Multiplying rawValue * 1e9 (or * 1e6) to convert to nanoseconds
+            // first overflows int64 for values near the Databricks limit of ±106,751,991 days,
+            // which is representable in microseconds (Long.MAX_VALUE µs) but not in nanoseconds.
+            if (rawValue == long.MinValue) rawValue += 1;  // guard negation overflow
+            bool neg = rawValue < 0;
+            long abs = neg ? -rawValue : rawValue;
+
+            long wholeSeconds, subNanos;
+            switch (unit)
             {
-                TimeUnit.Second => rawValue * 1_000_000_000L,
-                TimeUnit.Millisecond => rawValue * 1_000_000L,
-                TimeUnit.Microsecond => rawValue * 1_000L,
-                TimeUnit.Nanosecond => rawValue,
-                _ => rawValue * 1_000L
-            };
-
-            // Mirror JDBC: negate upfront, format the absolute value, prepend sign.
-            // This matches the server output for negative intervals (e.g. -3 days 12:30:15
-            // → "-3 12:30:15.000000000", not the floor-carry form "-4 11:29:45.000000000").
-            if (nanoseconds == long.MinValue) nanoseconds += 1;  // guard negation overflow
-            bool neg = nanoseconds < 0;
-            if (neg) nanoseconds = -nanoseconds;
-
-            long wholeSeconds = nanoseconds / 1_000_000_000L;
-            long subNanos = nanoseconds % 1_000_000_000L;
+                case TimeUnit.Second:
+                    wholeSeconds = abs;
+                    subNanos = 0;
+                    break;
+                case TimeUnit.Millisecond:
+                    wholeSeconds = abs / 1_000L;
+                    subNanos = (abs % 1_000L) * 1_000_000L;
+                    break;
+                case TimeUnit.Nanosecond:
+                    wholeSeconds = abs / 1_000_000_000L;
+                    subNanos = abs % 1_000_000_000L;
+                    break;
+                default: // Microsecond (Databricks SEA default) and unknown units
+                    wholeSeconds = abs / 1_000_000L;
+                    subNanos = (abs % 1_000_000L) * 1_000L;
+                    break;
+            }
 
             long days = wholeSeconds / 86400L;
             long remainderSeconds = wholeSeconds % 86400L;

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -22,6 +22,7 @@ using Apache.Arrow;
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Scalars;
 using Apache.Arrow.Types;
+using AdbcDrivers.Databricks.StatementExecution;
 
 namespace AdbcDrivers.Databricks
 {
@@ -55,8 +56,6 @@ namespace AdbcDrivers.Databricks
     /// </summary>
     internal sealed class IntervalSerializingStream : IArrowArrayStream
     {
-        private const string SparkSqlNameKey = "Spark:DataType:SqlName";
-
         private readonly IArrowArrayStream _inner;
         private readonly Schema _schema;
         private readonly HashSet<int> _intervalColumnIndices;
@@ -96,7 +95,7 @@ namespace AdbcDrivers.Databricks
             {
                 Field field = schema.FieldsList[i];
                 if (field.Metadata != null &&
-                    field.Metadata.TryGetValue(SparkSqlNameKey, out string? sqlName) &&
+                    field.Metadata.TryGetValue(ColumnMetadataHelper.ArrowMetadataKey, out string? sqlName) &&
                     sqlName != null &&
                     sqlName.StartsWith("INTERVAL", StringComparison.OrdinalIgnoreCase))
                 {

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -56,13 +56,11 @@ namespace AdbcDrivers.Databricks
         private readonly Schema _schema;
         private readonly HashSet<int> _intervalColumnIndices;
 
-        // Arrow field metadata key set by the Databricks server and by TryGetSchemaFromManifest.
-        private const string SparkSqlNameKey = "Spark:DataType:SqlName";
-
-        public IntervalSerializingStream(IArrowArrayStream inner)
+        public IntervalSerializingStream(IArrowArrayStream inner, Schema schema, IReadOnlyCollection<int> intervalColumnIndices)
         {
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-            (_schema, _intervalColumnIndices) = BuildStringSchema(inner.Schema);
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+            _intervalColumnIndices = new HashSet<int>(intervalColumnIndices);
         }
 
         public Schema Schema => _schema;
@@ -121,36 +119,6 @@ namespace AdbcDrivers.Databricks
                     builder.AppendNull();
             }
             return builder.Build();
-        }
-
-        private static (Schema schema, HashSet<int> intervalIndices) BuildStringSchema(Schema original)
-        {
-            List<Field> fields = new List<Field>(original.FieldsList.Count);
-            HashSet<int> indices = new HashSet<int>();
-
-            for (int i = 0; i < original.FieldsList.Count; i++)
-            {
-                Field field = original.FieldsList[i];
-                if (IsIntervalByMetadata(field))
-                {
-                    fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
-                    indices.Add(i);
-                }
-                else
-                {
-                    fields.Add(field);
-                }
-            }
-
-            return (new Schema(fields, original.Metadata), indices);
-        }
-
-        private static bool IsIntervalByMetadata(Field field)
-        {
-            return field.Metadata != null &&
-                   field.Metadata.TryGetValue(SparkSqlNameKey, out string? sqlName) &&
-                   sqlName != null &&
-                   sqlName.StartsWith("INTERVAL", StringComparison.OrdinalIgnoreCase);
         }
 
         // --- Formatting helpers ---

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -47,20 +47,25 @@ namespace AdbcDrivers.Databricks
     ///   </item>
     /// </list>
     ///
-    /// The schema reported to callers is rewritten so that converted columns have
-    /// <see cref="StringType"/> instead of the native type.
+    /// Column detection uses the <c>Spark:DataType:SqlName</c> field metadata set by
+    /// <c>TryGetSchemaFromManifest</c>, so the inner stream must already report the
+    /// manifest schema (which all three result paths — inline, CloudFetch, empty — do).
+    /// The schema exposed to callers is the inner stream's schema unchanged; it already
+    /// has <see cref="StringType"/> for interval columns.
     /// </summary>
     internal sealed class IntervalSerializingStream : IArrowArrayStream
     {
+        private const string SparkSqlNameKey = "Spark:DataType:SqlName";
+
         private readonly IArrowArrayStream _inner;
         private readonly Schema _schema;
         private readonly HashSet<int> _intervalColumnIndices;
 
-        public IntervalSerializingStream(IArrowArrayStream inner, Schema schema, IReadOnlyCollection<int> intervalColumnIndices)
+        public IntervalSerializingStream(IArrowArrayStream inner)
         {
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
-            _intervalColumnIndices = new HashSet<int>(intervalColumnIndices);
+            _schema = inner.Schema;
+            _intervalColumnIndices = DetectIntervalColumns(_schema);
         }
 
         public Schema Schema => _schema;
@@ -78,6 +83,28 @@ namespace AdbcDrivers.Databricks
         }
 
         public void Dispose() => _inner.Dispose();
+
+        /// <summary>
+        /// Detects interval columns by inspecting the <c>Spark:DataType:SqlName</c> metadata
+        /// on each field. This works for all result paths because they all expose the manifest
+        /// schema, which carries that metadata.
+        /// </summary>
+        private static HashSet<int> DetectIntervalColumns(Schema schema)
+        {
+            var indices = new HashSet<int>();
+            for (int i = 0; i < schema.FieldsList.Count; i++)
+            {
+                Field field = schema.FieldsList[i];
+                if (field.Metadata != null &&
+                    field.Metadata.TryGetValue(SparkSqlNameKey, out string? sqlName) &&
+                    sqlName != null &&
+                    sqlName.StartsWith("INTERVAL", StringComparison.OrdinalIgnoreCase))
+                {
+                    indices.Add(i);
+                }
+            }
+            return indices;
+        }
 
         private RecordBatch ConvertColumns(RecordBatch batch)
         {

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -20,7 +20,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow;
 using Apache.Arrow.Ipc;
-using Apache.Arrow.Scalars;
 using Apache.Arrow.Types;
 using AdbcDrivers.Databricks.StatementExecution;
 
@@ -175,9 +174,11 @@ namespace AdbcDrivers.Databricks
         /// </summary>
         internal static string FormatYearMonth(int totalMonths)
         {
-            int years = totalMonths / 12;
-            int months = totalMonths % 12;
-            return $"{years}-{months}";
+            bool neg = totalMonths < 0;
+            long abs = Math.Abs((long)totalMonths);  // (long) cast guards int.MinValue
+            long years = abs / 12;
+            long months = abs % 12;
+            return (neg ? "-" : "") + $"{years}-{months}";
         }
 
         /// <summary>
@@ -187,42 +188,33 @@ namespace AdbcDrivers.Databricks
         /// </summary>
         internal static string FormatDuration(long rawValue, TimeUnit unit)
         {
-            // Convert to nanoseconds first for uniform handling
             long nanoseconds = unit switch
             {
                 TimeUnit.Second => rawValue * 1_000_000_000L,
                 TimeUnit.Millisecond => rawValue * 1_000_000L,
                 TimeUnit.Microsecond => rawValue * 1_000L,
                 TimeUnit.Nanosecond => rawValue,
-                _ => rawValue * 1_000L // default to microseconds
+                _ => rawValue * 1_000L
             };
 
-            // Separate the nanosecond sub-second part from whole seconds
+            // Mirror JDBC: negate upfront, format the absolute value, prepend sign.
+            // This matches the server output for negative intervals (e.g. -3 days 12:30:15
+            // → "-3 12:30:15.000000000", not the floor-carry form "-4 11:29:45.000000000").
+            if (nanoseconds == long.MinValue) nanoseconds += 1;  // guard negation overflow
+            bool neg = nanoseconds < 0;
+            if (neg) nanoseconds = -nanoseconds;
+
             long wholeSeconds = nanoseconds / 1_000_000_000L;
             long subNanos = nanoseconds % 1_000_000_000L;
 
-            // Handle negative values: keep subNanos non-negative
-            if (subNanos < 0)
-            {
-                wholeSeconds -= 1;
-                subNanos += 1_000_000_000L;
-            }
-
             long days = wholeSeconds / 86400L;
             long remainderSeconds = wholeSeconds % 86400L;
-
-            // Handle negative days: ensure remainderSeconds is non-negative
-            if (remainderSeconds < 0)
-            {
-                days -= 1;
-                remainderSeconds += 86400L;
-            }
 
             int hours = (int)(remainderSeconds / 3600L);
             int minutes = (int)((remainderSeconds % 3600L) / 60L);
             int seconds = (int)(remainderSeconds % 60L);
 
-            return $"{days} {hours:D2}:{minutes:D2}:{seconds:D2}.{subNanos:D9}";
+            return (neg ? "-" : "") + $"{days} {hours:D2}:{minutes:D2}:{seconds:D2}.{subNanos:D9}";
         }
     }
 }

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -48,11 +48,27 @@ namespace AdbcDrivers.Databricks
     ///   </item>
     /// </list>
     ///
-    /// Column detection uses the <c>Spark:DataType:SqlName</c> field metadata set by
-    /// <c>TryGetSchemaFromManifest</c>, so the inner stream must already report the
-    /// manifest schema (which all three result paths — inline, CloudFetch, empty — do).
-    /// The schema exposed to callers is the inner stream's schema unchanged; it already
-    /// has <see cref="StringType"/> for interval columns.
+    /// <para><strong>Why both schema and data must be converted:</strong>
+    /// Unlike the JDBC driver, which returns <c>java.lang.Object</c> from <c>getObject()</c>
+    /// and can freely convert a native interval value to a string without touching the declared
+    /// type, <see cref="IArrowArrayStream"/> is a strongly-typed Arrow contract: the
+    /// <see cref="Schema"/> and the arrays inside each <see cref="RecordBatch"/> must agree on
+    /// the column type. This stream therefore changes both — the schema it exposes is already
+    /// <see cref="StringType"/> (coming from the manifest via
+    /// <c>TryGetSchemaFromManifest</c>), and the data arrays are converted to
+    /// <see cref="StringArray"/> at read time.
+    /// </para>
+    ///
+    /// <para><strong>Column detection:</strong>
+    /// Interval columns are identified by the <c>Spark:DataType:SqlName</c> field metadata
+    /// (<see cref="ColumnMetadataHelper.ArrowMetadataKey"/>) that
+    /// <c>TryGetSchemaFromManifest</c> embeds when building the manifest schema.
+    /// For SEA results the server may not include this key in the Arrow IPC field metadata
+    /// (unlike Thrift, where the server always embeds it); by computing it from the manifest
+    /// upfront we make detection consistent across all three result paths — inline, CloudFetch,
+    /// and empty. The actual Arrow subtype (year-month vs. day-time) is resolved at read time
+    /// by inspecting the incoming array type, not the metadata string.
+    /// </para>
     /// </summary>
     internal sealed class IntervalSerializingStream : IArrowArrayStream
     {
@@ -141,6 +157,10 @@ namespace AdbcDrivers.Databricks
             }
             else
             {
+                // The column was detected as INTERVAL via SqlName metadata but the
+                // underlying array is neither YearMonthIntervalArray nor DurationArray.
+                // This should not happen in practice — the SEA server always sends native
+                // interval types for INTERVAL columns — but null-fill defensively.
                 for (int i = 0; i < array.Length; i++)
                     builder.AppendNull();
             }

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -1,0 +1,212 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Scalars;
+using Apache.Arrow.Types;
+
+namespace AdbcDrivers.Databricks
+{
+    /// <summary>
+    /// Wraps an <see cref="IArrowArrayStream"/> and converts native Arrow interval and duration
+    /// columns to canonical UTF-8 string columns, matching the string representation that the
+    /// Thrift protocol returns:
+    ///
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///       <see cref="ArrowTypeId.Interval"/> with <see cref="IntervalUnit.YearMonth"/>
+    ///       (<c>YearMonthIntervalArray</c>) → "Y-M" string,
+    ///       e.g. 30 months → "2-6" (2 years, 6 months).
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///       <see cref="ArrowTypeId.Duration"/> (<c>DurationArray</c>) → "D HH:MM:SS.nnnnnnnnn"
+    ///       string, e.g. 3 days + 12 h + 30 min + 15 s → "3 12:30:15.000000000".
+    ///       The conversion respects the <see cref="DurationType.Unit"/> of the column.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    ///
+    /// The schema reported to callers is rewritten so that converted columns have
+    /// <see cref="StringType"/> instead of the native type.
+    /// </summary>
+    internal sealed class IntervalSerializingStream : IArrowArrayStream
+    {
+        private readonly IArrowArrayStream _inner;
+        private readonly Schema _schema;
+        // Maps column index → original interval/duration type, used to pick the right formatter
+        private readonly Dictionary<int, IArrowType> _intervalColumns;
+
+        public IntervalSerializingStream(IArrowArrayStream inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            (_schema, _intervalColumns) = BuildStringSchema(inner.Schema);
+        }
+
+        public Schema Schema => _schema;
+
+        public async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+        {
+            RecordBatch? batch = await _inner.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false);
+            if (batch == null)
+                return null;
+
+            if (_intervalColumns.Count == 0)
+                return batch;
+
+            return ConvertColumns(batch);
+        }
+
+        public void Dispose() => _inner.Dispose();
+
+        private RecordBatch ConvertColumns(RecordBatch batch)
+        {
+            IArrowArray[] arrays = new IArrowArray[batch.ColumnCount];
+            for (int i = 0; i < batch.ColumnCount; i++)
+            {
+                arrays[i] = _intervalColumns.TryGetValue(i, out IArrowType? originalType)
+                    ? SerializeIntervalToStringArray(batch.Column(i), originalType)
+                    : batch.Column(i);
+            }
+            return new RecordBatch(_schema, arrays, batch.Length);
+        }
+
+        private static StringArray SerializeIntervalToStringArray(IArrowArray array, IArrowType originalType)
+        {
+            StringArray.Builder builder = new StringArray.Builder();
+            for (int i = 0; i < array.Length; i++)
+            {
+                if (array.IsNull(i))
+                {
+                    builder.AppendNull();
+                }
+                else if (originalType is IntervalType intervalType &&
+                         intervalType.Unit == IntervalUnit.YearMonth)
+                {
+                    YearMonthIntervalArray ymArray = (YearMonthIntervalArray)array;
+                    var value = ymArray.GetValue(i);
+                    builder.Append(value.HasValue
+                        ? FormatYearMonth(value.Value.Months)
+                        : null);
+                }
+                else if (originalType is DurationType durationType)
+                {
+                    DurationArray durationArray = (DurationArray)array;
+                    long? rawValue = durationArray.GetValue(i);
+                    builder.Append(rawValue.HasValue
+                        ? FormatDuration(rawValue.Value, durationType.Unit)
+                        : null);
+                }
+                else
+                {
+                    builder.AppendNull();
+                }
+            }
+            return builder.Build();
+        }
+
+        private static (Schema schema, Dictionary<int, IArrowType> intervalColumns) BuildStringSchema(Schema original)
+        {
+            List<Field> fields = new List<Field>(original.FieldsList.Count);
+            Dictionary<int, IArrowType> intervalColumns = new Dictionary<int, IArrowType>();
+
+            for (int i = 0; i < original.FieldsList.Count; i++)
+            {
+                Field field = original.FieldsList[i];
+                if (IsIntervalOrDurationType(field.DataType))
+                {
+                    fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
+                    intervalColumns[i] = field.DataType;
+                }
+                else
+                {
+                    fields.Add(field);
+                }
+            }
+
+            return (new Schema(fields, original.Metadata), intervalColumns);
+        }
+
+        private static bool IsIntervalOrDurationType(IArrowType type) =>
+            (type is IntervalType intervalType && intervalType.Unit == IntervalUnit.YearMonth) ||
+            type is DurationType;
+
+        // --- Formatting helpers ---
+
+        /// <summary>
+        /// Formats a year-month interval (total months) as "Y-M", matching the Thrift output.
+        /// Example: 30 months → "2-6"
+        /// </summary>
+        internal static string FormatYearMonth(int totalMonths)
+        {
+            int years = totalMonths / 12;
+            int months = totalMonths % 12;
+            return $"{years}-{months}";
+        }
+
+        /// <summary>
+        /// Formats a duration value as "D HH:MM:SS.nnnnnnnnn", matching the Thrift output.
+        /// Example: 3 days + 12 h + 30 min + 15 s 500 ms → "3 12:30:15.500000000"
+        /// The <paramref name="unit"/> determines how to interpret <paramref name="rawValue"/>.
+        /// </summary>
+        internal static string FormatDuration(long rawValue, TimeUnit unit)
+        {
+            // Convert to nanoseconds first for uniform handling
+            long nanoseconds = unit switch
+            {
+                TimeUnit.Second => rawValue * 1_000_000_000L,
+                TimeUnit.Millisecond => rawValue * 1_000_000L,
+                TimeUnit.Microsecond => rawValue * 1_000L,
+                TimeUnit.Nanosecond => rawValue,
+                _ => rawValue * 1_000L // default to microseconds
+            };
+
+            // Separate the nanosecond sub-second part from whole seconds
+            long wholeSeconds = nanoseconds / 1_000_000_000L;
+            long subNanos = nanoseconds % 1_000_000_000L;
+
+            // Handle negative values: keep subNanos non-negative
+            if (subNanos < 0)
+            {
+                wholeSeconds -= 1;
+                subNanos += 1_000_000_000L;
+            }
+
+            long days = wholeSeconds / 86400L;
+            long remainderSeconds = wholeSeconds % 86400L;
+
+            // Handle negative days: ensure remainderSeconds is non-negative
+            if (remainderSeconds < 0)
+            {
+                days -= 1;
+                remainderSeconds += 86400L;
+            }
+
+            int hours = (int)(remainderSeconds / 3600L);
+            int minutes = (int)((remainderSeconds % 3600L) / 60L);
+            int seconds = (int)(remainderSeconds % 60L);
+
+            return $"{days} {hours:D2}:{minutes:D2}:{seconds:D2}.{subNanos:D9}";
+        }
+    }
+}

--- a/csharp/src/IntervalSerializingStream.cs
+++ b/csharp/src/IntervalSerializingStream.cs
@@ -54,13 +54,15 @@ namespace AdbcDrivers.Databricks
     {
         private readonly IArrowArrayStream _inner;
         private readonly Schema _schema;
-        // Maps column index → original interval/duration type, used to pick the right formatter
-        private readonly Dictionary<int, IArrowType> _intervalColumns;
+        private readonly HashSet<int> _intervalColumnIndices;
+
+        // Arrow field metadata key set by the Databricks server and by TryGetSchemaFromManifest.
+        private const string SparkSqlNameKey = "Spark:DataType:SqlName";
 
         public IntervalSerializingStream(IArrowArrayStream inner)
         {
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-            (_schema, _intervalColumns) = BuildStringSchema(inner.Schema);
+            (_schema, _intervalColumnIndices) = BuildStringSchema(inner.Schema);
         }
 
         public Schema Schema => _schema;
@@ -71,7 +73,7 @@ namespace AdbcDrivers.Databricks
             if (batch == null)
                 return null;
 
-            if (_intervalColumns.Count == 0)
+            if (_intervalColumnIndices.Count == 0)
                 return batch;
 
             return ConvertColumns(batch);
@@ -84,59 +86,55 @@ namespace AdbcDrivers.Databricks
             IArrowArray[] arrays = new IArrowArray[batch.ColumnCount];
             for (int i = 0; i < batch.ColumnCount; i++)
             {
-                arrays[i] = _intervalColumns.TryGetValue(i, out IArrowType? originalType)
-                    ? SerializeIntervalToStringArray(batch.Column(i), originalType)
+                arrays[i] = _intervalColumnIndices.Contains(i)
+                    ? SerializeIntervalToStringArray(batch.Column(i))
                     : batch.Column(i);
             }
             return new RecordBatch(_schema, arrays, batch.Length);
         }
 
-        private static StringArray SerializeIntervalToStringArray(IArrowArray array, IArrowType originalType)
+        private static StringArray SerializeIntervalToStringArray(IArrowArray array)
         {
             StringArray.Builder builder = new StringArray.Builder();
-            for (int i = 0; i < array.Length; i++)
+            if (array is YearMonthIntervalArray ymArray)
             {
-                if (array.IsNull(i))
+                for (int i = 0; i < array.Length; i++)
                 {
-                    builder.AppendNull();
-                }
-                else if (originalType is IntervalType intervalType &&
-                         intervalType.Unit == IntervalUnit.YearMonth)
-                {
-                    YearMonthIntervalArray ymArray = (YearMonthIntervalArray)array;
+                    if (array.IsNull(i)) { builder.AppendNull(); continue; }
                     var value = ymArray.GetValue(i);
-                    builder.Append(value.HasValue
-                        ? FormatYearMonth(value.Value.Months)
-                        : null);
+                    builder.Append(value.HasValue ? FormatYearMonth(value.Value.Months) : null);
                 }
-                else if (originalType is DurationType durationType)
+            }
+            else if (array is DurationArray durationArray)
+            {
+                DurationType durationType = (DurationType)durationArray.Data.DataType;
+                for (int i = 0; i < array.Length; i++)
                 {
-                    DurationArray durationArray = (DurationArray)array;
+                    if (array.IsNull(i)) { builder.AppendNull(); continue; }
                     long? rawValue = durationArray.GetValue(i);
-                    builder.Append(rawValue.HasValue
-                        ? FormatDuration(rawValue.Value, durationType.Unit)
-                        : null);
+                    builder.Append(rawValue.HasValue ? FormatDuration(rawValue.Value, durationType.Unit) : null);
                 }
-                else
-                {
+            }
+            else
+            {
+                for (int i = 0; i < array.Length; i++)
                     builder.AppendNull();
-                }
             }
             return builder.Build();
         }
 
-        private static (Schema schema, Dictionary<int, IArrowType> intervalColumns) BuildStringSchema(Schema original)
+        private static (Schema schema, HashSet<int> intervalIndices) BuildStringSchema(Schema original)
         {
             List<Field> fields = new List<Field>(original.FieldsList.Count);
-            Dictionary<int, IArrowType> intervalColumns = new Dictionary<int, IArrowType>();
+            HashSet<int> indices = new HashSet<int>();
 
             for (int i = 0; i < original.FieldsList.Count; i++)
             {
                 Field field = original.FieldsList[i];
-                if (IsIntervalOrDurationType(field.DataType))
+                if (IsIntervalByMetadata(field))
                 {
                     fields.Add(new Field(field.Name, StringType.Default, field.IsNullable, field.Metadata));
-                    intervalColumns[i] = field.DataType;
+                    indices.Add(i);
                 }
                 else
                 {
@@ -144,12 +142,16 @@ namespace AdbcDrivers.Databricks
                 }
             }
 
-            return (new Schema(fields, original.Metadata), intervalColumns);
+            return (new Schema(fields, original.Metadata), indices);
         }
 
-        private static bool IsIntervalOrDurationType(IArrowType type) =>
-            (type is IntervalType intervalType && intervalType.Unit == IntervalUnit.YearMonth) ||
-            type is DurationType;
+        private static bool IsIntervalByMetadata(Field field)
+        {
+            return field.Metadata != null &&
+                   field.Metadata.TryGetValue(SparkSqlNameKey, out string? sqlName) &&
+                   sqlName != null &&
+                   sqlName.StartsWith("INTERVAL", StringComparison.OrdinalIgnoreCase);
+        }
 
         // --- Formatting helpers ---
 

--- a/csharp/src/StatementExecution/ColumnMetadataHelper.cs
+++ b/csharp/src/StatementExecution/ColumnMetadataHelper.cs
@@ -102,9 +102,25 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
-        /// Arrow field metadata key used to carry the Spark SQL type name.
+        /// Arrow field metadata key that carries the Spark SQL type name for a column,
+        /// e.g. <c>"INTERVAL YEAR TO MONTH"</c>, <c>"ARRAY"</c>, <c>"TIMESTAMP"</c>.
+        ///
+        /// <para>
+        /// For Thrift results the Databricks server embeds this key directly inside the
+        /// Arrow IPC field metadata. For SEA (Statement Execution API) results the server
+        /// may or may not embed it in the IPC files; JDBC handles the missing-key case by
+        /// falling back to <c>ColumnInfo.typeText</c> from the manifest JSON
+        /// (<c>ArrowStreamResult.getObject</c>, JDBC source). In this driver we always
+        /// compute and embed the value ourselves in <see cref="TryGetSchemaFromManifest"/>
+        /// via <see cref="GetSparkSqlName"/>, so downstream stream wrappers
+        /// (<see cref="IntervalSerializingStream"/>, <see cref="ComplexTypeSerializingStream"/>)
+        /// can rely on it being present regardless of result path.
+        /// </para>
+        ///
+        /// <para>
         /// Mirrors <c>ARROW_METADATA_KEY</c> in the JDBC driver
         /// (<c>DatabricksJdbcConstants.java</c>).
+        /// </para>
         /// </summary>
         internal const string ArrowMetadataKey = "Spark:DataType:SqlName";
 

--- a/csharp/src/StatementExecution/ColumnMetadataHelper.cs
+++ b/csharp/src/StatementExecution/ColumnMetadataHelper.cs
@@ -103,16 +103,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         /// <summary>
         /// Arrow field metadata key that carries the Spark SQL type name for a column,
-        /// e.g. <c>"INTERVAL YEAR TO MONTH"</c>, <c>"ARRAY"</c>, <c>"TIMESTAMP"</c>.
+        /// e.g. <c>"INTERVAL YEAR TO MONTH"</c>, <c>"ARRAY&lt;INT&gt;"</c>, <c>"TIMESTAMP_NTZ"</c>.
         ///
         /// <para>
         /// For Thrift results the Databricks server embeds this key directly inside the
-        /// Arrow IPC field metadata. For SEA (Statement Execution API) results the server
-        /// may or may not embed it in the IPC files; JDBC handles the missing-key case by
-        /// falling back to <c>ColumnInfo.typeText</c> from the manifest JSON
-        /// (<c>ArrowStreamResult.getObject</c>, JDBC source). In this driver we always
-        /// compute and embed the value ourselves in <see cref="TryGetSchemaFromManifest"/>
-        /// via <see cref="GetSparkSqlName"/>, so downstream stream wrappers
+        /// Arrow IPC field metadata. For SEA results we embed it ourselves using
+        /// <c>column.TypeText</c> from the manifest, which matches the Thrift server's
+        /// values exactly (verified on live warehouse). Downstream stream wrappers
         /// (<see cref="IntervalSerializingStream"/>, <see cref="ComplexTypeSerializingStream"/>)
         /// can rely on it being present regardless of result path.
         /// </para>
@@ -123,30 +120,6 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// </para>
         /// </summary>
         internal const string ArrowMetadataKey = "Spark:DataType:SqlName";
-
-        // Corrections applied on top of GetBaseTypeName to produce the exact names
-        // the Thrift server embeds in Spark:DataType:SqlName Arrow metadata.
-        private static readonly Dictionary<string, string> s_sparkSqlNameOverrides = new(StringComparer.OrdinalIgnoreCase)
-        {
-            { "INTEGER", "INT" },
-            { "REAL", "FLOAT" },
-        };
-
-        /// <summary>
-        /// Returns the Spark:DataType:SqlName value for Arrow field metadata.
-        /// Uses the same SqlTypeNameParser as GetBaseTypeName, then applies overrides
-        /// for INTEGER→INT and REAL→FLOAT. TIMESTAMP_NTZ collapses to TIMESTAMP
-        /// (matching the Thrift server and Power BI connector expectations).
-        /// </summary>
-        internal static string GetSparkSqlName(string typeName)
-        {
-            string baseName = GetBaseTypeName(typeName);
-
-            if (s_sparkSqlNameOverrides.TryGetValue(baseName, out string? overridden))
-                return overridden;
-
-            return baseName;
-        }
 
         internal static int? GetColumnSizeDefault(string typeName)
         {

--- a/csharp/src/StatementExecution/ColumnMetadataHelper.cs
+++ b/csharp/src/StatementExecution/ColumnMetadataHelper.cs
@@ -101,6 +101,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
             return upper;
         }
 
+        /// <summary>
+        /// Arrow field metadata key used to carry the Spark SQL type name.
+        /// Mirrors <c>ARROW_METADATA_KEY</c> in the JDBC driver
+        /// (<c>DatabricksJdbcConstants.java</c>).
+        /// </summary>
+        internal const string ArrowMetadataKey = "Spark:DataType:SqlName";
+
         // Corrections applied on top of GetBaseTypeName to produce the exact names
         // the Thrift server embeds in Spark:DataType:SqlName Arrow metadata.
         private static readonly Dictionary<string, string> s_sparkSqlNameOverrides = new(StringComparer.OrdinalIgnoreCase)

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -533,9 +533,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 var typeName = column.TypeName ?? string.Empty;
                 var arrowType = MapDatabricksTypeToArrowType(typeName);
                 // Use TypeText (e.g. "INTERVAL YEAR TO MONTH", "ARRAY<INT>") for the SqlName
-                // metadata so it matches what the Thrift server embeds. Fall back to GetSparkSqlName
-                // on the bare TypeName when TypeText is absent.
-                var sqlName = column.TypeText ?? ColumnMetadataHelper.GetSparkSqlName(typeName);
+                // metadata so it matches what the Thrift server embeds. Fall back to GetBaseTypeName
+                // on the bare TypeName when TypeText is absent (handles BYTE→TINYINT etc.).
+                var sqlName = column.TypeText ?? ColumnMetadataHelper.GetBaseTypeName(typeName);
                 var metadata = new Dictionary<string, string>
                 {
                     [ColumnMetadataHelper.ArrowMetadataKey] = sqlName

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -304,9 +304,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Create appropriate reader based on result disposition
             IArrowArrayStream reader = CreateReader(response, cancellationToken);
 
+            // Build the output schema and conversion indices from the manifest upfront.
+            // This avoids embedding detection metadata in Arrow fields — the manifest is the source of truth.
+            Schema manifestSchema = TryGetSchemaFromManifest(response.Manifest) ?? reader.Schema;
+            HashSet<int> intervalIndices = ComputeIntervalIndices(response.Manifest);
+
             // SEA emits YearMonthIntervalType and DurationType; Thrift emits StringType for intervals.
             // Convert interval/duration columns to canonical UTF-8 strings to match Thrift behavior.
-            reader = new IntervalSerializingStream(reader);
+            reader = new IntervalSerializingStream(reader, manifestSchema, intervalIndices);
 
             // When EnableComplexDatatypeSupport=false (default), serialize complex Arrow types to JSON strings
             // so that SEA behavior matches Thrift (which sets ComplexTypesAsArrow=false).
@@ -488,6 +493,20 @@ namespace AdbcDrivers.Databricks.StatementExecution
         {
             return TryGetSchemaFromManifest(manifest)
                 ?? throw new AdbcException("Result manifest does not contain schema information");
+        }
+
+        private static HashSet<int> ComputeIntervalIndices(ResultManifest? manifest)
+        {
+            var indices = new HashSet<int>();
+            var columns = manifest?.Schema?.Columns;
+            if (columns == null) return indices;
+            for (int i = 0; i < columns.Count; i++)
+            {
+                if (ColumnMetadataHelper.GetBaseTypeName(columns[i].TypeName ?? string.Empty)
+                    .StartsWith("INTERVAL", StringComparison.OrdinalIgnoreCase))
+                    indices.Add(i);
+            }
+            return indices;
         }
 
         /// <summary>

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -589,15 +589,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
             var fields = new List<Field>();
             foreach (var column in manifest.Schema.Columns)
             {
-                var typeName = column.TypeName ?? string.Empty;
-                var arrowType = MapDatabricksTypeToArrowType(typeName);
-                // Use TypeText (e.g. "INTERVAL YEAR TO MONTH", "ARRAY<INT>") for the SqlName
-                // metadata so it matches what the Thrift server embeds. Fall back to GetBaseTypeName
-                // on the bare TypeName when TypeText is absent (handles BYTE→TINYINT etc.).
-                var sqlName = column.TypeText ?? ColumnMetadataHelper.GetBaseTypeName(typeName);
+                var typeText = column.TypeText ?? string.Empty;
+                var arrowType = MapDatabricksTypeToArrowType(typeText);
                 var metadata = new Dictionary<string, string>
                 {
-                    [ColumnMetadataHelper.ArrowMetadataKey] = sqlName
+                    [ColumnMetadataHelper.ArrowMetadataKey] = typeText
                 };
                 fields.Add(new Field(column.Name, arrowType, true, metadata));
             }

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -304,13 +304,16 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Create appropriate reader based on result disposition
             IArrowArrayStream reader = CreateReader(response, cancellationToken);
 
-            // ComplexTypeSerializingStream handles two concerns in a single pass:
-            //   1. When EnableComplexDatatypeSupport=false (default), it serializes complex Arrow types
-            //      (LIST, MAP, STRUCT) to JSON strings, matching legacy Thrift behavior.
-            //   2. Always: it converts native Arrow interval/duration types to canonical UTF-8 strings
-            //      so that SEA behavior matches Thrift, which emits interval values as strings.
-            //      SEA emits YearMonthIntervalType and DurationType; Thrift emits StringType for intervals.
-            reader = new ComplexTypeSerializingStream(reader, serializeComplexTypes: !_enableComplexDatatypeSupport);
+            // SEA emits YearMonthIntervalType and DurationType; Thrift emits StringType for intervals.
+            // Convert interval/duration columns to canonical UTF-8 strings to match Thrift behavior.
+            reader = new IntervalSerializingStream(reader);
+
+            // When EnableComplexDatatypeSupport=false (default), serialize complex Arrow types to JSON strings
+            // so that SEA behavior matches Thrift (which sets ComplexTypesAsArrow=false).
+            if (!_enableComplexDatatypeSupport)
+            {
+                reader = new ComplexTypeSerializingStream(reader);
+            }
 
             // Get schema from reader
             var schema = reader.Schema;

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -416,11 +416,6 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 return new EmptyArrowArrayStream();
             }
 
-            // Derive the output schema from the manifest once, for all paths.
-            // JDBC uses the manifest schema exclusively for both inline and CloudFetch results;
-            // the Arrow IPC bytes are only used for data extraction, not schema definition.
-            Schema manifestSchema = GetSchemaFromManifest(response.Manifest);
-
             // Check for external links in manifest chunks or result
             bool hasExternalLinksInChunks = response.Manifest.Chunks != null &&
                                   response.Manifest.Chunks.Count > 0 &&
@@ -434,7 +429,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             if (hasExternalLinks)
             {
                 // Use CloudFetch for external links
-                return CreateCloudFetchReader(response, manifestSchema);
+                return CreateCloudFetchReader(response, GetSchemaFromManifest(response.Manifest));
             }
             else if (response.Result != null && response.Result.Attachment != null && response.Result.Attachment.Length > 0)
             {
@@ -446,16 +441,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 // keeping inline consistent with CloudFetch (which also uses the manifest schema).
                 int totalChunks = response.Manifest?.Chunks?.Count ?? 1;
                 return new InlineArrowStreamReader(_client, _currentStatementId!, response.Result.Attachment,
-                    isLz4Compressed, totalChunks, _lz4BufferPool, cancellationToken, manifestSchema);
+                    isLz4Compressed, totalChunks, _lz4BufferPool, cancellationToken, GetSchemaFromManifest(response.Manifest));
             }
             else
             {
-                // No data rows, but the manifest contains schema information.
-                // Preserve the schema so callers get correct column metadata even
-                // when the queried table is empty — following the same pattern as
-                // the JDBC driver where ResultManifest schema is always extracted
-                // independently of data presence.
-                return new EmptyArrowArrayStream(manifestSchema);
+                // No data rows (e.g. DDL): manifest may have columns_count=0.
+                // Fall back to an empty schema rather than throwing so DDL statements succeed.
+                Schema schema = TryGetSchemaFromManifest(response.Manifest) ?? new Schema.Builder().Build();
+                return new EmptyArrowArrayStream(schema);
             }
         }
 
@@ -539,13 +532,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 var typeName = column.TypeName ?? string.Empty;
                 var arrowType = MapDatabricksTypeToArrowType(typeName);
-                // Embed Spark:DataType:SqlName so downstream stream wrappers and consumers
-                // (e.g. the PowerBI connector's AdjustNativeTypes) can read the SQL type name.
-                // Note: the Thrift server also sets "Spark:DataType:JsonType" alongside SqlName;
-                // that key is not read by any known consumer today, so we omit it here (PECO-2950).
+                // Use TypeText (e.g. "INTERVAL YEAR TO MONTH", "ARRAY<INT>") for the SqlName
+                // metadata so it matches what the Thrift server embeds. Fall back to GetSparkSqlName
+                // on the bare TypeName when TypeText is absent.
+                var sqlName = column.TypeText ?? ColumnMetadataHelper.GetSparkSqlName(typeName);
                 var metadata = new Dictionary<string, string>
                 {
-                    [ColumnMetadataHelper.ArrowMetadataKey] = ColumnMetadataHelper.GetSparkSqlName(typeName)
+                    [ColumnMetadataHelper.ArrowMetadataKey] = sqlName
                 };
                 fields.Add(new Field(column.Name, arrowType, true, metadata));
             }
@@ -566,8 +559,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// </summary>
         private IArrowType MapDatabricksTypeToArrowType(string typeName)
         {
-            // Handle parameterized types (e.g., DECIMAL(10,2), VARCHAR(100))
-            var baseType = typeName.Split('(')[0].ToUpperInvariant();
+            var baseType = ColumnMetadataHelper.GetBaseTypeName(typeName).ToUpperInvariant();
 
             return baseType switch
             {
@@ -810,6 +802,18 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
                 _memoryStream = new System.IO.MemoryStream(allData);
                 _streamReader = new ArrowStreamReader(_memoryStream);
+                // Validate that the IPC schema column count matches the manifest schema.
+                // Type mismatches are expected (manifest uses StringType for interval/complex columns),
+                // but a count mismatch indicates a server bug or version skew and should fail loudly.
+                var ipcFieldCount = _streamReader.Schema.FieldsList.Count;
+                if (manifestSchema.FieldsList.Count != ipcFieldCount)
+                {
+                    var manifestFields = string.Join(", ", manifestSchema.FieldsList.Select(f => f.Name));
+                    var ipcFields = string.Join(", ", _streamReader.Schema.FieldsList.Select(f => f.Name));
+                    throw new AdbcException(
+                        $"Manifest schema has {manifestSchema.FieldsList.Count} fields but IPC data has {ipcFieldCount} fields. " +
+                        $"Manifest: [{manifestFields}], IPC: [{ipcFields}]");
+                }
                 // Use the manifest schema as the reported schema rather than the IPC-embedded schema.
                 // Arrow IPC files are self-describing, but the IPC schema carries native types
                 // (YearMonthIntervalType, ListType, etc.) while callers expect the output contract

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -304,12 +304,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Create appropriate reader based on result disposition
             IArrowArrayStream reader = CreateReader(response, cancellationToken);
 
-            // When EnableComplexDatatypeSupport=false (default), serialize complex Arrow types to JSON strings
-            // so that SEA behavior matches Thrift (which sets ComplexTypesAsArrow=false).
-            if (!_enableComplexDatatypeSupport)
-            {
-                reader = new ComplexTypeSerializingStream(reader);
-            }
+            // ComplexTypeSerializingStream handles two concerns in a single pass:
+            //   1. When EnableComplexDatatypeSupport=false (default), it serializes complex Arrow types
+            //      (LIST, MAP, STRUCT) to JSON strings, matching legacy Thrift behavior.
+            //   2. Always: it converts native Arrow interval/duration types to canonical UTF-8 strings
+            //      so that SEA behavior matches Thrift, which emits interval values as strings.
+            //      SEA emits YearMonthIntervalType and DurationType; Thrift emits StringType for intervals.
+            reader = new ComplexTypeSerializingStream(reader, serializeComplexTypes: !_enableComplexDatatypeSupport);
 
             // Get schema from reader
             var schema = reader.Schema;
@@ -524,6 +525,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         /// <summary>
         /// Maps Databricks SQL type names to Arrow types.
+        /// Complex types (ARRAY, MAP, STRUCT) are mapped to placeholder Arrow complex types
+        /// so that <see cref="ComplexTypeSerializingStream"/> can detect and serialize them to
+        /// JSON strings when <see cref="_enableComplexDatatypeSupport"/> is false.
         /// </summary>
         private IArrowType MapDatabricksTypeToArrowType(string typeName)
         {
@@ -545,9 +549,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 "DATE" => Date32Type.Default,
                 "TIMESTAMP" or "TIMESTAMP_NTZ" or "TIMESTAMP_LTZ" => TimestampType.Default,
                 "INTERVAL" => StringType.Default, // Intervals as strings for now
-                "ARRAY" => StringType.Default, // Complex types as strings for now
-                "MAP" => StringType.Default,
-                "STRUCT" => StringType.Default,
+                // Complex types use placeholder Arrow types so ComplexTypeSerializingStream
+                // can detect them via IsComplexType() and serialize actual List/Map/Struct
+                // arrays from CloudFetch IPC data to JSON strings.  When
+                // EnableComplexDatatypeSupport=false (default) the wrapper replaces
+                // these fields with StringType in the schema exposed to callers.
+                "ARRAY" => new ListType(StringType.Default),
+                "MAP" => new MapType(StringType.Default, StringType.Default, keySorted: false),
+                "STRUCT" => new StructType(new List<Field> { new Field("__placeholder__", StringType.Default, nullable: true) }),
                 "NULL" or "VOID" => NullType.Default,
                 _ => StringType.Default // Default to string for unknown types
             };

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -434,7 +434,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             if (hasExternalLinks)
             {
                 // Use CloudFetch for external links
-                return CreateCloudFetchReader(response);
+                return CreateCloudFetchReader(response, manifestSchema);
             }
             else if (response.Result != null && response.Result.Attachment != null && response.Result.Attachment.Length > 0)
             {
@@ -462,12 +462,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// <summary>
         /// Creates a CloudFetch reader for external link results.
         /// </summary>
-        private IArrowArrayStream CreateCloudFetchReader(ExecuteStatementResponse response)
+        private IArrowArrayStream CreateCloudFetchReader(ExecuteStatementResponse response, Schema manifestSchema)
         {
             var manifest = response.Manifest!;
-
-            // Build schema from manifest
-            var schema = GetSchemaFromManifest(manifest);
+            var schema = manifestSchema;
 
             // The Statement Execution API response structure:
             // - manifest.chunks: Array of ChunkInfo with metadata for ALL chunks (row counts, offsets, etc.)

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -301,17 +301,15 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     }));
             }
 
-            // Create appropriate reader based on result disposition
+            // Create appropriate reader based on result disposition.
+            // All paths (inline, CloudFetch, empty) expose the manifest schema so that
+            // IntervalSerializingStream and ComplexTypeSerializingStream can detect columns
+            // uniformly via Spark:DataType:SqlName metadata rather than Arrow IPC types.
             IArrowArrayStream reader = CreateReader(response, cancellationToken);
-
-            // Build the output schema and conversion indices from the manifest upfront.
-            // This avoids embedding detection metadata in Arrow fields — the manifest is the source of truth.
-            Schema manifestSchema = TryGetSchemaFromManifest(response.Manifest) ?? reader.Schema;
-            HashSet<int> intervalIndices = ComputeIntervalIndices(response.Manifest);
 
             // SEA emits YearMonthIntervalType and DurationType; Thrift emits StringType for intervals.
             // Convert interval/duration columns to canonical UTF-8 strings to match Thrift behavior.
-            reader = new IntervalSerializingStream(reader, manifestSchema, intervalIndices);
+            reader = new IntervalSerializingStream(reader);
 
             // When EnableComplexDatatypeSupport=false (default), serialize complex Arrow types to JSON strings
             // so that SEA behavior matches Thrift (which sets ComplexTypesAsArrow=false).
@@ -418,6 +416,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 return new EmptyArrowArrayStream();
             }
 
+            // Derive the output schema from the manifest once, for all paths.
+            // JDBC uses the manifest schema exclusively for both inline and CloudFetch results;
+            // the Arrow IPC bytes are only used for data extraction, not schema definition.
+            Schema manifestSchema = TryGetSchemaFromManifest(response.Manifest) ?? new Schema.Builder().Build();
+
             // Check for external links in manifest chunks or result
             bool hasExternalLinksInChunks = response.Manifest.Chunks != null &&
                                   response.Manifest.Chunks.Count > 0 &&
@@ -438,10 +441,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 // Check if data is LZ4 compressed
                 bool isLz4Compressed = response.Manifest?.ResultCompression?.ToUpperInvariant() == "LZ4_FRAME";
 
-                // Inline results - may be split across multiple chunks
+                // Inline results - may be split across multiple chunks.
+                // Pass the manifest schema so the reader reports it instead of the IPC-embedded schema,
+                // keeping inline consistent with CloudFetch (which also uses the manifest schema).
                 int totalChunks = response.Manifest?.Chunks?.Count ?? 1;
                 return new InlineArrowStreamReader(_client, _currentStatementId!, response.Result.Attachment,
-                    isLz4Compressed, totalChunks, _lz4BufferPool, cancellationToken);
+                    isLz4Compressed, totalChunks, _lz4BufferPool, cancellationToken, manifestSchema);
             }
             else
             {
@@ -450,8 +455,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 // when the queried table is empty — following the same pattern as
                 // the JDBC driver where ResultManifest schema is always extracted
                 // independently of data presence.
-                Schema schema = TryGetSchemaFromManifest(response.Manifest) ?? new Schema.Builder().Build();
-                return new EmptyArrowArrayStream(schema);
+                return new EmptyArrowArrayStream(manifestSchema);
             }
         }
 
@@ -493,20 +497,6 @@ namespace AdbcDrivers.Databricks.StatementExecution
         {
             return TryGetSchemaFromManifest(manifest)
                 ?? throw new AdbcException("Result manifest does not contain schema information");
-        }
-
-        private static HashSet<int> ComputeIntervalIndices(ResultManifest? manifest)
-        {
-            var indices = new HashSet<int>();
-            var columns = manifest?.Schema?.Columns;
-            if (columns == null) return indices;
-            for (int i = 0; i < columns.Count; i++)
-            {
-                if (ColumnMetadataHelper.GetBaseTypeName(columns[i].TypeName ?? string.Empty)
-                    .StartsWith("INTERVAL", StringComparison.OrdinalIgnoreCase))
-                    indices.Add(i);
-            }
-            return indices;
         }
 
         /// <summary>
@@ -771,6 +761,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         {
             private readonly ArrowStreamReader _streamReader;
             private readonly System.IO.MemoryStream _memoryStream;
+            private readonly Schema _schema;
             private bool _disposed;
 
             public InlineArrowStreamReader(
@@ -780,7 +771,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 bool isLz4Compressed,
                 int totalChunks,
                 System.Buffers.ArrayPool<byte> bufferPool,
-                CancellationToken cancellationToken)
+                CancellationToken cancellationToken,
+                Schema manifestSchema)
             {
                 if (firstChunkData == null || firstChunkData.Length == 0)
                 {
@@ -792,9 +784,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
                 _memoryStream = new System.IO.MemoryStream(allData);
                 _streamReader = new ArrowStreamReader(_memoryStream);
+                // Report the manifest schema (not the IPC-embedded schema) so that all paths
+                // (inline, CloudFetch, empty) are consistent — matching JDBC behavior.
+                _schema = manifestSchema;
             }
 
-            public Schema Schema => _streamReader.Schema;
+            public Schema Schema => _schema;
 
             public async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
             {

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -500,9 +500,34 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
-        /// Tries to extract the Arrow schema from the result manifest.
-        /// Returns <c>null</c> when the manifest contains no column definitions,
-        /// allowing callers to decide on a fallback (e.g. empty schema for no-data results).
+        /// Builds an Arrow <see cref="Schema"/> from the SEA result manifest, or returns
+        /// <c>null</c> when the manifest contains no column definitions.
+        ///
+        /// <para>
+        /// This schema is used by all three result paths (inline, CloudFetch, empty) so
+        /// that every path exposes the same schema to callers — matching the JDBC driver,
+        /// which uses the manifest schema exclusively and treats Arrow IPC bytes as a data
+        /// source only.
+        /// </para>
+        ///
+        /// <para>
+        /// Each field carries <see cref="ColumnMetadataHelper.ArrowMetadataKey"/>
+        /// (<c>Spark:DataType:SqlName</c>) in its metadata. For Thrift results the server
+        /// embeds this key directly in the Arrow IPC field metadata; for SEA results it may
+        /// be absent from the IPC. By computing it here from the manifest type name and
+        /// embedding it on every field, we give <see cref="IntervalSerializingStream"/> and
+        /// <see cref="ComplexTypeSerializingStream"/> a reliable detection signal regardless
+        /// of result path. JDBC achieves the same effect by falling back to
+        /// <c>ColumnInfo.typeText</c> (the raw manifest type string) when the IPC metadata
+        /// key is absent.
+        /// </para>
+        ///
+        /// <para>
+        /// INTERVAL, ARRAY, MAP, and STRUCT columns are mapped to <see cref="StringType"/>
+        /// because the stream wrappers convert the native Arrow arrays to strings. The
+        /// declared Arrow type and the actual array type in each batch must always agree;
+        /// this is the output contract.
+        /// </para>
         /// </summary>
         private Schema? TryGetSchemaFromManifest(ResultManifest manifest)
         {
@@ -516,18 +541,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 var typeName = column.TypeName ?? string.Empty;
                 var arrowType = MapDatabricksTypeToArrowType(typeName);
-                // Embed the SQL type name as Arrow field metadata so that consumers
-                // (e.g. the PowerBI connector's AdjustNativeTypes) can read it via
-                // the "Spark:DataType:SqlName" key — the same metadata the Databricks
-                // server embeds in the Arrow IPC stream for non-empty results.
-                //
-                // Note: the Thrift server also sets "Spark:DataType:JsonType" (the JSON
-                // representation of the type, e.g. "{\"type\":\"integer\"}") alongside
-                // SqlName. That key is not read by any known consumer today, so we omit
-                // it here for now. Add it if a consumer requires it (PECO-2950).
+                // Embed Spark:DataType:SqlName so downstream stream wrappers and consumers
+                // (e.g. the PowerBI connector's AdjustNativeTypes) can read the SQL type name.
+                // Note: the Thrift server also sets "Spark:DataType:JsonType" alongside SqlName;
+                // that key is not read by any known consumer today, so we omit it here (PECO-2950).
                 var metadata = new Dictionary<string, string>
                 {
-                    ["Spark:DataType:SqlName"] = ColumnMetadataHelper.GetSparkSqlName(typeName)
+                    [ColumnMetadataHelper.ArrowMetadataKey] = ColumnMetadataHelper.GetSparkSqlName(typeName)
                 };
                 fields.Add(new Field(column.Name, arrowType, true, metadata));
             }
@@ -536,7 +556,15 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
-        /// Maps Databricks SQL type names to Arrow types.
+        /// Maps a Databricks SQL type name from the manifest to its Arrow output type.
+        ///
+        /// <para>
+        /// INTERVAL, ARRAY, MAP, and STRUCT are mapped to <see cref="StringType"/> because
+        /// <see cref="IntervalSerializingStream"/> and <see cref="ComplexTypeSerializingStream"/>
+        /// convert the native Arrow arrays (e.g. <c>YearMonthIntervalArray</c>, <c>ListArray</c>)
+        /// to <see cref="StringArray"/> at read time. The manifest schema is the output contract
+        /// exposed to callers, so the declared type must match the converted data type.
+        /// </para>
         /// </summary>
         private IArrowType MapDatabricksTypeToArrowType(string typeName)
         {
@@ -557,12 +585,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 "BINARY" or "VARBINARY" => BinaryType.Default,
                 "DATE" => Date32Type.Default,
                 "TIMESTAMP" or "TIMESTAMP_NTZ" or "TIMESTAMP_LTZ" => TimestampType.Default,
-                "INTERVAL" => StringType.Default, // Intervals as strings for now
-                "ARRAY" => StringType.Default, // Complex types as strings for now
-                "MAP" => StringType.Default,
-                "STRUCT" => StringType.Default,
+                // Converted to string by IntervalSerializingStream; StringType is the output contract.
+                "INTERVAL" => StringType.Default,
+                // Converted to JSON string by ComplexTypeSerializingStream; StringType is the output contract.
+                "ARRAY" or "MAP" or "STRUCT" => StringType.Default,
                 "NULL" or "VOID" => NullType.Default,
-                _ => StringType.Default // Default to string for unknown types
+                _ => StringType.Default
             };
         }
 
@@ -784,8 +812,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
                 _memoryStream = new System.IO.MemoryStream(allData);
                 _streamReader = new ArrowStreamReader(_memoryStream);
-                // Report the manifest schema (not the IPC-embedded schema) so that all paths
-                // (inline, CloudFetch, empty) are consistent — matching JDBC behavior.
+                // Use the manifest schema as the reported schema rather than the IPC-embedded schema.
+                // Arrow IPC files are self-describing, but the IPC schema carries native types
+                // (YearMonthIntervalType, ListType, etc.) while callers expect the output contract
+                // declared by the manifest (StringType for interval and complex columns). Keeping
+                // inline consistent with CloudFetch — which already uses GetSchemaFromManifest —
+                // lets IntervalSerializingStream and ComplexTypeSerializingStream detect and convert
+                // columns uniformly via Spark:DataType:SqlName metadata on every path.
                 _schema = manifestSchema;
             }
 

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -528,9 +528,6 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         /// <summary>
         /// Maps Databricks SQL type names to Arrow types.
-        /// Complex types (ARRAY, MAP, STRUCT) are mapped to placeholder Arrow complex types
-        /// so that <see cref="ComplexTypeSerializingStream"/> can detect and serialize them to
-        /// JSON strings when <see cref="_enableComplexDatatypeSupport"/> is false.
         /// </summary>
         private IArrowType MapDatabricksTypeToArrowType(string typeName)
         {
@@ -552,14 +549,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 "DATE" => Date32Type.Default,
                 "TIMESTAMP" or "TIMESTAMP_NTZ" or "TIMESTAMP_LTZ" => TimestampType.Default,
                 "INTERVAL" => StringType.Default, // Intervals as strings for now
-                // Complex types use placeholder Arrow types so ComplexTypeSerializingStream
-                // can detect them via IsComplexType() and serialize actual List/Map/Struct
-                // arrays from CloudFetch IPC data to JSON strings.  When
-                // EnableComplexDatatypeSupport=false (default) the wrapper replaces
-                // these fields with StringType in the schema exposed to callers.
-                "ARRAY" => new ListType(StringType.Default),
-                "MAP" => new MapType(StringType.Default, StringType.Default, keySorted: false),
-                "STRUCT" => new StructType(new List<Field> { new Field("__placeholder__", StringType.Default, nullable: true) }),
+                "ARRAY" => StringType.Default, // Complex types as strings for now
+                "MAP" => StringType.Default,
+                "STRUCT" => StringType.Default,
                 "NULL" or "VOID" => NullType.Default,
                 _ => StringType.Default // Default to string for unknown types
             };

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -419,7 +419,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Derive the output schema from the manifest once, for all paths.
             // JDBC uses the manifest schema exclusively for both inline and CloudFetch results;
             // the Arrow IPC bytes are only used for data extraction, not schema definition.
-            Schema manifestSchema = TryGetSchemaFromManifest(response.Manifest) ?? new Schema.Builder().Build();
+            Schema manifestSchema = GetSchemaFromManifest(response.Manifest);
 
             // Check for external links in manifest chunks or result
             bool hasExternalLinksInChunks = response.Manifest.Chunks != null &&

--- a/csharp/test/ColumnMetadataHelperTests.cs
+++ b/csharp/test/ColumnMetadataHelperTests.cs
@@ -195,36 +195,5 @@ namespace AdbcDrivers.Databricks.Tests
             Assert.Equal(expectedCode, ColumnMetadataHelper.GetDataTypeCode(typeName));
         }
 
-        [Theory]
-        [InlineData("INT", "INT")]
-        [InlineData("INTEGER", "INT")]
-        [InlineData("BYTE", "TINYINT")]
-        [InlineData("SHORT", "SMALLINT")]
-        [InlineData("LONG", "BIGINT")]
-        [InlineData("REAL", "FLOAT")]
-        [InlineData("TINYINT", "TINYINT")]
-        [InlineData("SMALLINT", "SMALLINT")]
-        [InlineData("BIGINT", "BIGINT")]
-        [InlineData("FLOAT", "FLOAT")]
-        [InlineData("DOUBLE", "DOUBLE")]
-        [InlineData("BOOLEAN", "BOOLEAN")]
-        [InlineData("STRING", "STRING")]
-        [InlineData("VARCHAR", "VARCHAR")]
-        [InlineData("CHAR", "CHAR")]
-        [InlineData("BINARY", "BINARY")]
-        [InlineData("DATE", "DATE")]
-        [InlineData("TIMESTAMP", "TIMESTAMP")]
-        [InlineData("TIMESTAMP_NTZ", "TIMESTAMP")]
-        [InlineData("DECIMAL(10,2)", "DECIMAL")]
-        [InlineData("ARRAY<INT>", "ARRAY")]
-        [InlineData("MAP<STRING,INT>", "MAP")]
-        [InlineData("STRUCT<a:INT>", "STRUCT")]
-        [InlineData("INTERVAL DAY TO SECOND", "INTERVAL")]
-        [InlineData("VARIANT", "VARIANT")]
-        [InlineData("", "")]
-        public void GetSparkSqlName_ReturnsCorrectValues(string typeName, string expected)
-        {
-            Assert.Equal(expected, ColumnMetadataHelper.GetSparkSqlName(typeName));
-        }
     }
 }

--- a/csharp/test/E2E/IntervalValueTests.cs
+++ b/csharp/test/E2E/IntervalValueTests.cs
@@ -1,0 +1,196 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Adbc.Tests;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using AdbcDrivers.Tests.HiveServer2.Common;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.Databricks.Tests
+{
+    /// <summary>
+    /// Validates that INTERVAL types (YEAR TO MONTH and DAY TO SECOND) are returned as
+    /// UTF-8 strings (StringType) for both Thrift and SEA (Statement Execution API) protocols.
+    ///
+    /// For SEA, the fix in ComplexTypeSerializingStream converts YearMonthIntervalArray and
+    /// DurationArray to StringArray before returning results to the caller.
+    ///
+    /// String formats:
+    ///   YEAR-MONTH: "Y-M" with no zero-padding (e.g., 2 years 6 months => "2-6")
+    ///   DAY-TIME:   "D HH:MM:SS.nnnnnnnnn" with 9-digit nanosecond precision
+    ///               (e.g., 3 days 12h 30m 15s => "3 12:30:15.000000000")
+    /// </summary>
+    public class IntervalValueTests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
+    {
+        public IntervalValueTests(ITestOutputHelper output)
+            : base(output, new DatabricksTestEnvironment.Factory())
+        {
+        }
+
+        /// <summary>
+        /// Executes a SELECT returning a single INTERVAL column and validates that the schema
+        /// reports StringType and the value matches the expected string representation.
+        /// </summary>
+        private async Task ValidateIntervalColumnAsync(string sql, string expectedValue)
+        {
+            Statement.SqlQuery = sql;
+            QueryResult result = await Statement.ExecuteQueryAsync();
+
+            using IArrowArrayStream stream = result.Stream ?? throw new InvalidOperationException("stream is null");
+            Field field = stream.Schema.GetFieldByIndex(0);
+
+            Assert.IsType<StringType>(field.DataType);
+
+            RecordBatch? batch = await stream.ReadNextRecordBatchAsync();
+            Assert.NotNull(batch);
+            Assert.Equal(1, batch.Length);
+
+            StringArray arr = (StringArray)batch.Column(0);
+            Assert.Equal(expectedValue, arr.GetString(0));
+        }
+
+        /// <summary>
+        /// Executes a SELECT returning a single NULL INTERVAL column and validates that the
+        /// schema reports StringType and the value is null.
+        /// </summary>
+        private async Task ValidateNullIntervalColumnAsync(string sql)
+        {
+            Statement.SqlQuery = sql;
+            QueryResult result = await Statement.ExecuteQueryAsync();
+
+            using IArrowArrayStream stream = result.Stream ?? throw new InvalidOperationException("stream is null");
+            Field field = stream.Schema.GetFieldByIndex(0);
+
+            Assert.IsType<StringType>(field.DataType);
+
+            RecordBatch? batch = await stream.ReadNextRecordBatchAsync();
+            Assert.NotNull(batch);
+            Assert.Equal(1, batch.Length);
+            Assert.True(batch.Column(0).IsNull(0), "Expected null value");
+        }
+
+        // INTERVAL-001: YEAR TO MONTH interval - 2 years 6 months
+        [SkippableFact]
+        public async Task INTERVAL001_YearMonthInterval()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await ValidateIntervalColumnAsync(
+                "SELECT INTERVAL '2-6' YEAR TO MONTH",
+                "2-6");
+        }
+
+        // INTERVAL-002: YEAR TO MONTH interval - 0 years 1 month
+        [SkippableFact]
+        public async Task INTERVAL002_YearMonthIntervalZeroYears()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await ValidateIntervalColumnAsync(
+                "SELECT INTERVAL '0-1' YEAR TO MONTH",
+                "0-1");
+        }
+
+        // INTERVAL-003: DAY TO SECOND interval - 3 days 12h 30m 15s
+        [SkippableFact]
+        public async Task INTERVAL003_DayTimeInterval()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await ValidateIntervalColumnAsync(
+                "SELECT INTERVAL '3 12:30:15' DAY TO SECOND",
+                "3 12:30:15.000000000");
+        }
+
+        // INTERVAL-004: DAY TO SECOND interval - zero duration
+        [SkippableFact]
+        public async Task INTERVAL004_DayTimeIntervalZero()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await ValidateIntervalColumnAsync(
+                "SELECT INTERVAL '0 00:00:00' DAY TO SECOND",
+                "0 00:00:00.000000000");
+        }
+
+        // INTERVAL-005: DAY TO SECOND interval - sub-second precision
+        [SkippableFact]
+        public async Task INTERVAL005_DayTimeIntervalSubSecond()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await ValidateIntervalColumnAsync(
+                "SELECT INTERVAL '1 00:00:00.123456' DAY TO SECOND",
+                "1 00:00:00.123456000");
+        }
+
+        // INTERVAL-006: NULL YEAR TO MONTH interval
+        [SkippableFact]
+        public async Task INTERVAL006_NullYearMonthInterval()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await ValidateNullIntervalColumnAsync(
+                "SELECT CAST(NULL AS INTERVAL YEAR TO MONTH)");
+        }
+
+        // INTERVAL-007: NULL DAY TO SECOND interval
+        [SkippableFact]
+        public async Task INTERVAL007_NullDayTimeInterval()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await ValidateNullIntervalColumnAsync(
+                "SELECT CAST(NULL AS INTERVAL DAY TO SECOND)");
+        }
+
+        // INTERVAL-008: CloudFetch path - YEAR TO MONTH interval over large result set
+        // Forces the CloudFetch path through ComplexTypeSerializingStream by generating 20,000 rows.
+        [SkippableFact]
+        public async Task INTERVAL008_YearMonthIntervalCloudFetch()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+
+            Statement.SqlQuery = "SELECT INTERVAL '2-6' YEAR TO MONTH FROM (SELECT explode(sequence(1, 20000)))";
+            QueryResult result = await Statement.ExecuteQueryAsync();
+
+            using IArrowArrayStream stream = result.Stream ?? throw new InvalidOperationException("stream is null");
+            Field field = stream.Schema.GetFieldByIndex(0);
+
+            Assert.IsType<StringType>(field.DataType);
+
+            long totalRows = 0;
+            RecordBatch? batch;
+            while ((batch = await stream.ReadNextRecordBatchAsync()) != null)
+            {
+                StringArray arr = (StringArray)batch.Column(0);
+                for (int i = 0; i < batch.Length; i++)
+                {
+                    Assert.Equal("2-6", arr.GetString(i));
+                }
+                totalRows += batch.Length;
+            }
+
+            Assert.Equal(20000L, totalRows);
+        }
+    }
+}

--- a/csharp/test/E2E/IntervalValueTests.cs
+++ b/csharp/test/E2E/IntervalValueTests.cs
@@ -15,6 +15,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
@@ -184,6 +186,115 @@ namespace AdbcDrivers.Databricks.Tests
             }
 
             Assert.Equal(20000L, totalRows);
+        }
+
+        // INTERVAL-009: Cross-protocol — Thrift and SEA return identical YEAR TO MONTH strings.
+        [SkippableFact]
+        public async Task INTERVAL009_YearMonthInterval_ThriftAndSEAReturnSameData()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await AssertProtocolsAgreeAsync(
+                "SELECT" +
+                "  INTERVAL '2-6' YEAR TO MONTH               AS c_ym," +
+                "  INTERVAL '0-1' YEAR TO MONTH               AS c_ym_zero_years," +
+                "  CAST(NULL AS INTERVAL YEAR TO MONTH)       AS c_ym_null");
+        }
+
+        // INTERVAL-010: Cross-protocol — Thrift and SEA return identical DAY TO SECOND strings.
+        [SkippableFact]
+        public async Task INTERVAL010_DayToSecondInterval_ThriftAndSEAReturnSameData()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+            await AssertProtocolsAgreeAsync(
+                "SELECT" +
+                "  INTERVAL '3 12:30:15' DAY TO SECOND        AS c_ds," +
+                "  INTERVAL '0 00:00:00' DAY TO SECOND        AS c_ds_zero," +
+                "  INTERVAL '1 00:00:00.123456' DAY TO SECOND AS c_ds_subsecond," +
+                "  CAST(NULL AS INTERVAL DAY TO SECOND)       AS c_ds_null");
+        }
+
+        // -----------------------------------------------------------------
+        // Cross-protocol helpers
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Runs <paramref name="sql"/> on independent Thrift and SEA connections (regardless
+        /// of what protocol the test config specifies) and asserts every cell is identical.
+        /// </summary>
+        private async Task AssertProtocolsAgreeAsync(string sql)
+        {
+            using AdbcConnection thriftConn = NewConnectionForProtocol(protocol: null);
+            using AdbcConnection seaConn = NewConnectionForProtocol(protocol: "rest");
+
+            List<string?[]> thriftRows = await ReadAllRowsAsStringsAsync(thriftConn, sql);
+            List<string?[]> seaRows = await ReadAllRowsAsStringsAsync(seaConn, sql);
+
+            Assert.Equal(thriftRows.Count, seaRows.Count);
+            for (int row = 0; row < thriftRows.Count; row++)
+            {
+                string?[] thrift = thriftRows[row];
+                string?[] sea = seaRows[row];
+                Assert.Equal(thrift.Length, sea.Length);
+                for (int col = 0; col < thrift.Length; col++)
+                {
+                    Assert.True(thrift[col] == sea[col],
+                        $"Row {row}, col {col}: Thrift={thrift[col]}, SEA={sea[col]}");
+                }
+            }
+        }
+
+        private AdbcConnection NewConnectionForProtocol(string? protocol)
+        {
+            var parameters = new Dictionary<string, string>(TestEnvironment.GetDriverParameters(TestConfiguration));
+            parameters.Remove(DatabricksParameters.Protocol);
+            if (protocol != null)
+                parameters[DatabricksParameters.Protocol] = protocol;
+            return TestEnvironment.CreateNewDriver().Open(parameters).Connect(new Dictionary<string, string>());
+        }
+
+        private static async Task<List<string?[]>> ReadAllRowsAsStringsAsync(AdbcConnection conn, string sql)
+        {
+            using AdbcStatement stmt = conn.CreateStatement();
+            stmt.SqlQuery = sql;
+            QueryResult result = await stmt.ExecuteQueryAsync();
+            using IArrowArrayStream stream = result.Stream ?? throw new InvalidOperationException("stream is null");
+
+            int colCount = stream.Schema.FieldsList.Count;
+            var rows = new List<string?[]>();
+            RecordBatch? batch;
+            while ((batch = await stream.ReadNextRecordBatchAsync()) != null)
+            {
+                for (int row = 0; row < batch.Length; row++)
+                {
+                    var rowData = new string?[colCount];
+                    for (int col = 0; col < colCount; col++)
+                        rowData[col] = ExtractValueAsString(batch.Column(col), row);
+                    rows.Add(rowData);
+                }
+            }
+            return rows;
+        }
+
+        private static string? ExtractValueAsString(IArrowArray array, int index)
+        {
+            if (array.IsNull(index))
+                return null;
+            return array switch
+            {
+                StringArray sa => sa.GetString(index),
+                Int8Array int8 => int8.GetValue(index)!.Value.ToString(CultureInfo.InvariantCulture),
+                Int16Array int16 => int16.GetValue(index)!.Value.ToString(CultureInfo.InvariantCulture),
+                Int32Array int32 => int32.GetValue(index)!.Value.ToString(CultureInfo.InvariantCulture),
+                Int64Array int64 => int64.GetValue(index)!.Value.ToString(CultureInfo.InvariantCulture),
+                FloatArray floatArr => floatArr.GetValue(index)!.Value.ToString("R", CultureInfo.InvariantCulture),
+                DoubleArray doubleArr => doubleArr.GetValue(index)!.Value.ToString("R", CultureInfo.InvariantCulture),
+                BooleanArray boolArr => boolArr.GetValue(index)!.Value.ToString(),
+                Date32Array date32 => date32.GetDateTime(index)!.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                TimestampArray ts => ts.GetTimestamp(index)!.Value.ToString("O", CultureInfo.InvariantCulture),
+                Decimal128Array dec => dec.GetString(index),
+                BinaryArray bin => Convert.ToHexString(bin.GetBytes(index, out _).ToArray()),
+                _ => throw new InvalidOperationException($"Unhandled Arrow array type: {array.GetType().Name}")
+            };
         }
     }
 }

--- a/csharp/test/E2E/IntervalValueTests.cs
+++ b/csharp/test/E2E/IntervalValueTests.cs
@@ -197,7 +197,9 @@ namespace AdbcDrivers.Databricks.Tests
                 "SELECT" +
                 "  INTERVAL '2-6' YEAR TO MONTH               AS c_ym," +
                 "  INTERVAL '0-1' YEAR TO MONTH               AS c_ym_zero_years," +
-                "  CAST(NULL AS INTERVAL YEAR TO MONTH)       AS c_ym_null");
+                "  CAST(NULL AS INTERVAL YEAR TO MONTH)       AS c_ym_null," +
+                "  INTERVAL '-2-6' YEAR TO MONTH              AS c_ym_neg," +
+                "  INTERVAL '-0-10' YEAR TO MONTH             AS c_ym_neg_zero_years");
         }
 
         // INTERVAL-010: Cross-protocol — Thrift and SEA return identical DAY TO SECOND strings.
@@ -210,7 +212,9 @@ namespace AdbcDrivers.Databricks.Tests
                 "  INTERVAL '3 12:30:15' DAY TO SECOND        AS c_ds," +
                 "  INTERVAL '0 00:00:00' DAY TO SECOND        AS c_ds_zero," +
                 "  INTERVAL '1 00:00:00.123456' DAY TO SECOND AS c_ds_subsecond," +
-                "  CAST(NULL AS INTERVAL DAY TO SECOND)       AS c_ds_null");
+                "  CAST(NULL AS INTERVAL DAY TO SECOND)       AS c_ds_null," +
+                "  INTERVAL '-3 12:30:15' DAY TO SECOND       AS c_ds_neg," +
+                "  INTERVAL '-0 00:00:00.000001' DAY TO SECOND AS c_ds_neg_subsecond");
         }
 
         // -----------------------------------------------------------------

--- a/csharp/test/E2E/IntervalValueTests.cs
+++ b/csharp/test/E2E/IntervalValueTests.cs
@@ -292,7 +292,7 @@ namespace AdbcDrivers.Databricks.Tests
                 Date32Array date32 => date32.GetDateTime(index)!.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
                 TimestampArray ts => ts.GetTimestamp(index)!.Value.ToString("O", CultureInfo.InvariantCulture),
                 Decimal128Array dec => dec.GetString(index),
-                BinaryArray bin => Convert.ToHexString(bin.GetBytes(index, out _).ToArray()),
+                BinaryArray bin => BitConverter.ToString(bin.GetBytes(index, out _).ToArray()).Replace("-", ""),
                 _ => throw new InvalidOperationException($"Unhandled Arrow array type: {array.GetType().Name}")
             };
         }

--- a/csharp/test/E2E/IntervalValueTests.cs
+++ b/csharp/test/E2E/IntervalValueTests.cs
@@ -1,18 +1,11 @@
 /*
 * Copyright (c) 2025 ADBC Drivers Contributors
 *
-* This file has been modified from its original version, which is
-* under the Apache License:
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
+*     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,7 +31,7 @@ namespace AdbcDrivers.Databricks.Tests
     /// Validates that INTERVAL types (YEAR TO MONTH and DAY TO SECOND) are returned as
     /// UTF-8 strings (StringType) for both Thrift and SEA (Statement Execution API) protocols.
     ///
-    /// For SEA, the fix in ComplexTypeSerializingStream converts YearMonthIntervalArray and
+    /// For SEA, the fix in IntervalSerializingStream converts YearMonthIntervalArray and
     /// DurationArray to StringArray before returning results to the caller.
     ///
     /// String formats:

--- a/csharp/test/Unit/ComplexTypeSerializingStreamTests.cs
+++ b/csharp/test/Unit/ComplexTypeSerializingStreamTests.cs
@@ -1,0 +1,325 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Scalars;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit
+{
+    /// <summary>
+    /// Unit tests for <see cref="ComplexTypeSerializingStream"/>.
+    ///
+    /// Covers:
+    ///   - Complex types (LIST, MAP, STRUCT) serialized to JSON strings when serializeComplexTypes=true.
+    ///   - Native Arrow interval/duration types always converted to canonical UTF-8 strings:
+    ///       YearMonth  → "Y-M"                        e.g. 30 months → "2-6"
+    ///       Duration   → "D HH:MM:SS.nnnnnnnnn"       e.g. 3 d + 12 h 30 m 15 s → "3 12:30:15.000000000"
+    ///   - serializeComplexTypes=false leaves complex columns untouched but still converts intervals.
+    /// </summary>
+    public class ComplexTypeSerializingStreamTests
+    {
+        // -----------------------------------------------------------------------
+        // FormatYearMonth static helper
+        // -----------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(0, "0-0")]          // zero
+        [InlineData(12, "1-0")]         // exactly 1 year
+        [InlineData(30, "2-6")]         // 2 years 6 months
+        [InlineData(1, "0-1")]          // 1 month only
+        [InlineData(25, "2-1")]         // 2 years 1 month
+        [InlineData(-30, "-2--6")]      // negative (mirrors Java driver)
+        public void FormatYearMonth_ReturnsExpectedString(int totalMonths, string expected)
+        {
+            string actual = ComplexTypeSerializingStream.FormatYearMonth(totalMonths);
+            Assert.Equal(expected, actual);
+        }
+
+        // -----------------------------------------------------------------------
+        // FormatDuration static helper — microsecond unit (Databricks default)
+        // -----------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(0L, "0 00:00:00.000000000")]                                   // zero
+        [InlineData(1_000_000L, "0 00:00:01.000000000")]                            // 1 second
+        [InlineData(60_000_000L, "0 00:01:00.000000000")]                           // 1 minute
+        [InlineData(3_600_000_000L, "0 01:00:00.000000000")]                        // 1 hour
+        [InlineData(86_400_000_000L, "1 00:00:00.000000000")]                       // 1 day
+        [InlineData(304_215_000_000L, "3 12:30:15.000000000")]                      // 3 d 12 h 30 m 15 s
+        [InlineData(304_215_000_500L, "3 12:30:15.000500000")]                      // plus 500 us
+        [InlineData(-304_215_000_000L, "-4 11:29:45.000000000")]                    // negative
+        public void FormatDuration_Microseconds_ReturnsExpectedString(long rawUs, string expected)
+        {
+            string actual = ComplexTypeSerializingStream.FormatDuration(rawUs, TimeUnit.Microsecond);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void FormatDuration_Nanoseconds_ReturnsExpectedString()
+        {
+            // 3 days 12 h 30 m 15 s in nanoseconds
+            long rawNs = 304_215L * 1_000_000_000L;
+            string actual = ComplexTypeSerializingStream.FormatDuration(rawNs, TimeUnit.Nanosecond);
+            Assert.Equal("3 12:30:15.000000000", actual);
+        }
+
+        [Fact]
+        public void FormatDuration_Seconds_ReturnsExpectedString()
+        {
+            long rawS = 304_215L; // 3 days 12 h 30 m 15 s
+            string actual = ComplexTypeSerializingStream.FormatDuration(rawS, TimeUnit.Second);
+            Assert.Equal("3 12:30:15.000000000", actual);
+        }
+
+        [Fact]
+        public void FormatDuration_Milliseconds_ReturnsExpectedString()
+        {
+            long rawMs = 304_215_000L; // 3 days 12 h 30 m 15 s
+            string actual = ComplexTypeSerializingStream.FormatDuration(rawMs, TimeUnit.Millisecond);
+            Assert.Equal("3 12:30:15.000000000", actual);
+        }
+
+        // -----------------------------------------------------------------------
+        // Schema rewriting — interval/duration columns
+        // -----------------------------------------------------------------------
+
+        [Fact]
+        public void Schema_YearMonthColumn_IsRewrittenToString()
+        {
+            Schema original = new Schema.Builder()
+                .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
+                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
+                .Build();
+
+            using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
+            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+
+            Schema rewritten = stream.Schema;
+            Assert.Equal(2, rewritten.FieldsList.Count);
+            Assert.IsType<Int32Type>(rewritten.FieldsList[0].DataType);
+            Assert.IsType<StringType>(rewritten.FieldsList[1].DataType);
+            Assert.Equal("tenure", rewritten.FieldsList[1].Name);
+        }
+
+        [Fact]
+        public void Schema_DurationColumn_IsRewrittenToString()
+        {
+            Schema original = new Schema.Builder()
+                .Field(f => f.Name("elapsed").DataType(DurationType.Microsecond).Nullable(true))
+                .Field(f => f.Name("label").DataType(StringType.Default).Nullable(true))
+                .Build();
+
+            using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
+            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+
+            Schema rewritten = stream.Schema;
+            Assert.Equal(2, rewritten.FieldsList.Count);
+            Assert.IsType<StringType>(rewritten.FieldsList[0].DataType);
+            Assert.Equal("elapsed", rewritten.FieldsList[0].Name);
+            Assert.IsType<StringType>(rewritten.FieldsList[1].DataType);
+        }
+
+        [Fact]
+        public void Schema_NonIntervalColumns_AreUnchanged()
+        {
+            Schema original = new Schema.Builder()
+                .Field(f => f.Name("a").DataType(Int64Type.Default).Nullable(false))
+                .Field(f => f.Name("b").DataType(StringType.Default).Nullable(true))
+                .Field(f => f.Name("c").DataType(DoubleType.Default).Nullable(true))
+                .Build();
+
+            using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
+            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+
+            Schema rewritten = stream.Schema;
+            Assert.Equal(3, rewritten.FieldsList.Count);
+            Assert.IsType<Int64Type>(rewritten.FieldsList[0].DataType);
+            Assert.IsType<StringType>(rewritten.FieldsList[1].DataType);
+            Assert.IsType<DoubleType>(rewritten.FieldsList[2].DataType);
+        }
+
+        // -----------------------------------------------------------------------
+        // Data conversion — YearMonthIntervalArray → StringArray
+        // -----------------------------------------------------------------------
+
+        [Fact]
+        public async Task ReadNextBatch_YearMonthColumn_ConvertsValues()
+        {
+            // Build a batch with two rows: 30 months ("2-6") and null
+            var ymBuilder = new YearMonthIntervalArray.Builder();
+            ymBuilder.Append(new YearMonthInterval(30)); // 2-6
+            ymBuilder.AppendNull();
+            ymBuilder.Append(new YearMonthInterval(12)); // 1-0
+            YearMonthIntervalArray ymArray = ymBuilder.Build();
+
+            Schema schema = new Schema.Builder()
+                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
+                .Build();
+
+            RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { ymArray }, ymArray.Length);
+
+            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
+            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+
+            RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
+            Assert.NotNull(result);
+            Assert.Equal(3, result!.Length);
+
+            StringArray strings = (StringArray)result.Column(0);
+            Assert.Equal("2-6", strings.GetString(0));
+            Assert.True(strings.IsNull(1));
+            Assert.Equal("1-0", strings.GetString(2));
+        }
+
+        // -----------------------------------------------------------------------
+        // Data conversion — DurationArray → StringArray
+        // -----------------------------------------------------------------------
+
+        [Fact]
+        public async Task ReadNextBatch_DurationColumn_ConvertsValues()
+        {
+            // 3 d 12 h 30 m 15 s in microseconds = 304_215_000_000
+            long us = 304_215_000_000L;
+
+            var dBuilder = new DurationArray.Builder(DurationType.Microsecond);
+            dBuilder.Append(us);
+            dBuilder.AppendNull();
+            DurationArray dArray = dBuilder.Build();
+
+            Schema schema = new Schema.Builder()
+                .Field(f => f.Name("elapsed").DataType(DurationType.Microsecond).Nullable(true))
+                .Build();
+
+            RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { dArray }, dArray.Length);
+
+            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
+            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+
+            RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
+            Assert.NotNull(result);
+            Assert.Equal(2, result!.Length);
+
+            StringArray strings = (StringArray)result.Column(0);
+            Assert.Equal("3 12:30:15.000000000", strings.GetString(0));
+            Assert.True(strings.IsNull(1));
+        }
+
+        // -----------------------------------------------------------------------
+        // Mixed schema: interval + non-interval columns
+        // -----------------------------------------------------------------------
+
+        [Fact]
+        public async Task ReadNextBatch_MixedColumns_OnlyIntervalColumnsConverted()
+        {
+            var idBuilder = new Int32Array.Builder();
+            idBuilder.Append(1);
+
+            var ymBuilder = new YearMonthIntervalArray.Builder();
+            ymBuilder.Append(new YearMonthInterval(30)); // "2-6"
+
+            var nameBuilder = new StringArray.Builder();
+            nameBuilder.Append("Alice");
+
+            Schema schema = new Schema.Builder()
+                .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
+                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
+                .Field(f => f.Name("name").DataType(StringType.Default).Nullable(true))
+                .Build();
+
+            Int32Array idArray = idBuilder.Build();
+            YearMonthIntervalArray ymArray = ymBuilder.Build();
+            StringArray nameArray = nameBuilder.Build();
+
+            RecordBatch batch = new RecordBatch(schema,
+                new IArrowArray[] { idArray, ymArray, nameArray }, 1);
+
+            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
+            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+
+            RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
+            Assert.NotNull(result);
+
+            Assert.IsType<Int32Array>(result!.Column(0));
+            Assert.IsType<StringArray>(result.Column(1));
+            Assert.IsType<StringArray>(result.Column(2));
+
+            Assert.Equal("2-6", ((StringArray)result.Column(1)).GetString(0));
+            Assert.Equal("Alice", ((StringArray)result.Column(2)).GetString(0));
+        }
+
+        // -----------------------------------------------------------------------
+        // serializeComplexTypes=false: intervals still converted, complex untouched
+        // -----------------------------------------------------------------------
+
+        [Fact]
+        public async Task ReadNextBatch_SerializeComplexTypesFalse_IntervalStillConverted()
+        {
+            var ymBuilder = new YearMonthIntervalArray.Builder();
+            ymBuilder.Append(new YearMonthInterval(30)); // "2-6"
+            YearMonthIntervalArray ymArray = ymBuilder.Build();
+
+            Schema schema = new Schema.Builder()
+                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
+                .Build();
+
+            RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { ymArray }, ymArray.Length);
+
+            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
+            // serializeComplexTypes=false — complex types pass through, but intervals are still converted
+            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner, serializeComplexTypes: false);
+
+            // Schema: interval column must still be rewritten to StringType
+            Assert.IsType<StringType>(stream.Schema.FieldsList[0].DataType);
+
+            RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
+            Assert.NotNull(result);
+            StringArray strings = (StringArray)result!.Column(0);
+            Assert.Equal("2-6", strings.GetString(0));
+        }
+
+        // -----------------------------------------------------------------------
+        // Helper: trivial IArrowArrayStream backed by a fixed list of batches
+        // -----------------------------------------------------------------------
+
+        private sealed class StubArrowArrayStream : IArrowArrayStream
+        {
+            private readonly Queue<RecordBatch> _batches;
+
+            public StubArrowArrayStream(Schema schema, IEnumerable<RecordBatch> batches)
+            {
+                Schema = schema;
+                _batches = new Queue<RecordBatch>(batches);
+            }
+
+            public Schema Schema { get; }
+
+            public ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+            {
+                RecordBatch? batch = _batches.Count > 0 ? _batches.Dequeue() : null;
+                return new ValueTask<RecordBatch?>(batch);
+            }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/csharp/test/Unit/IntervalSerializingStreamTests.cs
+++ b/csharp/test/Unit/IntervalSerializingStreamTests.cs
@@ -61,7 +61,10 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         [InlineData(30, "2-6")]         // 2 years 6 months
         [InlineData(1, "0-1")]          // 1 month only
         [InlineData(25, "2-1")]         // 2 years 1 month
-        [InlineData(-30, "-2--6")]      // negative (mirrors Java driver)
+        [InlineData(-30, "-2-6")]       // negative: matches JDBC and server
+        [InlineData(-22, "-1-10")]      // negative: 1 year 10 months
+        [InlineData(-10, "-0-10")]      // negative: 0 years 10 months
+        [InlineData(-1, "-0-1")]        // negative: 1 month
         public void FormatYearMonth_ReturnsExpectedString(int totalMonths, string expected)
         {
             string actual = IntervalSerializingStream.FormatYearMonth(totalMonths);
@@ -80,7 +83,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         [InlineData(86_400_000_000L, "1 00:00:00.000000000")]                       // 1 day
         [InlineData(304_215_000_000L, "3 12:30:15.000000000")]                      // 3 d 12 h 30 m 15 s
         [InlineData(304_215_000_500L, "3 12:30:15.000500000")]                      // plus 500 us
-        [InlineData(-304_215_000_000L, "-4 11:29:45.000000000")]                    // negative
+        [InlineData(-304_215_000_000L, "-3 12:30:15.000000000")]                    // negative: matches JDBC and server
         public void FormatDuration_Microseconds_ReturnsExpectedString(long rawUs, string expected)
         {
             string actual = IntervalSerializingStream.FormatDuration(rawUs, TimeUnit.Microsecond);

--- a/csharp/test/Unit/IntervalSerializingStreamTests.cs
+++ b/csharp/test/Unit/IntervalSerializingStreamTests.cs
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,9 @@ namespace AdbcDrivers.Databricks.Tests.Unit
     /// </summary>
     public class IntervalSerializingStreamTests
     {
+        private static readonly Dictionary<string, string> IntervalMetadata =
+            new Dictionary<string, string> { ["Spark:DataType:SqlName"] = "INTERVAL" };
+
         // -----------------------------------------------------------------------
         // FormatYearMonth static helper
         // -----------------------------------------------------------------------
@@ -107,7 +111,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         {
             Schema original = new Schema.Builder()
                 .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
+                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true, IntervalMetadata))
                 .Build();
 
             using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
@@ -124,7 +128,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         public void Schema_DurationColumn_IsRewrittenToString()
         {
             Schema original = new Schema.Builder()
-                .Field(f => f.Name("elapsed").DataType(DurationType.Microsecond).Nullable(true))
+                .Field(new Field("elapsed", DurationType.Microsecond, nullable: true, IntervalMetadata))
                 .Field(f => f.Name("label").DataType(StringType.Default).Nullable(true))
                 .Build();
 
@@ -170,7 +174,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             YearMonthIntervalArray ymArray = ymBuilder.Build();
 
             Schema schema = new Schema.Builder()
-                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
+                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true, IntervalMetadata))
                 .Build();
 
             RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { ymArray }, ymArray.Length);
@@ -204,7 +208,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             DurationArray dArray = dBuilder.Build();
 
             Schema schema = new Schema.Builder()
-                .Field(f => f.Name("elapsed").DataType(DurationType.Microsecond).Nullable(true))
+                .Field(new Field("elapsed", DurationType.Microsecond, nullable: true, IntervalMetadata))
                 .Build();
 
             RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { dArray }, dArray.Length);
@@ -239,7 +243,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
 
             Schema schema = new Schema.Builder()
                 .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
+                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true, IntervalMetadata))
                 .Field(f => f.Name("name").DataType(StringType.Default).Nullable(true))
                 .Build();
 

--- a/csharp/test/Unit/IntervalSerializingStreamTests.cs
+++ b/csharp/test/Unit/IntervalSerializingStreamTests.cs
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,15 +29,27 @@ namespace AdbcDrivers.Databricks.Tests.Unit
     /// <summary>
     /// Unit tests for <see cref="IntervalSerializingStream"/>.
     ///
+    /// The stream is constructed with an inner reader that exposes the manifest schema
+    /// (StringType for interval columns, with Spark:DataType:SqlName metadata for detection).
+    /// The record batches contain native Arrow interval arrays (as the IPC bytes would).
+    ///
     /// Covers:
     ///   - YearMonthIntervalArray → "Y-M" string
     ///   - DurationArray → "D HH:MM:SS.nnnnnnnnn" string
     ///   - Null handling for both types
-    ///   - Schema rewriting (converted columns become StringType)
+    ///   - Schema pass-through (manifest schema is already StringType)
     ///   - Non-interval columns pass through unchanged
     /// </summary>
     public class IntervalSerializingStreamTests
     {
+        // Helper: build a single-field manifest schema with Spark:DataType:SqlName metadata
+        private static Schema ManifestSchema(string fieldName, string sqlName, IArrowType arrowType, bool nullable = true)
+        {
+            var metadata = new Dictionary<string, string> { ["Spark:DataType:SqlName"] = sqlName };
+            return new Schema.Builder()
+                .Field(new Field(fieldName, arrowType, nullable, metadata))
+                .Build();
+        }
 
         // -----------------------------------------------------------------------
         // FormatYearMonth static helper
@@ -100,23 +113,21 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         }
 
         // -----------------------------------------------------------------------
-        // Schema — the wrapper reports the pre-built output schema as-is
+        // Schema — the wrapper passes the manifest schema through as-is
         // -----------------------------------------------------------------------
 
         [Fact]
-        public void Schema_YearMonthColumn_IsRewrittenToString()
+        public void Schema_YearMonthColumn_ReportsManifestStringType()
         {
-            Schema innerSchema = new Schema.Builder()
+            // Manifest schema: StringType for interval column (already correct output type)
+            Schema schema = new Schema.Builder()
                 .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true))
-                .Build();
-            Schema outputSchema = new Schema.Builder()
-                .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(f => f.Name("tenure").DataType(StringType.Default).Nullable(true))
+                .Field(new Field("tenure", StringType.Default, nullable: true,
+                    new Dictionary<string, string> { ["Spark:DataType:SqlName"] = "INTERVAL YEAR TO MONTH" }))
                 .Build();
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, System.Array.Empty<RecordBatch>());
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 1 });
+            using IArrowArrayStream inner = new StubArrowArrayStream(schema, System.Array.Empty<RecordBatch>());
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             Schema reported = stream.Schema;
             Assert.Equal(2, reported.FieldsList.Count);
@@ -126,19 +137,16 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         }
 
         [Fact]
-        public void Schema_DurationColumn_IsRewrittenToString()
+        public void Schema_DurationColumn_ReportsManifestStringType()
         {
-            Schema innerSchema = new Schema.Builder()
-                .Field(new Field("elapsed", DurationType.Microsecond, nullable: true))
-                .Field(f => f.Name("label").DataType(StringType.Default).Nullable(true))
-                .Build();
-            Schema outputSchema = new Schema.Builder()
-                .Field(f => f.Name("elapsed").DataType(StringType.Default).Nullable(true))
+            Schema schema = new Schema.Builder()
+                .Field(new Field("elapsed", StringType.Default, nullable: true,
+                    new Dictionary<string, string> { ["Spark:DataType:SqlName"] = "INTERVAL DAY TO SECOND" }))
                 .Field(f => f.Name("label").DataType(StringType.Default).Nullable(true))
                 .Build();
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, System.Array.Empty<RecordBatch>());
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 0 });
+            using IArrowArrayStream inner = new StubArrowArrayStream(schema, System.Array.Empty<RecordBatch>());
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             Schema reported = stream.Schema;
             Assert.Equal(2, reported.FieldsList.Count);
@@ -157,7 +165,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
                 .Build();
 
             using IArrowArrayStream inner = new StubArrowArrayStream(schema, System.Array.Empty<RecordBatch>());
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, schema, System.Array.Empty<int>());
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             Schema reported = stream.Schema;
             Assert.IsType<Int64Type>(reported.FieldsList[0].DataType);
@@ -178,17 +186,20 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             ymBuilder.Append(new YearMonthInterval(12)); // "1-0"
             YearMonthIntervalArray ymArray = ymBuilder.Build();
 
-            Schema innerSchema = new Schema.Builder()
+            // Manifest schema: StringType + SqlName metadata (what all result paths expose)
+            Schema manifestSchema = new Schema.Builder()
+                .Field(new Field("tenure", StringType.Default, nullable: true,
+                    new Dictionary<string, string> { ["Spark:DataType:SqlName"] = "INTERVAL YEAR TO MONTH" }))
+                .Build();
+
+            // Batch carries native arrays (as the IPC bytes would produce)
+            Schema nativeSchema = new Schema.Builder()
                 .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true))
                 .Build();
-            Schema outputSchema = new Schema.Builder()
-                .Field(f => f.Name("tenure").DataType(StringType.Default).Nullable(true))
-                .Build();
+            RecordBatch batch = new RecordBatch(nativeSchema, new IArrowArray[] { ymArray }, ymArray.Length);
 
-            RecordBatch batch = new RecordBatch(innerSchema, new IArrowArray[] { ymArray }, ymArray.Length);
-
-            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, new[] { batch });
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 0 });
+            using IArrowArrayStream inner = new StubArrowArrayStream(manifestSchema, new[] { batch });
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);
@@ -215,17 +226,18 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             dBuilder.AppendNull();
             DurationArray dArray = dBuilder.Build();
 
-            Schema innerSchema = new Schema.Builder()
+            Schema manifestSchema = new Schema.Builder()
+                .Field(new Field("elapsed", StringType.Default, nullable: true,
+                    new Dictionary<string, string> { ["Spark:DataType:SqlName"] = "INTERVAL DAY TO SECOND" }))
+                .Build();
+
+            Schema nativeSchema = new Schema.Builder()
                 .Field(new Field("elapsed", DurationType.Microsecond, nullable: true))
                 .Build();
-            Schema outputSchema = new Schema.Builder()
-                .Field(f => f.Name("elapsed").DataType(StringType.Default).Nullable(true))
-                .Build();
+            RecordBatch batch = new RecordBatch(nativeSchema, new IArrowArray[] { dArray }, dArray.Length);
 
-            RecordBatch batch = new RecordBatch(innerSchema, new IArrowArray[] { dArray }, dArray.Length);
-
-            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, new[] { batch });
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 0 });
+            using IArrowArrayStream inner = new StubArrowArrayStream(manifestSchema, new[] { batch });
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);
@@ -252,14 +264,16 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             var nameBuilder = new StringArray.Builder();
             nameBuilder.Append("Alice");
 
-            Schema innerSchema = new Schema.Builder()
+            Schema manifestSchema = new Schema.Builder()
                 .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true))
+                .Field(new Field("tenure", StringType.Default, nullable: true,
+                    new Dictionary<string, string> { ["Spark:DataType:SqlName"] = "INTERVAL YEAR TO MONTH" }))
                 .Field(f => f.Name("name").DataType(StringType.Default).Nullable(true))
                 .Build();
-            Schema outputSchema = new Schema.Builder()
+
+            Schema nativeSchema = new Schema.Builder()
                 .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(f => f.Name("tenure").DataType(StringType.Default).Nullable(true))
+                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true))
                 .Field(f => f.Name("name").DataType(StringType.Default).Nullable(true))
                 .Build();
 
@@ -267,11 +281,11 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             YearMonthIntervalArray ymArray = ymBuilder.Build();
             StringArray nameArray = nameBuilder.Build();
 
-            RecordBatch batch = new RecordBatch(innerSchema,
+            RecordBatch batch = new RecordBatch(nativeSchema,
                 new IArrowArray[] { idArray, ymArray, nameArray }, 1);
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, new[] { batch });
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 1 });
+            using IArrowArrayStream inner = new StubArrowArrayStream(manifestSchema, new[] { batch });
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);

--- a/csharp/test/Unit/IntervalSerializingStreamTests.cs
+++ b/csharp/test/Unit/IntervalSerializingStreamTests.cs
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,16 +26,16 @@ using Xunit;
 namespace AdbcDrivers.Databricks.Tests.Unit
 {
     /// <summary>
-    /// Unit tests for <see cref="ComplexTypeSerializingStream"/>.
+    /// Unit tests for <see cref="IntervalSerializingStream"/>.
     ///
     /// Covers:
-    ///   - Complex types (LIST, MAP, STRUCT) serialized to JSON strings when serializeComplexTypes=true.
-    ///   - Native Arrow interval/duration types always converted to canonical UTF-8 strings:
-    ///       YearMonth  → "Y-M"                        e.g. 30 months → "2-6"
-    ///       Duration   → "D HH:MM:SS.nnnnnnnnn"       e.g. 3 d + 12 h 30 m 15 s → "3 12:30:15.000000000"
-    ///   - serializeComplexTypes=false leaves complex columns untouched but still converts intervals.
+    ///   - YearMonthIntervalArray → "Y-M" string
+    ///   - DurationArray → "D HH:MM:SS.nnnnnnnnn" string
+    ///   - Null handling for both types
+    ///   - Schema rewriting (converted columns become StringType)
+    ///   - Non-interval columns pass through unchanged
     /// </summary>
-    public class ComplexTypeSerializingStreamTests
+    public class IntervalSerializingStreamTests
     {
         // -----------------------------------------------------------------------
         // FormatYearMonth static helper
@@ -51,7 +50,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         [InlineData(-30, "-2--6")]      // negative (mirrors Java driver)
         public void FormatYearMonth_ReturnsExpectedString(int totalMonths, string expected)
         {
-            string actual = ComplexTypeSerializingStream.FormatYearMonth(totalMonths);
+            string actual = IntervalSerializingStream.FormatYearMonth(totalMonths);
             Assert.Equal(expected, actual);
         }
 
@@ -70,7 +69,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         [InlineData(-304_215_000_000L, "-4 11:29:45.000000000")]                    // negative
         public void FormatDuration_Microseconds_ReturnsExpectedString(long rawUs, string expected)
         {
-            string actual = ComplexTypeSerializingStream.FormatDuration(rawUs, TimeUnit.Microsecond);
+            string actual = IntervalSerializingStream.FormatDuration(rawUs, TimeUnit.Microsecond);
             Assert.Equal(expected, actual);
         }
 
@@ -79,7 +78,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         {
             // 3 days 12 h 30 m 15 s in nanoseconds
             long rawNs = 304_215L * 1_000_000_000L;
-            string actual = ComplexTypeSerializingStream.FormatDuration(rawNs, TimeUnit.Nanosecond);
+            string actual = IntervalSerializingStream.FormatDuration(rawNs, TimeUnit.Nanosecond);
             Assert.Equal("3 12:30:15.000000000", actual);
         }
 
@@ -87,7 +86,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         public void FormatDuration_Seconds_ReturnsExpectedString()
         {
             long rawS = 304_215L; // 3 days 12 h 30 m 15 s
-            string actual = ComplexTypeSerializingStream.FormatDuration(rawS, TimeUnit.Second);
+            string actual = IntervalSerializingStream.FormatDuration(rawS, TimeUnit.Second);
             Assert.Equal("3 12:30:15.000000000", actual);
         }
 
@@ -95,7 +94,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         public void FormatDuration_Milliseconds_ReturnsExpectedString()
         {
             long rawMs = 304_215_000L; // 3 days 12 h 30 m 15 s
-            string actual = ComplexTypeSerializingStream.FormatDuration(rawMs, TimeUnit.Millisecond);
+            string actual = IntervalSerializingStream.FormatDuration(rawMs, TimeUnit.Millisecond);
             Assert.Equal("3 12:30:15.000000000", actual);
         }
 
@@ -112,7 +111,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
                 .Build();
 
             using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
-            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             Schema rewritten = stream.Schema;
             Assert.Equal(2, rewritten.FieldsList.Count);
@@ -130,7 +129,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
                 .Build();
 
             using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
-            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             Schema rewritten = stream.Schema;
             Assert.Equal(2, rewritten.FieldsList.Count);
@@ -149,10 +148,9 @@ namespace AdbcDrivers.Databricks.Tests.Unit
                 .Build();
 
             using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
-            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             Schema rewritten = stream.Schema;
-            Assert.Equal(3, rewritten.FieldsList.Count);
             Assert.IsType<Int64Type>(rewritten.FieldsList[0].DataType);
             Assert.IsType<StringType>(rewritten.FieldsList[1].DataType);
             Assert.IsType<DoubleType>(rewritten.FieldsList[2].DataType);
@@ -165,11 +163,10 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         [Fact]
         public async Task ReadNextBatch_YearMonthColumn_ConvertsValues()
         {
-            // Build a batch with two rows: 30 months ("2-6") and null
             var ymBuilder = new YearMonthIntervalArray.Builder();
-            ymBuilder.Append(new YearMonthInterval(30)); // 2-6
+            ymBuilder.Append(new YearMonthInterval(30)); // "2-6"
             ymBuilder.AppendNull();
-            ymBuilder.Append(new YearMonthInterval(12)); // 1-0
+            ymBuilder.Append(new YearMonthInterval(12)); // "1-0"
             YearMonthIntervalArray ymArray = ymBuilder.Build();
 
             Schema schema = new Schema.Builder()
@@ -179,7 +176,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { ymArray }, ymArray.Length);
 
             using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
-            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);
@@ -213,7 +210,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { dArray }, dArray.Length);
 
             using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
-            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);
@@ -254,7 +251,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit
                 new IArrowArray[] { idArray, ymArray, nameArray }, 1);
 
             using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
-            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner);
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);
@@ -265,36 +262,6 @@ namespace AdbcDrivers.Databricks.Tests.Unit
 
             Assert.Equal("2-6", ((StringArray)result.Column(1)).GetString(0));
             Assert.Equal("Alice", ((StringArray)result.Column(2)).GetString(0));
-        }
-
-        // -----------------------------------------------------------------------
-        // serializeComplexTypes=false: intervals still converted, complex untouched
-        // -----------------------------------------------------------------------
-
-        [Fact]
-        public async Task ReadNextBatch_SerializeComplexTypesFalse_IntervalStillConverted()
-        {
-            var ymBuilder = new YearMonthIntervalArray.Builder();
-            ymBuilder.Append(new YearMonthInterval(30)); // "2-6"
-            YearMonthIntervalArray ymArray = ymBuilder.Build();
-
-            Schema schema = new Schema.Builder()
-                .Field(f => f.Name("tenure").DataType(new IntervalType(IntervalUnit.YearMonth)).Nullable(true))
-                .Build();
-
-            RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { ymArray }, ymArray.Length);
-
-            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
-            // serializeComplexTypes=false — complex types pass through, but intervals are still converted
-            using ComplexTypeSerializingStream stream = new ComplexTypeSerializingStream(inner, serializeComplexTypes: false);
-
-            // Schema: interval column must still be rewritten to StringType
-            Assert.IsType<StringType>(stream.Schema.FieldsList[0].DataType);
-
-            RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
-            Assert.NotNull(result);
-            StringArray strings = (StringArray)result!.Column(0);
-            Assert.Equal("2-6", strings.GetString(0));
         }
 
         // -----------------------------------------------------------------------

--- a/csharp/test/Unit/IntervalSerializingStreamTests.cs
+++ b/csharp/test/Unit/IntervalSerializingStreamTests.cs
@@ -84,6 +84,11 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         [InlineData(304_215_000_000L, "3 12:30:15.000000000")]                      // 3 d 12 h 30 m 15 s
         [InlineData(304_215_000_500L, "3 12:30:15.000500000")]                      // plus 500 us
         [InlineData(-304_215_000_000L, "-3 12:30:15.000000000")]                    // negative: matches JDBC and server
+        // Databricks boundary: ±106,751,991 days (Long.MAX_VALUE microseconds).
+        // These would silently overflow if converted to nanoseconds first (* 1_000).
+        [InlineData(9_223_372_022_400_000_000L, "106751991 00:00:00.000000000")]    // max_positive
+        [InlineData(-9_223_372_022_400_000_000L, "-106751991 00:00:00.000000000")]  // max_negative
+        [InlineData(9_223_372_022_399_999_999L, "106751990 23:59:59.999999000")]    // near_max
         public void FormatDuration_Microseconds_ReturnsExpectedString(long rawUs, string expected)
         {
             string actual = IntervalSerializingStream.FormatDuration(rawUs, TimeUnit.Microsecond);
@@ -102,17 +107,29 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         [Fact]
         public void FormatDuration_Seconds_ReturnsExpectedString()
         {
-            long rawS = 304_215L; // 3 days 12 h 30 m 15 s
+            // 3 days 12 h 30 m 15 s — and a large value that would overflow if multiplied to ns.
+            long rawS = 304_215L;
             string actual = IntervalSerializingStream.FormatDuration(rawS, TimeUnit.Second);
             Assert.Equal("3 12:30:15.000000000", actual);
+
+            // 106,751 days in seconds (just under the nanosecond overflow boundary)
+            long largeSec = 106_751L * 86_400L;
+            string largeActual = IntervalSerializingStream.FormatDuration(largeSec, TimeUnit.Second);
+            Assert.Equal("106751 00:00:00.000000000", largeActual);
         }
 
         [Fact]
         public void FormatDuration_Milliseconds_ReturnsExpectedString()
         {
-            long rawMs = 304_215_000L; // 3 days 12 h 30 m 15 s
+            // 3 days 12 h 30 m 15 s — and a large value that would overflow if multiplied to ns.
+            long rawMs = 304_215_000L;
             string actual = IntervalSerializingStream.FormatDuration(rawMs, TimeUnit.Millisecond);
             Assert.Equal("3 12:30:15.000000000", actual);
+
+            // 106,751 days in milliseconds (just under the nanosecond overflow boundary)
+            long largeMs = 106_751L * 86_400_000L;
+            string largeActual = IntervalSerializingStream.FormatDuration(largeMs, TimeUnit.Millisecond);
+            Assert.Equal("106751 00:00:00.000000000", largeActual);
         }
 
         // -----------------------------------------------------------------------

--- a/csharp/test/Unit/IntervalSerializingStreamTests.cs
+++ b/csharp/test/Unit/IntervalSerializingStreamTests.cs
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,8 +37,6 @@ namespace AdbcDrivers.Databricks.Tests.Unit
     /// </summary>
     public class IntervalSerializingStreamTests
     {
-        private static readonly Dictionary<string, string> IntervalMetadata =
-            new Dictionary<string, string> { ["Spark:DataType:SqlName"] = "INTERVAL" };
 
         // -----------------------------------------------------------------------
         // FormatYearMonth static helper
@@ -103,61 +100,69 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         }
 
         // -----------------------------------------------------------------------
-        // Schema rewriting — interval/duration columns
+        // Schema — the wrapper reports the pre-built output schema as-is
         // -----------------------------------------------------------------------
 
         [Fact]
         public void Schema_YearMonthColumn_IsRewrittenToString()
         {
-            Schema original = new Schema.Builder()
+            Schema innerSchema = new Schema.Builder()
                 .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true, IntervalMetadata))
+                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true))
+                .Build();
+            Schema outputSchema = new Schema.Builder()
+                .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
+                .Field(f => f.Name("tenure").DataType(StringType.Default).Nullable(true))
                 .Build();
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
+            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, System.Array.Empty<RecordBatch>());
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 1 });
 
-            Schema rewritten = stream.Schema;
-            Assert.Equal(2, rewritten.FieldsList.Count);
-            Assert.IsType<Int32Type>(rewritten.FieldsList[0].DataType);
-            Assert.IsType<StringType>(rewritten.FieldsList[1].DataType);
-            Assert.Equal("tenure", rewritten.FieldsList[1].Name);
+            Schema reported = stream.Schema;
+            Assert.Equal(2, reported.FieldsList.Count);
+            Assert.IsType<Int32Type>(reported.FieldsList[0].DataType);
+            Assert.IsType<StringType>(reported.FieldsList[1].DataType);
+            Assert.Equal("tenure", reported.FieldsList[1].Name);
         }
 
         [Fact]
         public void Schema_DurationColumn_IsRewrittenToString()
         {
-            Schema original = new Schema.Builder()
-                .Field(new Field("elapsed", DurationType.Microsecond, nullable: true, IntervalMetadata))
+            Schema innerSchema = new Schema.Builder()
+                .Field(new Field("elapsed", DurationType.Microsecond, nullable: true))
+                .Field(f => f.Name("label").DataType(StringType.Default).Nullable(true))
+                .Build();
+            Schema outputSchema = new Schema.Builder()
+                .Field(f => f.Name("elapsed").DataType(StringType.Default).Nullable(true))
                 .Field(f => f.Name("label").DataType(StringType.Default).Nullable(true))
                 .Build();
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
+            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, System.Array.Empty<RecordBatch>());
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 0 });
 
-            Schema rewritten = stream.Schema;
-            Assert.Equal(2, rewritten.FieldsList.Count);
-            Assert.IsType<StringType>(rewritten.FieldsList[0].DataType);
-            Assert.Equal("elapsed", rewritten.FieldsList[0].Name);
-            Assert.IsType<StringType>(rewritten.FieldsList[1].DataType);
+            Schema reported = stream.Schema;
+            Assert.Equal(2, reported.FieldsList.Count);
+            Assert.IsType<StringType>(reported.FieldsList[0].DataType);
+            Assert.Equal("elapsed", reported.FieldsList[0].Name);
+            Assert.IsType<StringType>(reported.FieldsList[1].DataType);
         }
 
         [Fact]
         public void Schema_NonIntervalColumns_AreUnchanged()
         {
-            Schema original = new Schema.Builder()
+            Schema schema = new Schema.Builder()
                 .Field(f => f.Name("a").DataType(Int64Type.Default).Nullable(false))
                 .Field(f => f.Name("b").DataType(StringType.Default).Nullable(true))
                 .Field(f => f.Name("c").DataType(DoubleType.Default).Nullable(true))
                 .Build();
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(original, System.Array.Empty<RecordBatch>());
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
+            using IArrowArrayStream inner = new StubArrowArrayStream(schema, System.Array.Empty<RecordBatch>());
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, schema, System.Array.Empty<int>());
 
-            Schema rewritten = stream.Schema;
-            Assert.IsType<Int64Type>(rewritten.FieldsList[0].DataType);
-            Assert.IsType<StringType>(rewritten.FieldsList[1].DataType);
-            Assert.IsType<DoubleType>(rewritten.FieldsList[2].DataType);
+            Schema reported = stream.Schema;
+            Assert.IsType<Int64Type>(reported.FieldsList[0].DataType);
+            Assert.IsType<StringType>(reported.FieldsList[1].DataType);
+            Assert.IsType<DoubleType>(reported.FieldsList[2].DataType);
         }
 
         // -----------------------------------------------------------------------
@@ -173,14 +178,17 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             ymBuilder.Append(new YearMonthInterval(12)); // "1-0"
             YearMonthIntervalArray ymArray = ymBuilder.Build();
 
-            Schema schema = new Schema.Builder()
-                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true, IntervalMetadata))
+            Schema innerSchema = new Schema.Builder()
+                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true))
+                .Build();
+            Schema outputSchema = new Schema.Builder()
+                .Field(f => f.Name("tenure").DataType(StringType.Default).Nullable(true))
                 .Build();
 
-            RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { ymArray }, ymArray.Length);
+            RecordBatch batch = new RecordBatch(innerSchema, new IArrowArray[] { ymArray }, ymArray.Length);
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
+            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, new[] { batch });
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 0 });
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);
@@ -207,14 +215,17 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             dBuilder.AppendNull();
             DurationArray dArray = dBuilder.Build();
 
-            Schema schema = new Schema.Builder()
-                .Field(new Field("elapsed", DurationType.Microsecond, nullable: true, IntervalMetadata))
+            Schema innerSchema = new Schema.Builder()
+                .Field(new Field("elapsed", DurationType.Microsecond, nullable: true))
+                .Build();
+            Schema outputSchema = new Schema.Builder()
+                .Field(f => f.Name("elapsed").DataType(StringType.Default).Nullable(true))
                 .Build();
 
-            RecordBatch batch = new RecordBatch(schema, new IArrowArray[] { dArray }, dArray.Length);
+            RecordBatch batch = new RecordBatch(innerSchema, new IArrowArray[] { dArray }, dArray.Length);
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
+            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, new[] { batch });
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 0 });
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);
@@ -241,9 +252,14 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             var nameBuilder = new StringArray.Builder();
             nameBuilder.Append("Alice");
 
-            Schema schema = new Schema.Builder()
+            Schema innerSchema = new Schema.Builder()
                 .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
-                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true, IntervalMetadata))
+                .Field(new Field("tenure", new IntervalType(IntervalUnit.YearMonth), nullable: true))
+                .Field(f => f.Name("name").DataType(StringType.Default).Nullable(true))
+                .Build();
+            Schema outputSchema = new Schema.Builder()
+                .Field(f => f.Name("id").DataType(Int32Type.Default).Nullable(false))
+                .Field(f => f.Name("tenure").DataType(StringType.Default).Nullable(true))
                 .Field(f => f.Name("name").DataType(StringType.Default).Nullable(true))
                 .Build();
 
@@ -251,11 +267,11 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             YearMonthIntervalArray ymArray = ymBuilder.Build();
             StringArray nameArray = nameBuilder.Build();
 
-            RecordBatch batch = new RecordBatch(schema,
+            RecordBatch batch = new RecordBatch(innerSchema,
                 new IArrowArray[] { idArray, ymArray, nameArray }, 1);
 
-            using IArrowArrayStream inner = new StubArrowArrayStream(schema, new[] { batch });
-            using IntervalSerializingStream stream = new IntervalSerializingStream(inner);
+            using IArrowArrayStream inner = new StubArrowArrayStream(innerSchema, new[] { batch });
+            using IntervalSerializingStream stream = new IntervalSerializingStream(inner, outputSchema, new[] { 1 });
 
             RecordBatch? result = await stream.ReadNextRecordBatchAsync(CancellationToken.None);
             Assert.NotNull(result);

--- a/csharp/test/Unit/StatementExecution/StatementExecutionEmptyResultSchemaTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionEmptyResultSchemaTests.cs
@@ -86,12 +86,12 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 connection: connection);
         }
 
-        private static ResultManifest BuildManifest(params (string name, string typeName)[] columns)
+        private static ResultManifest BuildManifest(params (string name, string typeName, string typeText)[] columns)
         {
             var columnInfos = new List<ColumnInfo>();
-            foreach (var (name, typeName) in columns)
+            foreach (var (name, typeName, typeText) in columns)
             {
-                columnInfos.Add(new ColumnInfo { Name = name, TypeName = typeName, TypeText = typeName });
+                columnInfos.Add(new ColumnInfo { Name = name, TypeName = typeName, TypeText = typeText });
             }
 
             return new ResultManifest
@@ -107,7 +107,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         public async Task ExecuteQuery_EmptyTable_SchemaContainsCorrectColumns()
         {
             // Arrange: server returns SUCCEEDED with schema but no data
-            var manifest = BuildManifest(("id", "INT"), ("name", "STRING"), ("score", "DOUBLE"));
+            var manifest = BuildManifest(("id", "INT", "INT"), ("name", "STRING", "STRING"), ("score", "DOUBLE", "DOUBLE"));
 
             var mockClient = new Mock<IStatementExecutionClient>();
             mockClient
@@ -145,14 +145,15 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         public async Task ExecuteQuery_EmptyTable_ArrowTypesAreMappedCorrectly()
         {
             // Arrange: various Databricks SQL types
+            // TypeName is the bare Spark alias; TypeText is the canonical SQL name (matching real server).
             var manifest = BuildManifest(
-                ("a", "INT"),
-                ("b", "BIGINT"),
-                ("c", "STRING"),
-                ("d", "BOOLEAN"),
-                ("e", "DOUBLE"),
-                ("f", "DATE"),
-                ("g", "TIMESTAMP"));
+                ("a", "INT",       "INT"),
+                ("b", "LONG",      "BIGINT"),
+                ("c", "STRING",    "STRING"),
+                ("d", "BOOLEAN",   "BOOLEAN"),
+                ("e", "DOUBLE",    "DOUBLE"),
+                ("f", "DATE",      "DATE"),
+                ("g", "TIMESTAMP", "TIMESTAMP"));
 
             var mockClient = new Mock<IStatementExecutionClient>();
             mockClient
@@ -187,7 +188,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         public async Task ExecuteQuery_EmptyTable_FieldsHaveSparkSqlNameMetadata()
         {
             // Arrange: server returns SUCCEEDED with schema but no data
-            var manifest = BuildManifest(("id", "INT"), ("name", "STRING"));
+            var manifest = BuildManifest(("id", "INT", "INT"), ("name", "STRING", "STRING"));
 
             var mockClient = new Mock<IStatementExecutionClient>();
             mockClient
@@ -219,8 +220,11 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         [Fact]
         public async Task ExecuteQuery_EmptyTable_SqlNameAliasesNormalized()
         {
-            // Arrange: TypeText carries canonical names matching Thrift server output.
-            var manifest = BuildManifest(("a", "BIGINT"), ("b", "TINYINT"), ("c", "SMALLINT"));
+            // Arrange: TypeName uses Spark aliases; TypeText carries canonical SQL names (matching real server).
+            var manifest = BuildManifest(
+                ("a", "LONG",  "BIGINT"),
+                ("b", "BYTE",  "TINYINT"),
+                ("c", "SHORT", "SMALLINT"));
 
             var mockClient = new Mock<IStatementExecutionClient>();
             mockClient

--- a/csharp/test/Unit/StatementExecution/StatementExecutionEmptyResultSchemaTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionEmptyResultSchemaTests.cs
@@ -91,7 +91,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
             var columnInfos = new List<ColumnInfo>();
             foreach (var (name, typeName) in columns)
             {
-                columnInfos.Add(new ColumnInfo { Name = name, TypeName = typeName });
+                columnInfos.Add(new ColumnInfo { Name = name, TypeName = typeName, TypeText = typeName });
             }
 
             return new ResultManifest
@@ -219,10 +219,8 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         [Fact]
         public async Task ExecuteQuery_EmptyTable_SqlNameAliasesNormalized()
         {
-            // Arrange: SEA server returns Spark-internal aliases (LONG, BYTE, SHORT)
-            // rather than canonical SQL names. Verify they are normalized to the values
-            // PowerBI's DatabricksTypeMap expects (BIGINT, TINYINT, SMALLINT).
-            var manifest = BuildManifest(("a", "LONG"), ("b", "BYTE"), ("c", "SHORT"));
+            // Arrange: TypeText carries canonical names matching Thrift server output.
+            var manifest = BuildManifest(("a", "BIGINT"), ("b", "TINYINT"), ("c", "SMALLINT"));
 
             var mockClient = new Mock<IStatementExecutionClient>();
             mockClient


### PR DESCRIPTION
## Problem

The SEA result pipeline had two related type-alignment issues compared to Thrift:

1. **INTERVAL columns** — SEA returned native Arrow `YearMonthIntervalType` / `DurationType` arrays, while Thrift emitted plain UTF-8 strings (`"2-6"` for year-month, `"3 12:30:15.000000000"` for day-time).
2. **Complex type columns (ARRAY, MAP, STRUCT)** — The existing `ComplexTypeSerializingStream` detected complex types by inspecting the Arrow field type (`ListType || MapType || StructType`), which worked for the inline path but broke on CloudFetch: the manifest schema already declared these columns as `StringType`, so the detection always returned false and native Arrow arrays leaked through.

Both issues shared a root cause: the two result paths (inline vs. CloudFetch) exposed different schemas to the stream wrappers — inline used the Arrow IPC-embedded schema (native types), CloudFetch used the manifest schema (already `StringType`). Detection logic that worked for one path silently failed for the other.

## Changes

### New file: `csharp/src/IntervalSerializingStream.cs`

A thin `IArrowArrayStream` decorator that converts native interval arrays to UTF-8 strings:
- `YearMonthIntervalArray` → `"Y-M"` (e.g. 30 months → `"2-6"`)
- `DurationArray` → `"D HH:MM:SS.nnnnnnnnn"` (e.g. 304215 s → `"3 12:30:15.000000000"`)

Detects interval columns via `Spark:DataType:SqlName` field metadata (`ColumnMetadataHelper.ArrowMetadataKey`) rather than Arrow type inspection, so detection is consistent regardless of which schema the inner stream exposes.

### Modified: `csharp/src/ComplexTypeSerializingStream.cs`

Replaced `BuildStringSchema` / `IsComplexType` (Arrow-type-based detection) with `DetectComplexColumns`, which reads `Spark:DataType:SqlName` metadata from each field. Same pattern as `IntervalSerializingStream`: one-arg constructor, self-detecting, works on any result path.

### Modified: `csharp/src/StatementExecution/StatementExecutionStatement.cs`

- **Manifest schema unified across all three result paths** (inline, CloudFetch, empty): `GetSchemaFromManifest` is called once in `CreateReader` and the result is passed to every path. Previously inline used the IPC-embedded schema; now all paths agree.
- `InlineArrowStreamReader` accepts and exposes the manifest schema instead of `_streamReader.Schema`.
- `CreateCloudFetchReader` receives the already-computed `manifestSchema` rather than recomputing it internally.
- Both `IntervalSerializingStream` and `ComplexTypeSerializingStream` are wired in after `CreateReader`, where the schema is already the manifest schema.

### Modified: `csharp/src/StatementExecution/ColumnMetadataHelper.cs`

Added `ArrowMetadataKey = "Spark:DataType:SqlName"` constant, mirroring `ARROW_METADATA_KEY` in the JDBC driver (`DatabricksJdbcConstants.java`). `TryGetSchemaFromManifest` now embeds this key on every field so stream wrappers can rely on it being present regardless of result path (for SEA the server may not embed it in the Arrow IPC bytes).

## Test Plan

- **Unit tests** (`csharp/test/Unit/IntervalSerializingStreamTests.cs`): 23 tests covering format helpers, null handling, schema pass-through, and end-to-end stream conversion for both interval kinds.
- **E2E tests** (`csharp/test/E2E/IntervalValueTests.cs`): 10 tests covering inline and CloudFetch paths for both interval kinds plus null values; INTERVAL-009/010 run the same query on independent Thrift and SEA connections and assert identical output cell-by-cell.

## References

- PECO-3015 (interval UTF-8 alignment)
- PECO-3016 (complex type CloudFetch fix)