### PR TITLE
fix(csharp): resolve package conflict warnings

### DIFF
--- a/csharp/Benchmarks/DatabricksBenchmarks.csproj
+++ b/csharp/Benchmarks/DatabricksBenchmarks.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="K4os.Compression.LZ4" />
     <PackageReference Include="K4os.Compression.LZ4.Streams" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -32,6 +32,8 @@
     <!-- Benchmarking -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <!-- System -->
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- Resilience -->
     <PackageVersion Include="Polly" Version="8.5.0" />


### PR DESCRIPTION
## What's Changed

Resolves package conflicts on the `DatabricskBenchmark` project

This pull request adds new dependencies to the benchmarking project to support additional .NET features. Specifically, it introduces the `System.Collections.Immutable` and `System.Reflection.Metadata` packages, and ensures their versions are tracked in the central package properties file.

Dependency additions:

* Added `System.Collections.Immutable` and `System.Reflection.Metadata` as package references in `DatabricksBenchmarks.csproj` to provide immutable collection types and metadata reading capabilities.
* Specified versions (`8.0.0`) for `System.Collections.Immutable` and `System.Reflection.Metadata` in `Directory.Packages.props` to maintain consistent dependency management across the solution.
