### PR TITLE
feat(csharp): implement Cancel() for SEA protocol (PECO-2939)

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -224,6 +224,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
             properties.TryGetValue(DatabricksParameters.ResultCompression, out _resultCompression);
 
             _waitTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(properties, DatabricksParameters.WaitTimeout, 10);
+            if (properties.TryGetValue(DatabricksParameters.EnableDirectResults, out var directResults) &&
+                directResults.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                _waitTimeoutSeconds = 0;
+            }
             _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(properties, DatabricksParameters.PollingInterval, 1000);
 
             // Memory pooling

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -702,6 +702,25 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 throw new InvalidOperationException("SQL query is required");
             }
 
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            lock (_cancelLock) { _executeCts = cts; }
+            try
+            {
+                return await ExecuteUpdateInternalAsync(cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("The query execution timed out or was cancelled. Consider increasing the query timeout value.", ex);
+            }
+            finally
+            {
+                lock (_cancelLock) { _executeCts = null; }
+                cts.Dispose();
+            }
+        }
+
+        private async Task<UpdateResult> ExecuteUpdateInternalAsync(CancellationToken cancellationToken)
+        {
             // Build the execute statement request
             // Note: catalog/schema cannot be set when session_id is provided (session has context)
             var request = new ExecuteStatementRequest

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -308,6 +308,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 return await ExecuteQueryInternalAsync(cts.Token, isMetadataExecution).ConfigureAwait(false);
             }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Cancel() was called (not an external caller token) — surface as TimeoutException to match Thrift behavior.
+                throw new TimeoutException("The query execution timed out or was cancelled. Consider increasing the query timeout value.", ex);
+            }
             finally
             {
                 lock (_cancelLock) { _executeCts = null; }
@@ -434,7 +439,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 {
                     // Best-effort; ignore cancel errors
                 }
-                throw new AdbcException(
+                throw new TimeoutException(
                     $"Query timed out after {_queryTimeoutSeconds} seconds (statement {statementId}). " +
                     $"Increase timeout via '{ApacheParameters.QueryTimeoutSeconds}' or set to 0 for no timeout.");
             }

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -76,6 +76,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string? _currentStatementId;
         private string? _sqlQuery;
 
+        // Cancel support
+        private readonly object _cancelLock = new();
+        private CancellationTokenSource? _executeCts;
+
         // Metadata command support
         private bool _isMetadataCommand;
         private bool _escapePatternWildcards;
@@ -297,6 +301,22 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 throw new InvalidOperationException("SQL query is required");
             }
 
+            // Create a linked token so Cancel() can interrupt this execution.
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            lock (_cancelLock) { _executeCts = cts; }
+            try
+            {
+                return await ExecuteQueryInternalAsync(cts.Token, isMetadataExecution).ConfigureAwait(false);
+            }
+            finally
+            {
+                lock (_cancelLock) { _executeCts = null; }
+                cts.Dispose();
+            }
+        }
+
+        private async Task<QueryResult> ExecuteQueryInternalAsync(CancellationToken cancellationToken, bool isMetadataExecution)
+        {
             // Build the execute statement request
             // Note: warehouse_id is always required by the Databricks Statement Execution API
             // Note: catalog/schema cannot be set when session_id is provided (session has context)
@@ -797,6 +817,21 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 {
                     _currentStatementId = null;
                 }
+            }
+        }
+
+        public override void Cancel()
+        {
+            string? statementId;
+            lock (_cancelLock)
+            {
+                _executeCts?.Cancel();
+                statementId = _currentStatementId;
+            }
+            if (statementId != null)
+            {
+                try { _client.CancelStatementAsync(statementId, CancellationToken.None).GetAwaiter().GetResult(); }
+                catch { /* best-effort */ }
             }
         }
 

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -115,8 +115,6 @@ namespace AdbcDrivers.Databricks.Tests
         [ClassData(typeof(LongRunningStatementTimeoutTestData))]
         internal override void StatementTimeoutTest(StatementWithExceptions statementWithExceptions)
         {
-            // TODO: PECO-3013 - SEA throws AdbcException instead of TimeoutException on query timeout
-            Skip.If(TestConfiguration.Protocol == "rest", "SEA throws AdbcException not TimeoutException on timeout");
             base.StatementTimeoutTest(statementWithExceptions);
         }
 
