### PR TITLE
fix(csharp): enforce SetOption validation for BatchSize, PollTime, QueryTimeout in SEA (PECO-3011)

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -176,8 +176,15 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _waitTimeoutSeconds = waitTimeoutSeconds;
             _pollingIntervalMs = pollingIntervalMs;
             _properties = properties ?? throw new ArgumentNullException(nameof(properties));
-            _queryTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(
-                properties, ApacheParameters.QueryTimeoutSeconds, 0);
+            if (properties.TryGetValue(ApacheParameters.QueryTimeoutSeconds, out string? queryTimeoutValue))
+            {
+                ApacheUtility.QueryTimeoutIsValid(ApacheParameters.QueryTimeoutSeconds, queryTimeoutValue, out int queryTimeoutSeconds);
+                _queryTimeoutSeconds = queryTimeoutSeconds;
+            }
+            if (properties.TryGetValue(ApacheParameters.BatchSize, out string? batchSizeValue))
+                SetOption(ApacheParameters.BatchSize, batchSizeValue);
+            if (properties.TryGetValue(ApacheParameters.PollTimeMilliseconds, out string? pollTimeValue))
+                SetOption(ApacheParameters.PollTimeMilliseconds, pollTimeValue);
             _recyclableMemoryStreamManager = recyclableMemoryStreamManager ?? throw new ArgumentNullException(nameof(recyclableMemoryStreamManager));
             _lz4BufferPool = lz4BufferPool ?? throw new ArgumentNullException(nameof(lz4BufferPool));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -233,12 +240,21 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     _escapePatternWildcards = bool.TryParse(value, out bool escape) && escape;
                     break;
 
-                // These options are readonly in SEA (set at connection level).
-                // Accept but ignore them to avoid NotImplemented exceptions for compatibility.
-                case ApacheParameters.PollTimeMilliseconds:
+                // These options are managed at the connection level in SEA, not per-statement.
+                // Validate the value for consistency with Thrift, then ignore it.
                 case ApacheParameters.BatchSize:
-                case ApacheParameters.BatchSizeStopCondition:
+                    if (!(!string.IsNullOrEmpty(value) && long.TryParse(value, out long _batchSize) && _batchSize > 0))
+                        throw new ArgumentOutOfRangeException(key, value, $"The value '{value}' for option '{key}' is invalid. Must be a numeric value greater than zero.");
+                    break;
+                case ApacheParameters.PollTimeMilliseconds:
+                    if (!(!string.IsNullOrEmpty(value) && int.TryParse(value, out int _pollTime) && _pollTime >= 0))
+                        throw new ArgumentOutOfRangeException(key, value, $"The value '{value}' for option '{key}' is invalid. Must be a numeric value greater than or equal to 0.");
+                    break;
                 case ApacheParameters.QueryTimeoutSeconds:
+                    ApacheUtility.QueryTimeoutIsValid(key, value, out _);
+                    break;
+                case ApacheParameters.BatchSizeStopCondition:
+                    ApacheUtility.BooleanIsValid(key, value, out _);
                     break;
 
                 case DatabricksParameters.QueryTags:

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -37,33 +37,11 @@ using Xunit.Abstractions;
 
 namespace AdbcDrivers.Databricks.Tests
 {
-    // TODO: PECO-3011 - CanSetOptionBatchSize/PollTime/QueryTimeout inherited from base class not validated in SEA's StatementExecutionStatement
     public class StatementTests : StatementTests<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {
         public StatementTests(ITestOutputHelper? outputHelper)
             : base(outputHelper, new DatabricksTestEnvironment.Factory())
         {
-        }
-
-        // TODO: PECO-3011 - SEA StatementExecutionStatement does not validate poll time option
-        protected override void ValidateCanSetOptionPollTime(string value, bool throws = false)
-        {
-            Skip.If(TestConfiguration.Protocol == "rest", "SEA does not enforce poll time validation");
-            base.ValidateCanSetOptionPollTime(value, throws);
-        }
-
-        // TODO: PECO-3011 - SEA StatementExecutionStatement does not validate query timeout option
-        protected override void ValidateCanSetOptionQueryTimeout(string value, bool throws = false)
-        {
-            Skip.If(TestConfiguration.Protocol == "rest", "SEA does not enforce query timeout validation");
-            base.ValidateCanSetOptionQueryTimeout(value, throws);
-        }
-
-        // TODO: PECO-3011 - SEA StatementExecutionStatement does not validate batch size option
-        protected override void ValidateCanSetOptionBatchSize(string value, bool throws = false)
-        {
-            Skip.If(TestConfiguration.Protocol == "rest", "SEA does not enforce batch size validation");
-            base.ValidateCanSetOptionBatchSize(value, throws);
         }
 
         [SkippableTheory]


### PR DESCRIPTION
## Summary

- `StatementExecutionStatement.SetOption` was silently accepting all values for `BatchSize`, `PollTimeMilliseconds`, `QueryTimeoutSeconds`, and `BatchSizeStopCondition` with no validation
- Add the same `ArgumentOutOfRangeException` validation that the Thrift path (`HiveServer2Statement`) applies, so clients get consistent errors across both protocols
- Also validate these options from connection properties at statement creation time (via constructor), matching Thrift's `ValidateOptions` behavior
- Remove the `Skip.If` guards for `CanSetOptionBatchSize`, `CanSetOptionPollTime`, and `CanSetOptionQueryTimeout` in `StatementTests`

## Test plan

- [x] All 24 `CanSetOption{BatchSize,PollTime,QueryTimeout}` test cases pass on SEA path (`protocol: rest`)

Closes #NNN