### PR TITLE
feat(csharp): support ADBC_DATABRICKS_CONFIG_FILE env var

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -57,6 +57,12 @@ namespace AdbcDrivers.Databricks
 
         /// <summary>
         /// The environment variable name that contains the path to the default Databricks configuration file.
+        /// Takes precedence over <see cref="DefaultConfigEnvironmentVariable"/> when both are set.
+        /// </summary>
+        public const string AdbcConfigEnvironmentVariable = "ADBC_DATABRICKS_CONFIG_FILE";
+
+        /// <summary>
+        /// The environment variable name that contains the path to the default Databricks configuration file.
         /// </summary>
         public const string DefaultConfigEnvironmentVariable = "DATABRICKS_CONFIG_FILE";
 

--- a/csharp/src/DatabricksDatabase.cs
+++ b/csharp/src/DatabricksDatabase.cs
@@ -38,6 +38,12 @@ namespace AdbcDrivers.Databricks
     {
         /// <summary>
         /// The environment variable name that contains the path to the default Databricks configuration file.
+        /// Takes precedence over <see cref="DefaultConfigEnvironmentVariable"/> when both are set.
+        /// </summary>
+        public const string AdbcConfigEnvironmentVariable = "ADBC_DATABRICKS_CONFIG_FILE";
+
+        /// <summary>
+        /// The environment variable name that contains the path to the default Databricks configuration file.
         /// </summary>
         public const string DefaultConfigEnvironmentVariable = "DATABRICKS_CONFIG_FILE";
 
@@ -156,16 +162,18 @@ namespace AdbcDrivers.Databricks
         }
 
         /// <summary>
-        /// Automatically merges properties from the default DATABRICKS_CONFIG_FILE environment variable with passed-in properties.
+        /// Automatically merges properties from the default config environment variable with passed-in properties.
+        /// Checks ADBC_DATABRICKS_CONFIG_FILE first, falling back to DATABRICKS_CONFIG_FILE.
         /// The merge priority is controlled by the "adbc.databricks.driver_config_take_precedence" property.
-        /// If DATABRICKS_CONFIG_FILE is not set or invalid, only passed-in properties are used.
+        /// If neither environment variable is set or valid, only passed-in properties are used.
         /// </summary>
         /// <param name="properties">Properties passed to constructor.</param>
         /// <returns>Merged properties dictionary.</returns>
         private static IReadOnlyDictionary<string, string> MergeWithDefaultEnvironmentConfig(IReadOnlyDictionary<string, string> properties)
         {
-            // Try to load configuration from the default environment variable
-            var environmentConfig = DatabricksConfiguration.TryFromEnvironmentVariable(DefaultConfigEnvironmentVariable);
+            // Try to load configuration: ADBC_DATABRICKS_CONFIG_FILE takes precedence over DATABRICKS_CONFIG_FILE
+            var environmentConfig = DatabricksConfiguration.TryFromEnvironmentVariable(AdbcConfigEnvironmentVariable)
+                ?? DatabricksConfiguration.TryFromEnvironmentVariable(DefaultConfigEnvironmentVariable);
 
             if (environmentConfig != null)
             {

--- a/csharp/test/Unit/DatabricksConfigurationTest.cs
+++ b/csharp/test/Unit/DatabricksConfigurationTest.cs
@@ -296,6 +296,110 @@ namespace AdbcDrivers.Databricks.Tests
             }
         }
 
