### PR TITLE
refactor(csharp)!: prefix telemetry config keys with adbc.databricks

### DIFF
--- a/csharp/doc/telemetry-design.md
+++ b/csharp/doc/telemetry-design.md
@@ -285,8 +285,8 @@ private Dictionary<string, string> MergePropertiesWithFeatureFlags(
 // Feature flags have long names, map to driver property names
 private static readonly Dictionary<string, string> FeatureFlagToPropertyMap = new()
 {
-    ["databricks.partnerplatform.clientConfigsFeatureFlags.enableTelemetryForAdbc"] = "telemetry.enabled",
-    ["databricks.partnerplatform.clientConfigsFeatureFlags.enableCloudFetch"] = "cloudfetch.enabled",
+    ["databricks.partnerplatform.clientConfigsFeatureFlags.enableTelemetryForAdbc"] = "adbc.databricks.telemetry.enabled",
+    ["databricks.partnerplatform.clientConfigsFeatureFlags.enableCloudFetch"] = "adbc.databricks.cloudfetch.enabled",
     // ... more mappings
 };
 ```
@@ -598,7 +598,7 @@ bool IsTelemetryEnabled()
     // - User property (highest priority)
     // - Feature flag (merged in)
     // - Or falls back to driver default
-    if (Properties.TryGetValue("telemetry.enabled", out var value))
+    if (Properties.TryGetValue("adbc.databricks.telemetry.enabled", out var value))
     {
         return bool.TryParse(value, out var result) && result;
     }
@@ -2529,7 +2529,7 @@ Each test creates a real connection with a `CapturingTelemetryExporter`, execute
 
 | Aspect | Details |
 |--------|---------|
-| **Setup** | Connection with `telemetry.enabled=false` |
+| **Setup** | Connection with `adbc.databricks.telemetry.enabled=false` |
 | **Action** | Execute any query |
 | **Expected** | No telemetry logs captured |
 | **Emission count** | 0 |

--- a/csharp/doc/telemetry-sprint-plan.md
+++ b/csharp/doc/telemetry-sprint-plan.md
@@ -67,8 +67,8 @@ Implement the core telemetry infrastructure including feature flag management, p
 | Test Type | Test Name | Input | Expected Output |
 |-----------|-----------|-------|-----------------|
 | Unit | `TelemetryConfiguration_DefaultValues_AreCorrect` | No properties | Enabled=true, BatchSize=100, FlushIntervalMs=5000 |
-| Unit | `TelemetryConfiguration_FromProperties_ParsesCorrectly` | `{"telemetry.enabled": "false", "telemetry.batch_size": "50"}` | Enabled=false, BatchSize=50 |
-| Unit | `TelemetryConfiguration_InvalidProperty_UsesDefault` | `{"telemetry.batch_size": "invalid"}` | BatchSize=100 (default) |
+| Unit | `TelemetryConfiguration_FromProperties_ParsesCorrectly` | `{"adbc.databricks.telemetry.enabled": "false", "adbc.databricks.telemetry.batch_size": "50"}` | Enabled=false, BatchSize=50 |
+| Unit | `TelemetryConfiguration_InvalidProperty_UsesDefault` | `{"adbc.databricks.telemetry.batch_size": "invalid"}` | BatchSize=100 (default) |
 
 **Implementation Notes**:
 - Implemented with graceful degradation for invalid values (uses defaults instead of throwing exceptions)
@@ -84,7 +84,7 @@ Implement the core telemetry infrastructure including feature flag management, p
 
 **Key Design Decisions**:
 1. **Graceful degradation**: Invalid property values use defaults rather than throwing exceptions to ensure telemetry failures don't impact driver operations
-2. **Property naming**: Used `telemetry.*` prefix for connection properties and `DATABRICKS_TELEMETRY_*` for environment variables
+2. **Property naming**: Used `adbc.databricks.telemetry.*` prefix for connection properties and `DATABRICKS_TELEMETRY_*` for environment variables
 3. **Non-negative vs Positive**: MaxRetries and RetryDelayMs allow zero (for disabling), while BatchSize, FlushIntervalMs, and CircuitBreakerThreshold require positive values
 
 ---

--- a/csharp/src/Telemetry/TelemetryConfiguration.cs
+++ b/csharp/src/Telemetry/TelemetryConfiguration.cs
@@ -27,42 +27,42 @@ namespace AdbcDrivers.Databricks.Telemetry
         /// <summary>
         /// Property key for telemetry enabled flag in connection properties.
         /// </summary>
-        public const string PropertyKeyEnabled = "telemetry.enabled";
+        public const string PropertyKeyEnabled = "adbc.databricks.telemetry.enabled";
 
         /// <summary>
         /// Property key for batch size in connection properties.
         /// </summary>
-        public const string PropertyKeyBatchSize = "telemetry.batch_size";
+        public const string PropertyKeyBatchSize = "adbc.databricks.telemetry.batch_size";
 
         /// <summary>
         /// Property key for flush interval in connection properties.
         /// </summary>
-        public const string PropertyKeyFlushIntervalMs = "telemetry.flush_interval_ms";
+        public const string PropertyKeyFlushIntervalMs = "adbc.databricks.telemetry.flush_interval_ms";
 
         /// <summary>
         /// Property key for max retries in connection properties.
         /// </summary>
-        public const string PropertyKeyMaxRetries = "telemetry.max_retries";
+        public const string PropertyKeyMaxRetries = "adbc.databricks.telemetry.max_retries";
 
         /// <summary>
         /// Property key for retry delay in connection properties.
         /// </summary>
-        public const string PropertyKeyRetryDelayMs = "telemetry.retry_delay_ms";
+        public const string PropertyKeyRetryDelayMs = "adbc.databricks.telemetry.retry_delay_ms";
 
         /// <summary>
         /// Property key for circuit breaker enabled flag in connection properties.
         /// </summary>
-        public const string PropertyKeyCircuitBreakerEnabled = "telemetry.circuit_breaker_enabled";
+        public const string PropertyKeyCircuitBreakerEnabled = "adbc.databricks.telemetry.circuit_breaker_enabled";
 
         /// <summary>
         /// Property key for circuit breaker failure threshold in connection properties.
         /// </summary>
-        public const string PropertyKeyCircuitBreakerThreshold = "telemetry.circuit_breaker_threshold";
+        public const string PropertyKeyCircuitBreakerThreshold = "adbc.databricks.telemetry.circuit_breaker_threshold";
 
         /// <summary>
         /// Property key for circuit breaker timeout in connection properties.
         /// </summary>
-        public const string PropertyKeyCircuitBreakerTimeoutMs = "telemetry.circuit_breaker_timeout_ms";
+        public const string PropertyKeyCircuitBreakerTimeoutMs = "adbc.databricks.telemetry.circuit_breaker_timeout_ms";
 
         /// <summary>
         /// Environment variable key for telemetry enabled flag.

--- a/csharp/test/Unit/Telemetry/TelemetryConfigurationTests.cs
+++ b/csharp/test/Unit/Telemetry/TelemetryConfigurationTests.cs
@@ -322,14 +322,14 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
         public void TelemetryConfiguration_PropertyKeys_AreCorrect()
         {
             // Assert
-            Assert.Equal("telemetry.enabled", TelemetryConfiguration.PropertyKeyEnabled);
-            Assert.Equal("telemetry.batch_size", TelemetryConfiguration.PropertyKeyBatchSize);
-            Assert.Equal("telemetry.flush_interval_ms", TelemetryConfiguration.PropertyKeyFlushIntervalMs);
-            Assert.Equal("telemetry.max_retries", TelemetryConfiguration.PropertyKeyMaxRetries);
-            Assert.Equal("telemetry.retry_delay_ms", TelemetryConfiguration.PropertyKeyRetryDelayMs);
-            Assert.Equal("telemetry.circuit_breaker_enabled", TelemetryConfiguration.PropertyKeyCircuitBreakerEnabled);
-            Assert.Equal("telemetry.circuit_breaker_threshold", TelemetryConfiguration.PropertyKeyCircuitBreakerThreshold);
-            Assert.Equal("telemetry.circuit_breaker_timeout_ms", TelemetryConfiguration.PropertyKeyCircuitBreakerTimeoutMs);
+            Assert.Equal("adbc.databricks.telemetry.enabled", TelemetryConfiguration.PropertyKeyEnabled);
+            Assert.Equal("adbc.databricks.telemetry.batch_size", TelemetryConfiguration.PropertyKeyBatchSize);
+            Assert.Equal("adbc.databricks.telemetry.flush_interval_ms", TelemetryConfiguration.PropertyKeyFlushIntervalMs);
+            Assert.Equal("adbc.databricks.telemetry.max_retries", TelemetryConfiguration.PropertyKeyMaxRetries);
+            Assert.Equal("adbc.databricks.telemetry.retry_delay_ms", TelemetryConfiguration.PropertyKeyRetryDelayMs);
+            Assert.Equal("adbc.databricks.telemetry.circuit_breaker_enabled", TelemetryConfiguration.PropertyKeyCircuitBreakerEnabled);
+            Assert.Equal("adbc.databricks.telemetry.circuit_breaker_threshold", TelemetryConfiguration.PropertyKeyCircuitBreakerThreshold);
+            Assert.Equal("adbc.databricks.telemetry.circuit_breaker_timeout_ms", TelemetryConfiguration.PropertyKeyCircuitBreakerTimeoutMs);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- Rename the 8 telemetry connection-property keys in `TelemetryConfiguration` from `telemetry.*` to `adbc.databricks.telemetry.*` so all driver-defined property keys share the `adbc.databricks` namespace.
- C# constant names (`PropertyKeyEnabled`, `PropertyKeyBatchSize`, `PropertyKeyFlushIntervalMs`, `PropertyKeyMaxRetries`, `PropertyKeyRetryDelayMs`, `PropertyKeyCircuitBreakerEnabled`, `PropertyKeyCircuitBreakerThreshold`, `PropertyKeyCircuitBreakerTimeoutMs`) are unchanged; only the underlying string values move. Callers that reference the constants symbolically continue to work.
- Tests in `TelemetryConfigurationTests.cs` and design notes in `csharp/doc/telemetry-design.md` and `csharp/doc/telemetry-sprint-plan.md` updated to match.

## Breaking change
Callers that set these keys via raw strings (e.g. `"telemetry.enabled"`) in connection properties or JSON config files must rename them to the new `adbc.databricks.telemetry.*` form. Environment-variable keys (`DATABRICKS_TELEMETRY_*`) are unchanged.

## Out of scope
- The two `adbc.spark.temporarily_unavailable_retry*` keys defined in `DatabricksParameters.cs` and the hardcoded `adbc.spark.user_agent_entry` references are left as-is per discussion (the `adbc.spark` prefix is acceptable).
- Inherited `adbc.spark.*` keys from the `SparkParameters` base in the `hiveserver2` submodule are unchanged.

## Test plan
- [ ] `dotnet build csharp/src/AdbcDrivers.Databricks.csproj` (with `hiveserver2` submodule initialized)
- [ ] `dotnet test --filter FullyQualifiedName~TelemetryConfigurationTests` — confirm `TelemetryConfiguration_PropertyKeys_AreCorrect` passes against the new strings
- [ ] Smoke test: open a connection with `adbc.databricks.telemetry.enabled=false` and verify telemetry stays off

This pull request and its description were written by Isaac.