### PR TITLE
fix(csharp): set BUFFER_LENGTH to null in GetColumns result; re-enable CanGetColumnsExtended for SEA (PECO-3008)

### DIFF
--- a/csharp/src/FlatColumnsResultBuilder.cs
+++ b/csharp/src/FlatColumnsResultBuilder.cs
@@ -71,8 +71,7 @@ namespace AdbcDrivers.Databricks
 
                     if (info.Precision[i].HasValue) columnSizeBuilder.Append(info.Precision[i]!.Value); else columnSizeBuilder.AppendNull();
 
-                    int? bufLen = ColumnMetadataHelper.GetBufferLength(info.TypeName[i]);
-                    if (bufLen.HasValue) bufferLengthBuilder.Append(bufLen.Value); else bufferLengthBuilder.AppendNull();
+                    bufferLengthBuilder.AppendNull(); // JDBC spec: BUFFER_LENGTH is unused, always null
 
                     if (info.Scale[i].HasValue) decimalDigitsBuilder.Append(info.Scale[i]!.Value); else decimalDigitsBuilder.AppendNull();
 

--- a/csharp/src/FlatColumnsResultBuilder.cs
+++ b/csharp/src/FlatColumnsResultBuilder.cs
@@ -71,7 +71,11 @@ namespace AdbcDrivers.Databricks
 
                     if (info.Precision[i].HasValue) columnSizeBuilder.Append(info.Precision[i]!.Value); else columnSizeBuilder.AppendNull();
 
-                    bufferLengthBuilder.AppendNull(); // JDBC spec: BUFFER_LENGTH is unused, always null
+                    // BUFFER_LENGTH is a JDBC-compatibility column in the getColumns metadata result
+                    // (ADBC surfaces the same value as xdbc_buffer_length). It is defined as "not used"
+                    // by the JDBC contract, so no driver populates it — always null here, matching the
+                    // Thrift path (server leaves it unset) and the SEA DESC TABLE EXTENDED path.
+                    bufferLengthBuilder.AppendNull();
 
                     if (info.Scale[i].HasValue) decimalDigitsBuilder.Append(info.Scale[i]!.Value); else decimalDigitsBuilder.AppendNull();
 

--- a/csharp/src/FlatColumnsResultBuilder.cs
+++ b/csharp/src/FlatColumnsResultBuilder.cs
@@ -71,10 +71,13 @@ namespace AdbcDrivers.Databricks
 
                     if (info.Precision[i].HasValue) columnSizeBuilder.Append(info.Precision[i]!.Value); else columnSizeBuilder.AppendNull();
 
-                    // BUFFER_LENGTH is a JDBC-compatibility column in the getColumns metadata result
-                    // (ADBC surfaces the same value as xdbc_buffer_length). It is defined as "not used"
-                    // by the JDBC contract, so no driver populates it — always null here, matching the
-                    // Thrift path (server leaves it unset) and the SEA DESC TABLE EXTENDED path.
+                    // BUFFER_LENGTH is an ODBC carryover (SQLColumns col 8): the byte size an ODBC
+                    // application would allocate to bind/fetch the column into its own C buffer.
+                    // Managed APIs that own their buffers have no use for it, so JDBC marks it
+                    // "not used" — and ADBC even less so, since results are self-describing Arrow
+                    // (buffer sizes come from the column's type + data, not from a metadata field).
+                    // Always null here, matching the Thrift path and the SEA DESC TABLE EXTENDED path.
+                    // (ADBC surfaces the same field as xdbc_buffer_length.)
                     bufferLengthBuilder.AppendNull();
 
                     if (info.Scale[i].HasValue) decimalDigitsBuilder.Append(info.Scale[i]!.Value); else decimalDigitsBuilder.AppendNull();

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -476,13 +476,11 @@ namespace AdbcDrivers.Databricks.Tests
             Assert.Equal(TestConfiguration.Metadata.ExpectedColumnCount, actualBatchLength);
         }
 
-        // TODO: PECO-3008 - CanGetColumnsExtended fails for SEA; investigate catalog/schema metadata path in StatementExecutionConnection
         [SkippableTheory]
         [InlineData("all_column_types", "Resources/create_table_all_types.sql", "Resources/result_get_column_extended_all_types.json", true, new[] { "PK_IS_NULLABLE:NO" })]
         [InlineData("all_column_types", "Resources/create_table_all_types.sql", "Resources/result_get_column_extended_all_types.json", false, new[] { "PK_IS_NULLABLE:YES" })]
         public async Task CanGetColumnsExtended(string tableName, string createTableSqlLocation, string resultLocation, bool useDescTableExtended, string[]? extraPlaceholdsInResult = null)
         {
-            Skip.If(TestConfiguration.Protocol == "rest", "SEA CanGetColumnsExtended returns different BUFFER_LENGTH values (PECO-3008)");
             var connectionParams = new Dictionary<string, string> { ["adbc.databricks.use_desc_table_extended"] = $"{useDescTableExtended}" };
 
             using AdbcConnection connection = NewConnection(TestConfiguration, connectionParams);


### PR DESCRIPTION
## Problem

`CanGetColumnsExtended` was skipped for SEA (`Skip.If(Protocol == "rest")`) because the SEA path returned different `BUFFER_LENGTH` values than Thrift.

Root cause: `FlatColumnsResultBuilder` (used by the three-calls fallback path via `GetColumnsAsync`) called `ColumnMetadataHelper.GetBufferLength` which returned non-null values for numeric types (BOOLEAN=1, TINYINT=1, SMALLINT=2, INT=4, FLOAT=4, BIGINT=8, DOUBLE=8, TIMESTAMP=8, DATE=8, DECIMAL=computed). The expected test values and the Thrift path both return `null` for all columns.

The JDBC spec defines `BUFFER_LENGTH` as an unused column — it should always be `null`. `CreateExtendedColumnsResult` (the `DESC TABLE EXTENDED` path) already returned `null` unconditionally via `bufferLengthBuilder.AppendNull()`. `FlatColumnsResultBuilder` was inconsistent.

## Changes

- `FlatColumnsResultBuilder`: replace the `GetBufferLength` call with `AppendNull()`, making `BUFFER_LENGTH` consistently null across all result paths (matching `CreateExtendedColumnsResult` and Thrift).
- `StatementTests.cs`: remove the `Skip.If(Protocol == "rest")` guard from `CanGetColumnsExtended`.

## Test Plan

`CanGetColumnsExtended` now runs for both Thrift and SEA protocols, covering both `useDescTableExtended=true` and `useDescTableExtended=false`.

Fixes PECO-3008

🤖 Generated with [Claude Code](https://claude.ai/claude-code)