### PR TITLE
chore(csharp): bump version to 1.1.4

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -18,7 +18,13 @@
 
 All notable changes to the C# Databricks ADBC driver are documented in this file.
 
-## [1.1.3] - Unreleased
+## [1.1.4] - Unreleased
+
+### Changed
+
+- Prefix telemetry config keys with `adbc.databricks` namespace (#452)
+
+## [1.1.3] - 2026-05-08
 
 ### Added
 

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` from `1.1.3` → `1.1.4` in `csharp/Directory.Build.props`
- Mark `[1.1.3]` as released (2026-05-08) and add `[1.1.4]` section in `CHANGELOG.md`

The 1.1.4 patch release captures the telemetry config key rename (#452) that prefixes all `telemetry.*` connection-property keys with `adbc.databricks.telemetry.*`.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, `csharp-sync-latest.yml` creates `release/csharp/v1.1.latest` tag `csharp/v1.1.4` and updates `release/csharp/latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)