### PR TITLE
chore(csharp): bump version to 1.1.3

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -18,6 +18,18 @@
 
 All notable changes to the C# Databricks ADBC driver are documented in this file.
 
+## [1.1.3] - Unreleased
+
+### Added
+
+- Implement Cancel() for SEA protocol (#450)
+
+### Fixed
+
+- Map OAuth 401/403 to Unauthorized in SEA path (#447)
+- Isolate per-run mutable state to a per-job schema (#446)
+- Resolve package conflict warnings (#449)
+
 ## [1.1.2] - Unreleased
 
 ### Added

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>1.1.2</VersionPrefix>
+    <VersionPrefix>1.1.3</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Bumps `VersionPrefix` from `1.1.2` to `1.1.3` in `csharp/Directory.Build.props`
- Adds `[1.1.3] - Unreleased` section to `csharp/CHANGELOG.md` covering the 4 commits that landed after the `csharp/v1.1.2` tag

### Changes included in 1.1.3

| PR | Type | Description |
|----|------|-------------|
| #450 | feat | Implement Cancel() for SEA protocol (PECO-2939) |
| #447 | fix | Map OAuth 401/403 to Unauthorized in SEA path (PECO-3007) |
| #446 | fix | Isolate per-run mutable state to a per-job schema |
| #449 | fix | Resolve package conflict warnings |

## Release branch

Merging this PR will trigger `csharp-sync-latest.yml` to:
- Push `main` to `release/csharp/v1.1.latest`
- Tag the tip as `csharp/v1.1.3`
- Force-update `release/csharp/latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)