### PR TITLE
[SEA] Fix GetCatalogsAsync to handle ADBC catalog patterns correctly (PECO-3018)

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -18,6 +18,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Http;
@@ -571,7 +573,28 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         async Task<IReadOnlyList<string>> IGetObjectsDataProvider.GetCatalogsAsync(string? catalogPattern, CancellationToken cancellationToken)
         {
-            string sql = new ShowCatalogsCommand(catalogPattern).Build();
+            // Catalog-pattern handling (mirrors the Thrift path in HiveServer2Connection):
+            //
+            // SHOW CATALOGS LIKE '<pattern>' is not suitable for ADBC patterns because:
+            //   - "comparator\_tests" (ADBC escaped literal underscore) would emit
+            //     SHOW CATALOGS LIKE 'comparator_tests' where SQL _ is a wildcard → too broad.
+            //   - "%" would emit SHOW CATALOGS LIKE '*' which may not be valid SQL.
+            //
+            // Instead we always issue a bare SHOW CATALOGS (returns all catalogs) and then
+            // filter client-side using the standard ADBC/SQL pattern-to-regex conversion,
+            // exactly as the Thrift path does via PatternToRegEx().
+            //
+            // Special cases:
+            //   - null   → no filter, return all catalogs (JDBC spec: null means "any catalog").
+            //   - ""     → no catalog can have an empty name; return empty list immediately.
+
+            if (catalogPattern != null && catalogPattern.Length == 0)
+                return System.Array.Empty<string>();
+
+            // Build optional client-side filter.
+            Regex? catalogFilter = catalogPattern != null ? CatalogPatternToRegex(catalogPattern) : null;
+
+            string sql = new ShowCatalogsCommand().Build(); // SHOW CATALOGS (no LIKE)
             var batches = await ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
             var result = new List<string>();
             foreach (var batch in batches)
@@ -580,8 +603,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 if (catalogArray == null) continue;
                 for (int i = 0; i < batch.Length; i++)
                 {
-                    if (!catalogArray.IsNull(i))
-                        result.Add(catalogArray.GetString(i));
+                    if (catalogArray.IsNull(i)) continue;
+                    string catalog = catalogArray.GetString(i);
+                    if (catalogFilter == null || catalogFilter.IsMatch(catalog))
+                        result.Add(catalog);
                 }
             }
             return result;
@@ -752,6 +777,70 @@ namespace AdbcDrivers.Databricks.StatementExecution
         internal List<RecordBatch> ExecuteMetadataSql(string sql, CancellationToken cancellationToken = default)
         {
             return ExecuteMetadataSqlAsync(sql, cancellationToken).GetAwaiter().GetResult();
+        }
+
+        // ----------------------------------------------------------------
+        // ADBC catalog-pattern helpers (used by GetCatalogsAsync)
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the ADBC/SQL pattern contains an unescaped
+        /// <c>%</c> or <c>_</c> wildcard character.
+        /// A <c>\</c> immediately before <c>%</c>, <c>_</c>, or <c>\</c> is an escape sequence
+        /// and does not count as a wildcard.
+        /// </summary>
+        internal static bool ContainsUnescapedWildcard(string pattern)
+        {
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                char c = pattern[i];
+                if (c == '\\')
+                {
+                    i++; // skip the escaped character
+                    continue;
+                }
+                if (c == '%' || c == '_')
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Converts an ADBC/SQL wildcard pattern to a case-insensitive <see cref="Regex"/>
+        /// anchored to the full string.
+        /// <list type="bullet">
+        ///   <item><c>%</c>  → <c>.*</c> (any sequence of characters)</item>
+        ///   <item><c>_</c>  → <c>.</c>  (any single character)</item>
+        ///   <item><c>\_</c> → <c>_</c>  (literal underscore)</item>
+        ///   <item><c>\%</c> → <c>%</c>  (literal percent)</item>
+        ///   <item><c>\\</c> → <c>\</c>  (literal backslash)</item>
+        /// </list>
+        /// </summary>
+        internal static Regex CatalogPatternToRegex(string pattern)
+        {
+            var sb = new StringBuilder("^");
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                char c = pattern[i];
+                if (c == '\\' && i + 1 < pattern.Length)
+                {
+                    char next = pattern[i + 1];
+                    if (next == '_' || next == '%' || next == '\\')
+                    {
+                        sb.Append(Regex.Escape(next.ToString()));
+                        i++;
+                        continue;
+                    }
+                }
+                if (c == '%')
+                    sb.Append(".*");
+                else if (c == '_')
+                    sb.Append('.');
+                else
+                    sb.Append(Regex.Escape(c.ToString()));
+            }
+            sb.Append('$');
+            return new Regex(sb.ToString(), RegexOptions.IgnoreCase);
         }
 
         /// <summary>

