### PR TITLE
fix(csharp): isolate per-run mutable state to a per-job schema

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -106,8 +106,55 @@ jobs:
           echo "::add-mask::$OAUTH_TOKEN"
           echo "OAUTH_TOKEN=$OAUTH_TOKEN" >> $GITHUB_OUTPUT
 
+      # Per-run mutable schema isolates this job's CREATE/DROP/INSERT activity
+      # from every other job that hits the same shared workspace (parallel
+      # protocol matrix entries, parallel merge-queue PRs, etc.). Read-only
+      # fixture tables (all_column_types, cross_ref_customers, …) continue to
+      # live in main.adbc_testing and are not touched here. See
+      # docs/e2e-test-isolation-guidance.md.
+      - name: Compute per-run schema name
+        if: steps.gate.outputs.run == 'true'
+        id: schema
+        run: |
+          # Schema names allow [A-Za-z0-9_]; run_id and run_attempt are
+          # numeric, protocol is alphabetic, so no escaping needed.
+          PER_RUN_SCHEMA="adbc_testing_run_${{ github.run_id }}_${{ github.run_attempt }}_${{ matrix.protocol }}"
+          echo "PER_RUN_SCHEMA=$PER_RUN_SCHEMA" >> $GITHUB_OUTPUT
+          echo "Per-run schema: main.$PER_RUN_SCHEMA"
+          # Extract warehouse id from the http path (/sql/1.0/warehouses/<id>)
+          WAREHOUSE_ID=$(echo "${{ env.DATABRICKS_HTTP_PATH }}" | awk -F/ '{print $NF}')
+          if [ -z "$WAREHOUSE_ID" ]; then
+            echo "ERROR: Could not extract warehouse id from DATABRICKS_HTTP_PATH"
+            exit 1
+          fi
+          echo "WAREHOUSE_ID=$WAREHOUSE_ID" >> $GITHUB_OUTPUT
+
+      - name: Provision per-run schema
+        if: steps.gate.outputs.run == 'true'
+        env:
+          OAUTH_TOKEN: ${{ steps.oauth.outputs.OAUTH_TOKEN }}
+          PER_RUN_SCHEMA: ${{ steps.schema.outputs.PER_RUN_SCHEMA }}
+          WAREHOUSE_ID: ${{ steps.schema.outputs.WAREHOUSE_ID }}
+        run: |
+          set -e
+          STATEMENT="CREATE SCHEMA IF NOT EXISTS main.${PER_RUN_SCHEMA}"
+          PAYLOAD=$(jq -n --arg w "$WAREHOUSE_ID" --arg s "$STATEMENT" '{warehouse_id: $w, statement: $s, wait_timeout: "30s"}')
+          RESPONSE=$(curl -sS -X POST "https://${{ env.DATABRICKS_SERVER_HOSTNAME }}/api/2.0/sql/statements" \
+            -H "Authorization: Bearer $OAUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          STATUS=$(echo "$RESPONSE" | python3 -c "import sys, json; print(json.load(sys.stdin).get('status', {}).get('state', ''))")
+          if [ "$STATUS" != "SUCCEEDED" ]; then
+            echo "ERROR: CREATE SCHEMA failed (status=$STATUS)"
+            echo "Response: $RESPONSE"
+            exit 1
+          fi
+          echo "Created schema: main.${PER_RUN_SCHEMA}"
+
       - name: Create Databricks config file
         if: steps.gate.outputs.run == 'true'
+        env:
+          PER_RUN_SCHEMA: ${{ steps.schema.outputs.PER_RUN_SCHEMA }}
         run: |
           mkdir -p ~/.databricks
           cat > ~/.databricks/connection.json << EOF
@@ -122,8 +169,8 @@ jobs:
             "type": "databricks",
             "protocol": "${{ matrix.protocol }}",
             "catalog": "main",
-            "db_schema": "adbc_testing",
-            "query": "SELECT * FROM main.adbc_testing.adbc_testing_table",
+            "db_schema": "${PER_RUN_SCHEMA}",
+            "query": "SELECT * FROM main.${PER_RUN_SCHEMA}.adbc_testing_table",
             "expectedResults": 12,
             "isCITesting": true,
             "tracePropagationEnabled": "true",
@@ -131,7 +178,7 @@ jobs:
             "traceStateEnabled": "false",
             "metadata": {
               "catalog": "main",
-              "schema": "adbc_testing",
+              "schema": "${PER_RUN_SCHEMA}",
               "table": "adbc_testing_table",
               "expectedColumnCount": 19
             }
@@ -151,3 +198,28 @@ jobs:
         run: |
           export DATABRICKS_TEST_CONFIG_FILE="$HOME/.databricks/connection.json"
           ./ci/scripts/csharp_test_databricks_e2e.sh "${{ github.workspace }}"
+
+      # Always run, even on test failure or job cancellation, so we don't
+      # leak schemas in the workspace.
+      - name: Drop per-run schema
+        if: always() && steps.gate.outputs.run == 'true' && steps.schema.outputs.PER_RUN_SCHEMA != ''
+        env:
+          OAUTH_TOKEN: ${{ steps.oauth.outputs.OAUTH_TOKEN }}
+          PER_RUN_SCHEMA: ${{ steps.schema.outputs.PER_RUN_SCHEMA }}
+          WAREHOUSE_ID: ${{ steps.schema.outputs.WAREHOUSE_ID }}
+        run: |
+          STATEMENT="DROP SCHEMA IF EXISTS main.${PER_RUN_SCHEMA} CASCADE"
+          PAYLOAD=$(jq -n --arg w "$WAREHOUSE_ID" --arg s "$STATEMENT" '{warehouse_id: $w, statement: $s, wait_timeout: "30s"}')
+          RESPONSE=$(curl -sS -X POST "https://${{ env.DATABRICKS_SERVER_HOSTNAME }}/api/2.0/sql/statements" \
+            -H "Authorization: Bearer $OAUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          STATUS=$(echo "$RESPONSE" | python3 -c "import sys, json; print(json.load(sys.stdin).get('status', {}).get('state', ''))")
+          if [ "$STATUS" != "SUCCEEDED" ]; then
+            # Don't fail the job on cleanup error — leaked schemas can be
+            # garbage-collected later. But surface the failure.
+            echo "WARNING: DROP SCHEMA failed (status=$STATUS)"
+            echo "Response: $RESPONSE"
+          else
+            echo "Dropped schema: main.${PER_RUN_SCHEMA}"
+          fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -151,6 +151,63 @@ jobs:
           fi
           echo "Created schema: main.${PER_RUN_SCHEMA}"
 
+      # Pre-seed adbc_testing_table so tests that read it don't depend on
+      # CanExecuteUpdate (which runs the same SQL) running first. xUnit
+      # doesn't guarantee inter-class order, so without this seed the per-run
+      # schema is empty when StatementTests / ClientTests / etc. read the
+      # table, even though DriverTests.CanExecuteUpdate is supposed to seed
+      # it. Tests that do mutate the table still work — CREATE OR REPLACE
+      # rewrites it idempotently.
+      - name: Seed test data
+        if: steps.gate.outputs.run == 'true'
+        env:
+          OAUTH_TOKEN: ${{ steps.oauth.outputs.OAUTH_TOKEN }}
+          PER_RUN_SCHEMA: ${{ steps.schema.outputs.PER_RUN_SCHEMA }}
+          WAREHOUSE_ID: ${{ steps.schema.outputs.WAREHOUSE_ID }}
+          DATABRICKS_SERVER_HOSTNAME: ${{ env.DATABRICKS_SERVER_HOSTNAME }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, re, sys, urllib.request
+
+          with open("csharp/test/Resources/Databricks.sql") as f:
+              content = f.read()
+          # Strip line comments
+          content = re.sub(r"^\s*--.*$", "", content, flags=re.MULTILINE)
+          # Substitute the templated table name
+          full_table = f"main.{os.environ['PER_RUN_SCHEMA']}.adbc_testing_table"
+          content = content.replace("{ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE}", full_table)
+          # Split on ; — Databricks.sql has no semicolons inside string literals
+          statements = [s.strip() for s in content.split(";") if s.strip()]
+
+          host = os.environ["DATABRICKS_SERVER_HOSTNAME"]
+          token = os.environ["OAUTH_TOKEN"]
+          warehouse = os.environ["WAREHOUSE_ID"]
+          url = f"https://{host}/api/2.0/sql/statements"
+
+          for i, stmt in enumerate(statements, 1):
+              payload = json.dumps({
+                  "warehouse_id": warehouse,
+                  "statement": stmt,
+                  "wait_timeout": "30s",
+              }).encode()
+              req = urllib.request.Request(
+                  url, data=payload,
+                  headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                  method="POST",
+              )
+              with urllib.request.urlopen(req) as resp:
+                  body = json.loads(resp.read())
+              state = body.get("status", {}).get("state", "")
+              if state != "SUCCEEDED":
+                  print(f"ERROR: statement {i} failed (state={state})")
+                  print(f"Statement: {stmt[:200]}")
+                  print(f"Response: {json.dumps(body, indent=2)}")
+                  sys.exit(1)
+              # Keep log noise low — first 80 chars per statement.
+              print(f"OK [{i}/{len(statements)}]: {stmt[:80].replace(chr(10), ' ')}")
+          print(f"Seeded {len(statements)} statements into main.{os.environ['PER_RUN_SCHEMA']}")
+          PYEOF
+
       - name: Create Databricks config file
         if: steps.gate.outputs.run == 'true'
         env:

--- a/csharp/test/AssemblyInfo.cs
+++ b/csharp/test/AssemblyInfo.cs
@@ -16,9 +16,10 @@
 
 using Xunit;
 
-// E2E tests run against a single shared Databricks workspace and share fixture
-// tables under main.adbc_testing. Cross-class parallelism races on these
-// tables (e.g. one class DROPs+CREATEs while another reads), causing flaky
-// merge-queue failures. Serialize the whole assembly to avoid the races.
+// E2E tests run against a single shared Databricks workspace. Even with
+// per-run schema isolation in CI, two test classes inside the same job may
+// still race on the per-run schema (e.g. one CREATEs a table while another
+// reads). Serialize the whole assembly to avoid those intra-job races.
 // Within-class test order is already sequential by xUnit default.
+// See docs/e2e-test-isolation-guidance.md.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/csharp/test/E2E/ClientTests.cs
+++ b/csharp/test/E2E/ClientTests.cs
@@ -29,6 +29,9 @@ using Xunit.Abstractions;
 
 namespace AdbcDrivers.Databricks.Tests
 {
+    // Re-declare the orderer here so [Order(N)] is honored on this concrete
+    // class — see comment in DriverTests.cs for details.
+    [TestCaseOrderer("Apache.Arrow.Adbc.Tests.Xunit.TestOrderer", "Apache.Arrow.Adbc.Tests")]
     public class ClientTests : ClientTests<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {
         public ClientTests(ITestOutputHelper? outputHelper)

--- a/csharp/test/E2E/ClientTests.cs
+++ b/csharp/test/E2E/ClientTests.cs
@@ -29,8 +29,9 @@ using Xunit.Abstractions;
 
 namespace AdbcDrivers.Databricks.Tests
 {
-    // Re-declare the orderer here so [Order(N)] is honored on this concrete
-    // class — see comment in DriverTests.cs for details.
+    // The orderer is declared on the abstract base, but xUnit applies
+    // [TestCaseOrderer] from the concrete class — set it here so [Order(N)]
+    // is honored. See comment in DriverTests.cs for details.
     [TestCaseOrderer("Apache.Arrow.Adbc.Tests.Xunit.TestOrderer", "Apache.Arrow.Adbc.Tests")]
     public class ClientTests : ClientTests<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {

--- a/csharp/test/E2E/DatabricksTestEnvironment.cs
+++ b/csharp/test/E2E/DatabricksTestEnvironment.cs
@@ -38,6 +38,16 @@ namespace AdbcDrivers.Databricks.Tests
 {
     public class DatabricksTestEnvironment : CommonTestEnvironment<DatabricksTestConfiguration>
     {
+        /// <summary>
+        /// Schema in the test workspace holding stable, hand-managed fixture
+        /// tables (<c>all_column_types</c>, <c>cross_ref_customers</c>, …).
+        /// Tests must treat this schema as read-only — never CREATE/DROP/INSERT
+        /// here. Per-run mutable state lives in
+        /// <c>TestConfiguration.Metadata.Schema</c>, which CI sets to a
+        /// per-run-unique schema. See docs/e2e-test-isolation-guidance.md.
+        /// </summary>
+        public const string FixtureSchema = "adbc_testing";
+
         public class Factory : Factory<DatabricksTestEnvironment>
         {
             public override DatabricksTestEnvironment Create(Func<AdbcConnection> getConnection) => new(getConnection);

--- a/csharp/test/E2E/DriverTests.cs
+++ b/csharp/test/E2E/DriverTests.cs
@@ -36,10 +36,10 @@ using Metadata = Apache.Arrow.Adbc.Tests.Metadata;
 namespace AdbcDrivers.Databricks.Tests
 {
     // The orderer is declared on the abstract base, but xUnit applies
-    // [TestCaseOrderer] from the concrete class — re-declare it here so
-    // [Order(N)] is honored. Without this, CanExecuteQuery runs before
-    // CanExecuteUpdate and fails because adbc_testing_table doesn't exist
-    // yet in the per-run schema.
+    // [TestCaseOrderer] from the concrete class — set it here so [Order(N)]
+    // is honored. Without this, CanExecuteQuery runs before CanExecuteUpdate
+    // and fails because adbc_testing_table doesn't exist yet in the per-run
+    // schema.
     [TestCaseOrderer("Apache.Arrow.Adbc.Tests.Xunit.TestOrderer", "Apache.Arrow.Adbc.Tests")]
     public class DriverTests : DriverTests<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {

--- a/csharp/test/E2E/DriverTests.cs
+++ b/csharp/test/E2E/DriverTests.cs
@@ -35,6 +35,12 @@ using Metadata = Apache.Arrow.Adbc.Tests.Metadata;
 
 namespace AdbcDrivers.Databricks.Tests
 {
+    // The orderer is declared on the abstract base, but xUnit applies
+    // [TestCaseOrderer] from the concrete class — re-declare it here so
+    // [Order(N)] is honored. Without this, CanExecuteQuery runs before
+    // CanExecuteUpdate and fails because adbc_testing_table doesn't exist
+    // yet in the per-run schema.
+    [TestCaseOrderer("Apache.Arrow.Adbc.Tests.Xunit.TestOrderer", "Apache.Arrow.Adbc.Tests")]
     public class DriverTests : DriverTests<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {
         public DriverTests(ITestOutputHelper? outputHelper)

--- a/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
@@ -34,7 +34,9 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
     public class SeaMetadataE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {
         private const string TestCatalog = "main";
-        private const string TestSchema = "adbc_testing";
+        // Read-only fixture schema. CREATE/DROP/INSERT must use
+        // TestConfiguration.Metadata.Schema instead.
+        private const string TestSchema = DatabricksTestEnvironment.FixtureSchema;
         private const string TestTable = "all_column_types";
 
         public SeaMetadataE2ETests(ITestOutputHelper? outputHelper)

--- a/csharp/test/E2E/Telemetry/StatementMetadataTelemetryTests.cs
+++ b/csharp/test/E2E/Telemetry/StatementMetadataTelemetryTests.cs
@@ -37,9 +37,10 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
     /// </summary>
     public class StatementMetadataTelemetryTests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {
-        // Filters to scope metadata queries and avoid MaxMessageSize errors
+        // Filters to scope metadata queries and avoid MaxMessageSize errors.
+        // Read-only fixture schema — tests here must not mutate.
         private const string TestCatalog = "main";
-        private const string TestSchema = "adbc_testing";
+        private const string TestSchema = DatabricksTestEnvironment.FixtureSchema;
         private const string TestTable = "all_column_types";
 
         // TODO: PECO-3010 - telemetry not wired for SEA protocol; these tests fail for rest protocol

--- a/docs/e2e-test-isolation-guidance.md
+++ b/docs/e2e-test-isolation-guidance.md
@@ -1,0 +1,116 @@
+<!--
+  Copyright (c) 2025 ADBC Drivers Contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# E2E Test Isolation Guidance
+
+Guidance for writing and reviewing E2E tests that share a Databricks workspace. Prevents the flaky merge-queue failures tracked in PECO-3000.
+
+## TL;DR
+
+- The CI workspace is shared across parallel jobs and across PRs. Any tables your test writes to are visible — and writable — by other jobs.
+- Tests must isolate **mutable** state to a per-run schema, and treat **fixture** tables as read-only.
+- Never assert on metadata that depends on the entire schema (table counts, schema counts) — those reflect concurrent jobs' state.
+
+## Why this matters
+
+E2E tests run against a single shared Databricks workspace. Two sources of concurrency cause flake:
+
+1. **Within one workflow run** — the `thrift` and `rest` matrix jobs run in parallel and hit the same workspace.
+2. **Across PRs** — every merge-queue Tests Workflow on `gh-readonly-queue/main/pr-*` runs against the same workspace at the same time.
+
+Assembly-level serialization (`csharp/test/AssemblyInfo.cs`: `[assembly: CollectionBehavior(DisableTestParallelization = true)]`) prevents races *inside* one job. It cannot prevent races *between* jobs.
+
+Observed failure patterns:
+
+| Symptom | Mechanism |
+|---|---|
+| `parsed records (13) differ from expected (12)` | Job A finishes inserting 13 rows; Job B reads before Job A's `DELETE` drops it to 12. |
+| `DELTA_METADATA_CHANGED: ... CREATE OR REPLACE TABLE` conflict | Job A reads while Job B's `CREATE OR REPLACE TABLE` rewrites the Delta log. |
+| `GetTables count: 221 vs 220` | Two `GetTables` calls separated by milliseconds; another job creates/drops a table in the schema in between. |
+
+## Schema model
+
+Two schemas with different roles:
+
+| Schema | Role | Lifecycle |
+|---|---|---|
+| `main.adbc_testing` | Stable read-only fixture tables (`all_column_types`, `cross_ref_customers`, `cross_ref_orders`, `fk_test_ref_table`, …) | Hand-managed in the workspace. Tests **read** from it; never write. |
+| `main.adbc_testing_run_${run_id}_${attempt}_${proto}` | Per-run mutable state (`adbc_testing_table` and any other table the test creates) | `CREATE SCHEMA IF NOT EXISTS` at job start; `DROP SCHEMA … CASCADE` at job end (with `if: always()`). |
+
+Tests get the writable schema name via `TestConfiguration.Metadata.Schema` (CI substitutes the per-run schema into `connection.json`). Fixture lookups use the constant `DatabricksTestEnvironment.FixtureSchema`.
+
+> Historical note: `main.adbc_testing` was originally the only schema and held both fixtures and mutable state, which caused the cross-job races tracked by PECO-3000. After this refactor, only fixtures remain there; all mutation moved to the per-run schema. The fixture schema's name was kept as-is to avoid a workspace-rename operation.
+
+## Rules for engineers
+
+### Writing tests
+
+- **Don't hard-code `"adbc_testing"` or `"adbc_testing_table"` as string literals.** Use `TestConfiguration.Metadata.Schema` (writable) or `DatabricksTestEnvironment.FixtureSchema` (read-only).
+- **Any `CREATE`, `DROP`, `INSERT`, `UPDATE`, `DELETE` must target the per-run schema.** Any DML on `DatabricksTestEnvironment.FixtureSchema` is a bug.
+- **Cleanup must be idempotent.** Prefer `DROP TABLE IF EXISTS` over `DROP TABLE`. The schema-level `DROP SCHEMA … CASCADE` runs automatically; per-test cleanup is for fast-feedback only.
+- **Avoid schema-wide assertions.** Don't compare `GetTables` counts across protocols, don't assert on total row counts in shared fixtures, don't compare schema lists. These reflect every concurrent job's state.
+
+### Assertions to prefer
+
+```csharp
+// BAD — depends on the entire schema:
+Assert.Equal(thriftRows.Count, seaRows.Count);
+Assert.Equal(12, allRows.Count);
+
+// GOOD — scoped to the test's own table:
+Assert.Contains(rows, r => r["TABLE_NAME"] == myTestTable);
+Assert.Equal(12, myTestTableRowCount);  // OK because myTestTable is per-run-unique
+```
+
+### Adding a new test class
+
+- If it writes anything: route through `TestConfiguration.Metadata.Schema`.
+- If it only reads fixtures: use `DatabricksTestEnvironment.FixtureSchema`.
+- Keep `[assembly: CollectionBehavior(DisableTestParallelization = true)]` in place. New test assemblies that hit the workspace need the same attribute.
+
+### Adding a new fixture
+
+- Don't create it lazily inside a test. Add it to the hand-managed fixture schema (`DatabricksTestEnvironment.FixtureSchema` → `main.adbc_testing`) and document the row counts and structure.
+- Don't put new fixtures in the per-run schema "for safety" — that's wasted setup time on every job.
+
+## Code review checklist
+
+When reviewing PRs that touch E2E tests, the workspace setup, or CI workflows:
+
+### Schema and table naming
+- [ ] No new hard-coded `"adbc_testing"` or `"adbc_testing_table"` literals in test code (use `DatabricksTestEnvironment.FixtureSchema` or `TestConfiguration.Metadata.{Schema,Table}`).
+- [ ] New tests that mutate state use `TestConfiguration.Metadata.Schema`.
+- [ ] New SQL files use `{ADBC_CATALOG}.{ADBC_DATASET}.{ADBC_TABLE}` placeholders, not literal names.
+
+### Setup and teardown
+- [ ] Tests that `CREATE` a table also `DROP IF EXISTS` it, or rely on the per-run schema cleanup.
+- [ ] No DML against the fixture schema.
+- [ ] No assumption that a previous test left state behind — each test owns its setup.
+
+### Assertions
+- [ ] No `Assert.Equal(thriftCount, seaCount)` or other cross-schema-wide equality assertions.
+- [ ] Row-count assertions are scoped to a per-run-unique table.
+- [ ] Metadata assertions (`GetTables`, `GetSchemas`) use `Assert.Contains` for the specific entity, not equality on the full list.
+
+### CI workflow changes
+- [ ] `.github/workflows/e2e-tests.yml` schema/table fields stay templated from `${{ github.run_id }}` / `${{ matrix.protocol }}` / `${{ github.run_attempt }}`.
+- [ ] Cleanup steps use `if: always()` so they run on test failure too.
+- [ ] New matrix dimensions are reflected in the schema suffix to keep parallel jobs isolated.
+
+### Telemetry tests
+- [ ] Tests asserting on telemetry payload values (operation type, statement count) only count operations they themselves triggered — not catalog/schema-wide totals — because metadata operations from concurrent jobs are not visible in this driver's telemetry but related counts (e.g., schema sizes) can still drift.
+
+## References
+
+- PECO-3000 — Flaky CI: Tests Workflow merge-queue E2E tests fail intermittently due to test-workspace data drift
+- `csharp/test/AssemblyInfo.cs` — assembly-level parallelization disable
+- `csharp/test/E2E/DatabricksTestEnvironment.cs` — `FixtureSchema` constant
+- `csharp/test/Resources/Databricks.sql` — shared setup script (templated against the per-run schema)
+- `.github/workflows/e2e-tests.yml` — CI matrix and per-run schema lifecycle


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/adbc-drivers/databricks/pull/446/files) to review incremental changes.
- [**stack/PECO-3000-e2e-schema-isolation**](https://github.com/adbc-drivers/databricks/pull/446) [[Files changed](https://github.com/adbc-drivers/databricks/pull/446/files)]

---------
## What's Changed

Each Tests Workflow job (and matrix entry) now creates its own per-run
schema in the shared workspace and drops it at job end:

  main.adbc_testing_run_${run_id}_${run_attempt}_${protocol}

CI uses this name for db_schema, metadata.schema, and the connection
test query. Existing tests that mutate state via TestConfiguration.
Metadata.Schema (StatementTests, DriverTests, ClientTests, the
Databricks.sql template, etc.) automatically inherit the isolation
without code changes.

main.adbc_testing remains as the read-only fixture schema. The two
test classes that hard-code it (SeaMetadataE2ETests,
StatementMetadataTelemetryTests) now reference
DatabricksTestEnvironment.FixtureSchema with a comment noting the
read-only contract.

Why: cross-job races on the shared workspace were the root cause of
PECO-3000 flakes. Disabling intra-assembly parallelism (PR #395)
covered within-job races; this change closes the across-job races
(thrift/rest matrix entries, parallel merge-queue PRs).

The cleanup step uses if: always() so failed/cancelled jobs still drop
their schemas. Cleanup errors warn but do not fail the job — leaked
schemas are harmless and can be GC'd separately.

Adds docs/e2e-test-isolation-guidance.md describing the schema model
and the rules for writing/reviewing E2E tests against a shared
workspace.

Co-authored-by: Isaac

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