@@ -126,7 +124,12 @@ namespace AdbcDrivers.Databricks.Tests
         [InlineData(LongRunningStatementTimeoutTestData.LongRunningQuery, "true", "false")]
         internal async Task DatabricksCanCancelStatementTest(string query, string enableRunAsyncInThriftOp, string enableDirectResults)
         {
-            Skip.If(TestConfiguration.Protocol == "rest", "EnableRunAsyncInThriftOp and EnableDirectResults are Thrift-only");
+            if (TestConfiguration.Protocol == "rest")
+            {
+                // SEA: Thrift flags don't apply; run basic cancel test directly
+                await base.CanCancelStatementTest(query);
+                return;
+            }
             string enableRunAsyncInThriftOpOrig = TestConfiguration.EnableRunAsyncInThriftOp;
             string enableDirectResultsOrig = TestConfiguration.EnableDirectResults;
             try

--- a/csharp/test/Unit/StatementExecution/StatementExecutionQueryTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionQueryTimeoutTests.cs
@@ -156,7 +156,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         }
 
         [Fact]
-        public async Task ExecuteQueryAsync_TimeoutExpires_ThrowsAdbcExceptionAndCancelsStatement()
+        public async Task ExecuteQueryAsync_TimeoutExpires_ThrowsTimeoutExceptionAndCancelsStatement()
         {
             SetupExecuteReturnsRunning();
 
@@ -175,7 +175,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
 
             using var stmt = CreateStatement(queryTimeoutSeconds: 1, pollingIntervalMs: 50);
 
-            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+            var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
                 stmt.ExecuteQueryAsync(CancellationToken.None));
 
             Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -243,7 +243,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         }
 
         [Fact]
-        public async Task ExecuteUpdateAsync_TimeoutExpires_ThrowsAdbcExceptionAndCancelsStatement()
+        public async Task ExecuteUpdateAsync_TimeoutExpires_ThrowsTimeoutExceptionAndCancelsStatement()
         {
             SetupExecuteReturnsRunning();
 
@@ -261,7 +261,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
 
             using var stmt = CreateStatement(queryTimeoutSeconds: 1, pollingIntervalMs: 50);
 
-            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+            var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
                 stmt.ExecuteUpdateAsync(CancellationToken.None));
 
             Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -290,7 +290,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
 
             using var stmt = CreateStatement(queryTimeoutSeconds: 1, pollingIntervalMs: 50);
 
-            var ex = await Assert.ThrowsAsync<AdbcException>(() =>
+            var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
                 stmt.ExecuteQueryAsync(CancellationToken.None));
 
             Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary

Implements \`Cancel()\` for the SEA (REST) protocol path and aligns timeout behaviour with Thrift (PECO-2939, PECO-3013).

**Cancel support (PECO-2939)**
- Adds \`Cancel()\` override to \`StatementExecutionStatement\`
- Adds a lock-protected \`_executeCts\` field; \`ExecuteQueryAsync\` and \`ExecuteUpdateAsync\` now create a linked \`CancellationTokenSource\` so \`Cancel()\` can interrupt the in-flight poll loop immediately
- \`Cancel()\` cancels the local CTS and calls \`CancelStatementAsync\` on the server best-effort (\`POST /statements/{id}/cancel\`)
- Previously \`Cancel()\` fell through to \`AdbcStatement.Cancel()\` which always throws \`NotImplemented\`

**TimeoutException alignment (PECO-3013)**
- SEA now throws \`TimeoutException\` (not \`AdbcException\`) on poll timeout, matching Thrift behaviour
- \`PollWithTimeoutAsync\` deadline path changed from \`throw new AdbcException\` → \`throw new TimeoutException\`
- \`ExecuteQueryAsync\` and \`ExecuteUpdateAsync\` wrap \`OperationCanceledException\` (when the caller did not cancel) in \`TimeoutException\`

**\`enable_direct_results=false\` → \`wait_timeout=0\` mapping**
- \`StatementExecutionConnection\` now reads \`adbc.databricks.enable_direct_results\`; when set to \`"false"\` it overrides \`_waitTimeoutSeconds\` to 0, forcing the server to return immediately with PENDING/RUNNING (same semantics as disabling direct results on Thrift)

## Test plan

- [x] \`CancelRunningOperation\` passes in SEA mode — proxy asserts \`CountSeaCallsAsync("CancelStatement") == 1\`
- [x] \`SimultaneousStatementCancellation\` passes in SEA mode — proxy asserts \`InRange(1, 3)\` CancelStatement calls
- [x] \`StatementTimeoutTest\` (8 cases) passes in SEA mode — asserts \`TimeoutException\` is thrown
- [x] Unit tests in \`StatementExecutionQueryTimeoutTests.cs\` updated: \`ThrowsAsync<TimeoutException>\` for timeout cases, \`ThrowsAsync<OperationCanceledException>\` for explicit caller cancellation
- [x] No regression on Thrift path — \`Cancel()\` override is only in \`StatementExecutionStatement\` (SEA)

Fixes PECO-2939, PECO-3013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)