--- a/csharp/test/E2E/CloseOperationE2ETest.cs
+++ b/csharp/test/E2E/CloseOperationE2ETest.cs
@@ -134,10 +134,11 @@ namespace AdbcDrivers.Databricks.Tests
 
             var parameters = new Dictionary<string, string>
             {
-                [DatabricksParameters.Protocol] = "thrift",
                 [DatabricksParameters.UseCloudFetch] = useCloudFetch.ToString(),
                 [DatabricksParameters.EnableDirectResults] = enableDirectResults.ToString(),
             };
+            if (!string.IsNullOrEmpty(TestConfiguration.Protocol))
+                parameters[DatabricksParameters.Protocol] = TestConfiguration.Protocol;
 
             // Keep connection alive without disposing — simulates a connection pool.
             // In a pool CloseSession is never sent, so CloseOperation is the only mechanism

--- a/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
@@ -47,6 +47,12 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable), "Test configuration not available");
         }
 
+        private void SkipIfThriftNotSupported()
+        {
+            SkipIfNotConfigured();
+            Skip.If(TestConfiguration.Protocol == "rest", "Thrift protocol not available on SEA-only endpoint");
+        }
+
         private AdbcConnection CreateThriftConnection()
         {
             var parameters = GetDriverParameters(TestConfiguration);
@@ -126,7 +132,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task Thrift_GetCatalogs_ContainsMain()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var conn = CreateThriftConnection();
             var rows = await ReadMetadata(conn, "GetCatalogs");
             Assert.True(rows.Count > 0, "GetCatalogs should return at least one catalog");
@@ -146,7 +152,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task GetCatalogs_ThriftAndSEA_SameRowCount()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var thrift = CreateThriftConnection();
             using var sea = CreateSeaConnection();
             var thriftRows = await ReadMetadata(thrift, "GetCatalogs");
@@ -159,7 +165,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task Thrift_GetTables_ReturnsAllColumnTypes()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var conn = CreateThriftConnection();
             var rows = await ReadMetadata(conn, "GetTables", TestCatalog, TestSchema);
             Assert.Contains(rows, r => r["TABLE_NAME"] == TestTable);
@@ -190,7 +196,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task GetTables_ThriftAndSEA_SameCount()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var thrift = CreateThriftConnection();
             using var sea = CreateSeaConnection();
             var thriftRows = await ReadMetadata(thrift, "GetTables", TestCatalog, TestSchema);
@@ -203,7 +209,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task Thrift_GetColumnsExtended_Returns20Columns()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var conn = CreateThriftConnection();
             var rows = await ReadMetadata(conn, "GetColumnsExtended", TestCatalog, TestSchema, TestTable);
             Assert.Equal(20, rows.Count);
@@ -221,7 +227,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task GetColumnsExtended_ThriftAndSEA_SameColumnNames()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var thrift = CreateThriftConnection();
             using var sea = CreateSeaConnection();
             var thriftRows = await ReadMetadata(thrift, "GetColumnsExtended", TestCatalog, TestSchema, TestTable);
@@ -240,7 +246,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task GetColumnsExtended_ThriftAndSEA_32ColumnSchema()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var thrift = CreateThriftConnection();
             using var sea = CreateSeaConnection();
             var thriftRows = await ReadMetadata(thrift, "GetColumnsExtended", TestCatalog, TestSchema, TestTable);
@@ -309,7 +315,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public async Task Thrift_GetPrimaryKeys_ReturnsPKColumns()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var conn = CreateThriftConnection();
             var rows = await ReadMetadata(conn, "GetPrimaryKeys", TestCatalog, TestSchema, TestTable);
             Assert.Equal(2, rows.Count);
@@ -333,7 +339,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public void Thrift_GetTableSchema_Returns20Fields()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var conn = CreateThriftConnection();
             // Use cross_ref_customers to avoid Thrift NotImplementedException on complex types
             var schema = conn.GetTableSchema(TestCatalog, TestSchema, "cross_ref_customers");
@@ -354,7 +360,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         [SkippableFact]
         public void GetTableSchema_ThriftAndSEA_SameFieldNames()
         {
-            SkipIfNotConfigured();
+            SkipIfThriftNotSupported();
             using var thrift = CreateThriftConnection();
             using var sea = CreateSeaConnection();
             var thriftSchema = thrift.GetTableSchema(TestCatalog, TestSchema, "cross_ref_customers");

--- a/csharp/test/Unit/StatementExecution/GetCatalogsAsyncTests.cs
+++ b/csharp/test/Unit/StatementExecution/GetCatalogsAsyncTests.cs
@@ -1,0 +1,213 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Text.RegularExpressions;
+using AdbcDrivers.Databricks.StatementExecution;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
+{
+    /// <summary>
+    /// Unit tests for the helper methods introduced to fix PECO-3018 (D8):
+    /// <see cref="StatementExecutionConnection.ContainsUnescapedWildcard"/> and
+    /// <see cref="StatementExecutionConnection.CatalogPatternToRegex"/>.
+    ///
+    /// These helpers enable GetCatalogsAsync to correctly handle wildcard catalog
+    /// patterns (%, _), escaped literals (\_), and empty strings without sending
+    /// broken LIKE clauses to the server.
+    ///
+    /// Root cause: the previous implementation passed the ADBC catalogPattern directly
+    /// to ShowCatalogsCommand which converted it via ConvertPattern() and appended it as
+    /// a SQL LIKE clause.  This was wrong because:
+    ///   - "comparator\_tests" → SHOW CATALOGS LIKE 'comparator_tests'
+    ///     (SQL _ is a single-char wildcard, so the literal underscore was not preserved)
+    ///   - "%" → SHOW CATALOGS LIKE '*'
+    ///     (the glob '*' may not be valid in all SQL LIKE contexts)
+    ///
+    /// Fix: always issue SHOW CATALOGS (no LIKE) and filter client-side using
+    /// CatalogPatternToRegex, mirroring the Thrift path's PatternToRegEx().
+    /// </summary>
+    public class GetCatalogsAsyncTests
+    {
+        // ----------------------------------------------------------------
+        // ContainsUnescapedWildcard
+        // ----------------------------------------------------------------
+
+        [Theory]
+        [InlineData("%", true)]                      // bare % is a wildcard
+        [InlineData("compar%", true)]                // trailing %
+        [InlineData("_", true)]                      // bare _ is a wildcard
+        [InlineData("comparator_tests", true)]       // unescaped _ is a wildcard
+        [InlineData(@"comparator\_tests", false)]    // \_ is escaped → not a wildcard
+        [InlineData(@"\%", false)]                   // \% is escaped → not a wildcard
+        [InlineData("", false)]                      // empty — no wildcard
+        [InlineData("nonexistent", false)]           // plain literal — no wildcard
+        [InlineData("main", false)]                  // plain literal — no wildcard
+        [InlineData(@"\\", false)]                   // escaped backslash — no wildcard
+        public void ContainsUnescapedWildcard_ReturnsExpected(string pattern, bool expected)
+        {
+            Assert.Equal(expected, StatementExecutionConnection.ContainsUnescapedWildcard(pattern));
+        }
+
+        // ----------------------------------------------------------------
+        // CatalogPatternToRegex — wildcard expansion
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void CatalogPatternToRegex_PercentMatchesAllCatalogs()
+        {
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("%");
+            Assert.Matches(regex, "main");
+            Assert.Matches(regex, "comparator_tests");
+            Assert.Matches(regex, "hive_metastore");
+            Assert.Matches(regex, "");
+        }
+
+        [Fact]
+        public void CatalogPatternToRegex_PercentPrefix_MatchesCatalogsStartingWithPrefix()
+        {
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("compar%");
+            Assert.Matches(regex, "comparator_tests");
+            Assert.Matches(regex, "comparator-tests");
+            Assert.Matches(regex, "compar");
+            Assert.DoesNotMatch(regex, "main");
+            Assert.DoesNotMatch(regex, "xcompar");
+        }
+
+        [Fact]
+        public void CatalogPatternToRegex_UnderscoreMatchesSingleChar()
+        {
+            // "comparator_tests" pattern: _ matches any single char
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("comparator_tests");
+            Assert.Matches(regex, "comparator_tests");
+            Assert.Matches(regex, "comparator-tests");
+            Assert.Matches(regex, "comparatorXtests");
+            Assert.DoesNotMatch(regex, "comparatortests");   // _ requires exactly one char
+            Assert.DoesNotMatch(regex, "comparator__tests"); // one char too many
+        }
+
+        [Fact]
+        public void CatalogPatternToRegex_EscapedUnderscore_MatchesLiteralUnderscore()
+        {
+            // D8 bug case: "comparator\_tests" — \_ is a literal underscore, not a wildcard.
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex(@"comparator\_tests");
+            Assert.Matches(regex, "comparator_tests");
+            Assert.DoesNotMatch(regex, "comparator-tests");
+            Assert.DoesNotMatch(regex, "comparatorXtests");
+            Assert.DoesNotMatch(regex, "comparator_Xtests");
+        }
+
+        [Fact]
+        public void CatalogPatternToRegex_EscapedPercent_MatchesLiteralPercent()
+        {
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex(@"cat\%log");
+            Assert.Matches(regex, "cat%log");
+            Assert.DoesNotMatch(regex, "catalog");
+            Assert.DoesNotMatch(regex, "catXlog");
+        }
+
+        [Fact]
+        public void CatalogPatternToRegex_IsCaseInsensitive()
+        {
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("MAIN");
+            Assert.Matches(regex, "main");
+            Assert.Matches(regex, "Main");
+            Assert.Matches(regex, "MAIN");
+        }
+
+        [Fact]
+        public void CatalogPatternToRegex_RegexSpecialCharsInPattern_AreEscaped()
+        {
+            // Dots in a catalog name must be treated as literals, not regex wildcards.
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("my.catalog");
+            Assert.Matches(regex, "my.catalog");
+            Assert.DoesNotMatch(regex, "myXcatalog"); // dot in pattern is literal
+        }
+
+        [Fact]
+        public void CatalogPatternToRegex_EscapedBackslash()
+        {
+            // \\ in pattern → literal backslash in output
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex(@"back\\slash");
+            Assert.Matches(regex, @"back\slash");
+            Assert.DoesNotMatch(regex, "backslash");
+        }
+
+        // ----------------------------------------------------------------
+        // D8 bug-report scenarios (from PECO-3018 bug report)
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void BugReport_D8_EscapedUnderscore_NotAWildcard()
+        {
+            // D8: "comparator\_tests" should match the literal catalog "comparator_tests"
+            // only, not "comparatorXtests" or other single-char variations.
+            Assert.False(StatementExecutionConnection.ContainsUnescapedWildcard(@"comparator\_tests"));
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex(@"comparator\_tests");
+            Assert.Matches(regex, "comparator_tests");
+            Assert.DoesNotMatch(regex, "comparator-tests");
+            Assert.DoesNotMatch(regex, "comparatorXtests");
+        }
+
+        [Fact]
+        public void BugReport_UnescapedUnderscore_IsSingleCharWildcard()
+        {
+            // "comparator_tests" (no escape): _ is a wildcard matching any single char.
+            Assert.True(StatementExecutionConnection.ContainsUnescapedWildcard("comparator_tests"));
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("comparator_tests");
+            Assert.Matches(regex, "comparator_tests");
+            Assert.Matches(regex, "comparator-tests");
+        }
+
+        [Fact]
+        public void BugReport_PercentPattern_DetectedAsWildcard()
+        {
+            // "%" should be a wildcard matching everything.
+            Assert.True(StatementExecutionConnection.ContainsUnescapedWildcard("%"));
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("%");
+            Assert.Matches(regex, "any_catalog");
+        }
+
+        [Fact]
+        public void BugReport_ComparPercentPrefix_DetectedAsWildcard()
+        {
+            // "compar%" should be a wildcard prefix match.
+            Assert.True(StatementExecutionConnection.ContainsUnescapedWildcard("compar%"));
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("compar%");
+            Assert.Matches(regex, "comparator_tests");
+            Assert.DoesNotMatch(regex, "main");
+        }
+
+        [Fact]
+        public void BugReport_EmptyString_NotAWildcard()
+        {
+            // Empty string: GetCatalogsAsync returns empty list immediately (no server call).
+            Assert.False(StatementExecutionConnection.ContainsUnescapedWildcard(""));
+        }
+
+        [Fact]
+        public void BugReport_NonexistentCatalog_NotAWildcard_NoMatch()
+        {
+            // "nonexistent": no wildcard. CatalogPatternToRegex produces a regex that
+            // matches only "nonexistent", so real catalogs won't appear in the result.
+            Assert.False(StatementExecutionConnection.ContainsUnescapedWildcard("nonexistent"));
+            Regex regex = StatementExecutionConnection.CatalogPatternToRegex("nonexistent");
+            Assert.DoesNotMatch(regex, "main");
+            Assert.DoesNotMatch(regex, "comparator_tests");
+            Assert.Matches(regex, "nonexistent");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the D8 bug case in `IGetObjectsDataProvider.GetCatalogsAsync` on the SEA (Statement Execution API) path.

**Root cause**: `GetCatalogsAsync` passed the ADBC `catalogPattern` directly to `ShowCatalogsCommand`, which converted it via `ConvertPattern()` and appended it as a SQL `LIKE` clause. This was wrong because:

- `"comparator\_tests"` → `SHOW CATALOGS LIKE 'comparator_tests'`  
  SQL `_` is a wildcard, so the escaped literal underscore was lost. The catalog `comparator_tests` would be found but so would `comparatorXtests` (too broad).
- `"%"` → `SHOW CATALOGS LIKE '*'` — glob `*` is not valid SQL LIKE syntax.
- `""` → `SHOW CATALOGS LIKE ''` — happened to return nothing, but by accident.

**Fix**: Mirror the Thrift path (`HiveServer2Connection.GetCatalogsAsync`) which fetches all catalogs via a bare `SHOW CATALOGS` request and filters results client-side using a pattern-to-regex conversion:

| `catalogPattern` | behavior |
|---|---|
| `null` | `SHOW CATALOGS`, no filter — return all (JDBC spec: null = any) |
| `""` | Return empty list immediately (no server call needed) |
| any other | `SHOW CATALOGS`, filter results with `CatalogPatternToRegex(pattern)` |

**New helpers** (analogous to `PatternToRegEx` in the Thrift layer):
- `ContainsUnescapedWildcard`: detects `%` or `_` not preceded by backslash
- `CatalogPatternToRegex`: converts ADBC/SQL pattern to anchored case-insensitive `Regex`
  - `%` → `.*`, `_` → `.`, `\_` → `_`, `\%` → `%`, `\\` → `\`

Also includes minor E2E test fixes to skip Thrift-specific tests when running against SEA-only endpoints.

**Note on hiveserver2**: This fix is entirely within the Databricks-specific layer (`csharp/src/StatementExecution/`). No changes were made to `csharp/hiveserver2/` (the upstream submodule).

## Test plan

- [x] 24 new unit tests in `GetCatalogsAsyncTests.cs` covering all pattern cases
- [x] `ContainsUnescapedWildcard`: 10 theory cases
- [x] `CatalogPatternToRegex`: wildcard expansion, escaped literals, case-insensitivity, regex-char escaping
- [x] D8 bug-report scenarios: `comparator\_tests`, `comparator_tests`, `%`, `compar%`, `""`, `nonexistent`
- [x] All unit tests pass: `dotnet test --filter "FullyQualifiedName~StatementExecution"` → 174 passed, 29 skipped (E2E only)
- [x] Build succeeds: `dotnet build AdbcDrivers.Databricks.csproj`

Fixes #PECO-3018