+        /// <summary>
+        /// Tests that ADBC_DATABRICKS_CONFIG_FILE loads configuration correctly.
+        /// </summary>
+        [Fact]
+        public void TryFromEnvironmentVariable_AdbcConfigEnvVar_LoadsConfiguration()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "adbc.databricks.com",
+                [SparkParameters.Token] = "adbc-token"
+            };
+            var configFile = CreateTempJsonFile(properties);
+
+            try
+            {
+                Environment.SetEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable, configFile);
+
+                // Act
+                var config = DatabricksConfiguration.TryFromEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable);
+
+                // Assert
+                Assert.NotNull(config);
+                Assert.Equal("adbc.databricks.com", config.Properties[SparkParameters.HostName]);
+                Assert.Equal("adbc-token", config.Properties[SparkParameters.Token]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable, null);
+            }
+        }
+
+        /// <summary>
+        /// Tests that ADBC_DATABRICKS_CONFIG_FILE takes precedence over DATABRICKS_CONFIG_FILE
+        /// when both are set, mirroring the ?? precedence logic in DatabricksDatabase.
+        /// </summary>
+        [Fact]
+        public void TryFromEnvironmentVariable_AdbcEnvVarTakesPrecedenceOverDefault()
+        {
+            // Arrange
+            var adbcProperties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "adbc.databricks.com"
+            };
+            var defaultProperties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "default.databricks.com"
+            };
+
+            var adbcConfigFile = CreateTempJsonFile(adbcProperties);
+            var defaultConfigFile = CreateTempJsonFile(defaultProperties);
+
+            try
+            {
+                Environment.SetEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable, adbcConfigFile);
+                Environment.SetEnvironmentVariable(DatabricksDatabase.DefaultConfigEnvironmentVariable, defaultConfigFile);
+
+                // Act: simulate the precedence logic used in DatabricksDatabase
+                var config = DatabricksConfiguration.TryFromEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable)
+                    ?? DatabricksConfiguration.TryFromEnvironmentVariable(DatabricksDatabase.DefaultConfigEnvironmentVariable);
+
+                // Assert: ADBC_DATABRICKS_CONFIG_FILE wins
+                Assert.NotNull(config);
+                Assert.Equal("adbc.databricks.com", config.Properties[SparkParameters.HostName]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable, null);
+                Environment.SetEnvironmentVariable(DatabricksDatabase.DefaultConfigEnvironmentVariable, null);
+            }
+        }
+
+        /// <summary>
+        /// Tests that DATABRICKS_CONFIG_FILE is used as fallback when ADBC_DATABRICKS_CONFIG_FILE is not set.
+        /// </summary>
+        [Fact]
+        public void TryFromEnvironmentVariable_FallsBackToDefaultWhenAdbcEnvVarNotSet()
+        {
+            // Arrange
+            var defaultProperties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "default.databricks.com"
+            };
+            var defaultConfigFile = CreateTempJsonFile(defaultProperties);
+
+            try
+            {
+                Environment.SetEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable, null);
+                Environment.SetEnvironmentVariable(DatabricksDatabase.DefaultConfigEnvironmentVariable, defaultConfigFile);
+
+                // Act: simulate the precedence logic used in DatabricksDatabase
+                var config = DatabricksConfiguration.TryFromEnvironmentVariable(DatabricksDatabase.AdbcConfigEnvironmentVariable)
+                    ?? DatabricksConfiguration.TryFromEnvironmentVariable(DatabricksDatabase.DefaultConfigEnvironmentVariable);
+
+                // Assert: falls back to DATABRICKS_CONFIG_FILE
+                Assert.NotNull(config);
+                Assert.Equal("default.databricks.com", config.Properties[SparkParameters.HostName]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(DatabricksDatabase.DefaultConfigEnvironmentVariable, null);
+            }
+        }
+
         #region Helper Methods
 
         /// <summary>


### PR DESCRIPTION
## Summary
DATABRICKS_CONFIG_FILE is conflicted with Databricks CLI env variable, this PR introduce a new env var name of ADBC_DATABRICKS_CONFIG_FILE.

- Add `ADBC_DATABRICKS_CONFIG_FILE` as a higher-priority alternative to `DATABRICKS_CONFIG_FILE` for specifying the driver config file path
- Resolves naming conflicts when `DATABRICKS_CONFIG_FILE` is already used by another tool in the same environment
- When both env vars are set, `ADBC_DATABRICKS_CONFIG_FILE` takes precedence; falls back to `DATABRICKS_CONFIG_FILE` if not set
- Expose `AdbcConfigEnvironmentVariable` constant on both `DatabricksDatabase` and `DatabricksConnection` for consumers

## Test Plan

- [x] Existing unit tests in `DatabricksConfigurationTest.cs` continue to pass (no behavior change for `DATABRICKS_CONFIG_FILE`)
- [x] Logic verified: `TryFromEnvironmentVariable(AdbcConfigEnvironmentVariable) ?? TryFromEnvironmentVariable(DefaultConfigEnvironmentVariable)`

## Verification Commands

```bash
cd csharp/test
dotnet test Apache.Arrow.Adbc.Tests.Drivers.Databricks.csproj --filter "FullyQualifiedName~DatabricksConfigurationTest"
```

Closes #

---
_This PR was created with [GitHub MCP](http://go/mcps)._