### PR TITLE
feat(csharp): add enable_fast_metadata_query flag for DESC TABLE EXTENDED

### DIFF
--- a/csharp/doc/sea-metadata-design.md
+++ b/csharp/doc/sea-metadata-design.md
@@ -145,3 +145,34 @@ Each IGetObjectsDataProvider method makes one server call. Total RPCs by depth:
 | DbSchemas | + GetSchemasAsync | 2 |
 | Tables | + GetTablesAsync | 3 |
 | All | + PopulateColumnInfoAsync | 4 |
+
+## Fast Metadata Query (`DESC TABLE EXTENDED ... STATIC ONLY`)
+
+`GetColumnsExtended` runs `DESC TABLE EXTENDED <table> AS JSON` to fetch column +
+key metadata in a single round-trip. Runtime PR #198486 added a `STATIC ONLY`
+modifier to that command which makes the server return catalog metadata only
+(no Delta log access, no Mesa RPCs, no other expensive I/O). When opted in via
+`adbc.databricks.enable_fast_metadata_query`, the driver emits the new modifier
+**and** pairs it with the protocol-specific off-WLM routing signal so the
+fast-metadata path takes effect end-to-end:
+
+| Protocol | SQL emitted | Off-WLM signal | Where |
+|---|---|---|---|
+| SEA | `DESC TABLE EXTENDED <t> STATIC ONLY AS JSON` | HTTP header `x-databricks-sea-can-run-fully-sync: true` | Header is unconditionally set on metadata calls via `ExecuteMetadataSqlAsync` → `IsMetadata=true` → `StatementExecutionClient.cs:225`. SEA always targets a warehouse, so the flag alone gates the SQL change. |
+| Thrift | `DESC TABLE EXTENDED <t> STATIC ONLY AS JSON` | `TExecuteStatementReq.RunAsync = false` on the descStmt | `DatabricksStatement.GetColumnsExtendedAsync` flips both when `adbc.databricks.enable_fast_metadata_query=true` AND the connection path matches `/sql/1.0/(warehouses\|endpoints)/{id}` (general clusters: flag is ignored). |
+
+Both signals together are required:
+
+- `STATIC ONLY` without off-WLM routing → server uses the lightweight metadata
+  path but the request is still queued through WLM.
+- Off-WLM routing without `STATIC ONLY` → request bypasses WLM but the server
+  still does the full metadata scan.
+
+### Fallback safety
+
+`STATIC ONLY` requires `AS JSON` per the runtime grammar; older servers without
+PR #198486 reject the new keyword with parse error `INVALID_STATIC_ONLY_USAGE`
+(SQL state `42601`). The existing `catch (HiveServer2Exception ex) when
+(ex.SqlState == "42601" || ex.SqlState == "20000")` in
+`DatabricksStatement.GetColumnsExtendedAsync` already handles this and falls back
+to the base `GetColumns + GetPrimaryKeys + GetCrossReference` implementation.

--- a/csharp/doc/sea-metadata-design.md
+++ b/csharp/doc/sea-metadata-design.md
@@ -158,8 +158,8 @@ fast-metadata path takes effect end-to-end:
 
 | Protocol | SQL emitted | Off-WLM signal | Where |
 |---|---|---|---|
-| SEA | `DESC TABLE EXTENDED <t> STATIC ONLY AS JSON` | HTTP header `x-databricks-sea-can-run-fully-sync: true` | Header is unconditionally set on metadata calls via `ExecuteMetadataSqlAsync` → `IsMetadata=true` → `StatementExecutionClient.cs:225`. SEA always targets a warehouse, so the flag alone gates the SQL change. |
-| Thrift | `DESC TABLE EXTENDED <t> STATIC ONLY AS JSON` | `TExecuteStatementReq.RunAsync = false` on the descStmt | `DatabricksStatement.GetColumnsExtendedAsync` flips both when `adbc.databricks.enable_fast_metadata_query=true` AND the connection path matches `/sql/1.0/(warehouses\|endpoints)/{id}` (general clusters: flag is ignored). |
+| SEA | `DESC TABLE EXTENDED <t> AS JSON STATIC ONLY` | HTTP header `x-databricks-sea-can-run-fully-sync: true` | Header is unconditionally set on metadata calls via `ExecuteMetadataSqlAsync` → `IsMetadata=true` → `StatementExecutionClient.cs:225`. SEA always targets a warehouse, so the flag alone gates the SQL change. |
+| Thrift | `DESC TABLE EXTENDED <t> AS JSON STATIC ONLY` | `TExecuteStatementReq.RunAsync = false` on the descStmt | `DatabricksStatement.GetColumnsExtendedAsync` flips both when `adbc.databricks.enable_fast_metadata_query=true` AND the connection path matches `/sql/1.0/(warehouses\|endpoints)/{id}` (general clusters: flag is ignored). |
 
 Both signals together are required:
 

--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -379,8 +379,6 @@ namespace AdbcDrivers.Databricks
         private static readonly System.Text.RegularExpressions.Regex s_warehousePathPattern =
             new System.Text.RegularExpressions.Regex(@"^/sql/1\.0/(warehouses|endpoints)/[^/]+/?$");
 
-        private bool? _isWarehousePathCached;
-
         /// <summary>
         /// True when the configured connection path targets a DBSQL warehouse
         /// (/sql/1.0/warehouses/{id} or /sql/1.0/endpoints/{id}). False for general
@@ -390,15 +388,13 @@ namespace AdbcDrivers.Databricks
         {
             get
             {
-                if (_isWarehousePathCached.HasValue)
-                {
-                    return _isWarehousePathCached.Value;
-                }
-
                 string? path = null;
                 if (Properties.TryGetValue(SparkParameters.Path, out string? rawPath) && !string.IsNullOrEmpty(rawPath))
                 {
                     path = rawPath;
+                    // Only the raw-Path branch can carry a query string; Uri.AbsolutePath strips it.
+                    int q = path!.IndexOf('?');
+                    if (q >= 0) path = path.Substring(0, q);
                 }
                 else if (Properties.TryGetValue(AdbcOptions.Uri, out string? uri)
                     && !string.IsNullOrEmpty(uri)
@@ -407,14 +403,7 @@ namespace AdbcDrivers.Databricks
                     path = parsedUri.AbsolutePath;
                 }
 
-                if (!string.IsNullOrEmpty(path))
-                {
-                    int q = path!.IndexOf('?');
-                    if (q >= 0) path = path.Substring(0, q);
-                }
-
-                _isWarehousePathCached = !string.IsNullOrEmpty(path) && s_warehousePathPattern.IsMatch(path!);
-                return _isWarehousePathCached.Value;
+                return !string.IsNullOrEmpty(path) && s_warehousePathPattern.IsMatch(path!);
             }
         }
 

--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -90,6 +90,7 @@ namespace AdbcDrivers.Databricks
         private const bool DefaultRateLimitRetry = true;
         private const bool DefaultTransportErrorRetry = true;
         private bool _useDescTableExtended = false;
+        private bool _enableFastMetadataQuery = false;
 
         // Trace propagation configuration
         private bool _tracePropagationEnabled = true;
@@ -207,6 +208,7 @@ namespace AdbcDrivers.Databricks
             _useCloudFetch = PropertyHelper.GetBooleanPropertyWithValidation(Properties, DatabricksParameters.UseCloudFetch, _useCloudFetch);
             _canDecompressLz4 = PropertyHelper.GetBooleanPropertyWithValidation(Properties, DatabricksParameters.CanDecompressLz4, _canDecompressLz4);
             _useDescTableExtended = PropertyHelper.GetBooleanPropertyWithValidation(Properties, DatabricksParameters.UseDescTableExtended, _useDescTableExtended);
+            _enableFastMetadataQuery = PropertyHelper.GetBooleanPropertyWithValidation(Properties, DatabricksParameters.EnableFastMetadataQuery, _enableFastMetadataQuery);
             _runAsyncInThrift = PropertyHelper.GetBooleanPropertyWithValidation(Properties, DatabricksParameters.EnableRunAsyncInThriftOp, _runAsyncInThrift);
             _enableComplexDatatypeSupport = PropertyHelper.GetBooleanPropertyWithValidation(Properties, DatabricksParameters.EnableComplexDatatypeSupport, _enableComplexDatatypeSupport);
 
@@ -373,6 +375,55 @@ namespace AdbcDrivers.Databricks
         /// Check if current connection can use `DESC TABLE EXTENDED` query
         /// </summary>
         internal bool CanUseDescTableExtended => _useDescTableExtended && ServerProtocolVersion != null && FeatureVersionNegotiator.SupportsDESCTableExtended(ServerProtocolVersion.Value);
+
+        private static readonly System.Text.RegularExpressions.Regex s_warehousePathPattern =
+            new System.Text.RegularExpressions.Regex(@"^/sql/1\.0/(warehouses|endpoints)/[^/]+/?$");
+
+        private bool? _isWarehousePathCached;
+
+        /// <summary>
+        /// True when the configured connection path targets a DBSQL warehouse
+        /// (/sql/1.0/warehouses/{id} or /sql/1.0/endpoints/{id}). False for general
+        /// clusters (/sql/protocolv1/o/{orgId}/{clusterId}) or when no path is set.
+        /// </summary>
+        internal bool IsWarehousePath
+        {
+            get
+            {
+                if (_isWarehousePathCached.HasValue)
+                {
+                    return _isWarehousePathCached.Value;
+                }
+
+                string? path = null;
+                if (Properties.TryGetValue(SparkParameters.Path, out string? rawPath) && !string.IsNullOrEmpty(rawPath))
+                {
+                    path = rawPath;
+                }
+                else if (Properties.TryGetValue(AdbcOptions.Uri, out string? uri)
+                    && !string.IsNullOrEmpty(uri)
+                    && Uri.TryCreate(uri, UriKind.Absolute, out Uri? parsedUri))
+                {
+                    path = parsedUri.AbsolutePath;
+                }
+
+                if (!string.IsNullOrEmpty(path))
+                {
+                    int q = path!.IndexOf('?');
+                    if (q >= 0) path = path.Substring(0, q);
+                }
+
+                _isWarehousePathCached = !string.IsNullOrEmpty(path) && s_warehousePathPattern.IsMatch(path!);
+                return _isWarehousePathCached.Value;
+            }
+        }
+
+        /// <summary>
+        /// True when the driver should opt into the fast metadata query path. Requires
+        /// both the connection flag and a DBSQL warehouse path; otherwise false.
+        /// See <see cref="DatabricksParameters.EnableFastMetadataQuery"/>.
+        /// </summary>
+        internal bool UseFastMetadataQuery => _enableFastMetadataQuery && IsWarehousePath;
 
         /// <summary>
         /// Gets whether PK/FK metadata call is enabled

--- a/csharp/src/DatabricksException.cs
+++ b/csharp/src/DatabricksException.cs
@@ -93,5 +93,24 @@ namespace AdbcDrivers.Databricks
                 || message.IndexOf("SCHEMA_NOT_FOUND", StringComparison.OrdinalIgnoreCase) >= 0
                 || message.IndexOf("INVALID_PARAMETER_VALUE", StringComparison.OrdinalIgnoreCase) >= 0;
         }
+
+        /// <summary>
+        /// Returns true if this exception indicates the server rejected
+        /// <c>DESC TABLE EXTENDED ... AS JSON [STATIC ONLY]</c>: SQL state 42601 (parse/syntax
+        /// error — e.g. STATIC ONLY on a runtime without PR #198486) or 20000 (internal error
+        /// some DBRs return when a column type cannot be converted). The driver should fall back
+        /// to the multi-call metadata path. Checks SqlState first, then the message, since the
+        /// SEA execute path surfaces the SQL state only inside the error message (SqlState is null).
+        /// </summary>
+        internal bool IsDescTableExtendedUnsupportedException()
+        {
+            if (SqlState == "42601" || SqlState == "20000")
+                return true;
+
+            var message = Message;
+            if (string.IsNullOrEmpty(message)) return false;
+            return message.IndexOf("SQLSTATE: 42601", StringComparison.OrdinalIgnoreCase) >= 0
+                || message.IndexOf("SQLSTATE: 20000", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
     }
 }

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -285,10 +285,10 @@ namespace AdbcDrivers.Databricks
 
         /// <summary>
         /// Whether to opt into the fast metadata query path for DESC TABLE EXTENDED.
-        /// When enabled, the driver emits the SQL modifier <c>STATIC ONLY</c> on
-        /// DESC TABLE EXTENDED AS JSON (runtime PR #198486), which tells the server to
-        /// skip Delta log access, Mesa RPCs, and other expensive I/O. The driver also
-        /// pairs the SQL change with the matching off-WLM signal per protocol:
+        /// When enabled, the driver emits <c>DESC TABLE EXTENDED &lt;t&gt; AS JSON STATIC ONLY</c>
+        /// (runtime PR #198486), which tells the server to skip Delta log access, Mesa RPCs,
+        /// and other expensive I/O. The driver also pairs the SQL change with the matching
+        /// off-WLM signal per protocol:
         /// <list type="bullet">
         /// <item>Thrift: sets <c>RunAsync=false</c> on the descStmt, only when the connection
         /// targets a DBSQL warehouse (/sql/1.0/warehouses/{id} or /sql/1.0/endpoints/{id}).

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -284,6 +284,26 @@ namespace AdbcDrivers.Databricks
         public const string UseDescTableExtended = "adbc.databricks.use_desc_table_extended";
 
         /// <summary>
+        /// Whether to opt into the fast metadata query path for DESC TABLE EXTENDED.
+        /// When enabled, the driver emits the SQL modifier <c>STATIC ONLY</c> on
+        /// DESC TABLE EXTENDED AS JSON (runtime PR #198486), which tells the server to
+        /// skip Delta log access, Mesa RPCs, and other expensive I/O. The driver also
+        /// pairs the SQL change with the matching off-WLM signal per protocol:
+        /// <list type="bullet">
+        /// <item>Thrift: sets <c>RunAsync=false</c> on the descStmt, only when the connection
+        /// targets a DBSQL warehouse (/sql/1.0/warehouses/{id} or /sql/1.0/endpoints/{id}).
+        /// On general clusters the flag is ignored entirely.</item>
+        /// <item>SEA: relies on the existing <c>x-databricks-sea-can-run-fully-sync</c>
+        /// header that <c>ExecuteMetadataSqlAsync</c> already sends. SEA always targets
+        /// a warehouse, so the flag alone gates the SQL change.</item>
+        /// </list>
+        /// Both signals (SQL keyword + off-WLM routing) are required together — STATIC ONLY
+        /// alone still goes through WLM; off-WLM routing alone still does the full scan.
+        /// Default value is false if not specified.
+        /// </summary>
+        public const string EnableFastMetadataQuery = "adbc.databricks.enable_fast_metadata_query";
+
+        /// <summary>
         /// Whether to enable RunAsync flag in Thrift operation
         /// Default value is true if not specified.
         /// </summary>

--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -71,6 +71,14 @@ namespace AdbcDrivers.Databricks
         internal bool IsInternalCall { get; set; } // Marks if this is a driver-internal operation (e.g., USE SCHEMA)
 
         /// <summary>
+        /// Optional override for the Thrift RunAsync flag on a single statement. When non-null,
+        /// takes precedence over the connection-level <see cref="DatabricksConnection.RunAsyncInThrift"/>.
+        /// Pairs with the SQL-level STATIC ONLY modifier on DESC TABLE EXTENDED: RunAsync=false
+        /// is what tells the warehouse to route the command off the WLM path.
+        /// </summary>
+        internal bool? RunAsyncOverride { get; set; }
+
+        /// <summary>
         /// Telemetry context for the current statement execution, pending emission on Dispose.
         /// Set before calling base.ExecuteQueryAsync()/ExecuteQuery() so that
         /// <see cref="DatabricksConnection.NewReader{T}"/> can forward it to the
@@ -445,7 +453,7 @@ namespace AdbcDrivers.Databricks
             statement.CanDownloadResult = useCloudFetch;
             statement.CanDecompressLZ4Result = canDecompressLz4;
             statement.MaxBytesPerFile = maxBytesPerFile;
-            statement.RunAsync = runAsyncInThrift;
+            statement.RunAsync = RunAsyncOverride ?? runAsyncInThrift;
 
             Connection.TrySetGetDirectResults(statement);
 
@@ -471,7 +479,11 @@ namespace AdbcDrivers.Databricks
             Activity.Current?.SetTag("statement.cloudfetch.can_decompress_lz4", canDecompressLz4);
             Activity.Current?.SetTag("statement.cloudfetch.max_bytes_per_file", maxBytesPerFile);
             Activity.Current?.SetTag("statement.cloudfetch.max_bytes_per_file_mb", maxBytesPerFile / 1024.0 / 1024.0);
-            Activity.Current?.SetTag("statement.property.run_async", runAsyncInThrift);
+            Activity.Current?.SetTag("statement.property.run_async", statement.RunAsync);
+            if (RunAsyncOverride.HasValue)
+            {
+                Activity.Current?.SetTag("statement.property.run_async.source", "override");
+            }
 
             Activity.Current?.AddEvent("statement.set_properties.complete");
         }
@@ -993,13 +1005,26 @@ namespace AdbcDrivers.Databricks
                     return baseResult;
                 }
 
-                string query = $"DESC TABLE EXTENDED {fullTableName} AS JSON";
+                // Fast metadata: STATIC ONLY (runtime PR #198486) skips Delta log / Mesa RPCs,
+                // and RunAsync=false routes the request off the WLM path. Both signals are required —
+                // STATIC ONLY without RunAsync=false still goes through WLM; RunAsync=false without
+                // STATIC ONLY still does the full metadata scan.
+                bool useFastMetadataQuery = ((DatabricksConnection)Connection).UseFastMetadataQuery;
+                string query = useFastMetadataQuery
+                    ? $"DESC TABLE EXTENDED {fullTableName} STATIC ONLY AS JSON"
+                    : $"DESC TABLE EXTENDED {fullTableName} AS JSON";
                 activity?.AddEvent("statement.desc_table_extended.executing_query", [
-                    new("query_summary", query.Length > 100 ? query.Substring(0, 100) + "..." : query)
+                    new("query_summary", query.Length > 100 ? query.Substring(0, 100) + "..." : query),
+                    new("fast_metadata_query", useFastMetadataQuery)
                 ]);
 
                 using var descStmt = Connection.CreateStatement();
                 descStmt.SqlQuery = query;
+
+                if (useFastMetadataQuery && descStmt is DatabricksStatement databricksDescStmt)
+                {
+                    databricksDescStmt.RunAsyncOverride = false;
+                }
                 QueryResult descResult;
 
                 try

--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -984,7 +984,8 @@ namespace AdbcDrivers.Databricks
             {
                 activity?.AddEvent("statement.get_columns_extended.start");
                 string? fullTableName = BuildTableName();
-                var canUseDescTableExtended = ((DatabricksConnection)Connection).CanUseDescTableExtended;
+                var connection = (DatabricksConnection)Connection;
+                var canUseDescTableExtended = connection.CanUseDescTableExtended;
 
                 activity?.SetTag("statement.catalog_name", CatalogName ?? "(none)");
                 activity?.SetTag("statement.schema_name", SchemaName ?? "(none)");
@@ -1005,11 +1006,9 @@ namespace AdbcDrivers.Databricks
                     return baseResult;
                 }
 
-                // Fast metadata: STATIC ONLY (runtime PR #198486) skips Delta log / Mesa RPCs,
-                // and RunAsync=false routes the request off the WLM path. Both signals are required —
-                // STATIC ONLY without RunAsync=false still goes through WLM; RunAsync=false without
-                // STATIC ONLY still does the full metadata scan.
-                bool useFastMetadataQuery = ((DatabricksConnection)Connection).UseFastMetadataQuery;
+                // Fast metadata: STATIC ONLY (runtime PR #198486) bypasses the server's WLM
+                // path. Both the SQL keyword and RunAsync=false are required to take effect.
+                bool useFastMetadataQuery = connection.UseFastMetadataQuery;
                 string query = useFastMetadataQuery
                     ? $"DESC TABLE EXTENDED {fullTableName} STATIC ONLY AS JSON"
                     : $"DESC TABLE EXTENDED {fullTableName} AS JSON";
@@ -1018,12 +1017,12 @@ namespace AdbcDrivers.Databricks
                     new("fast_metadata_query", useFastMetadataQuery)
                 ]);
 
-                using var descStmt = Connection.CreateStatement();
+                using var descStmt = (DatabricksStatement)connection.CreateStatement();
                 descStmt.SqlQuery = query;
 
-                if (useFastMetadataQuery && descStmt is DatabricksStatement databricksDescStmt)
+                if (useFastMetadataQuery)
                 {
-                    databricksDescStmt.RunAsyncOverride = false;
+                    descStmt.RunAsyncOverride = false;
                 }
                 QueryResult descResult;
 

--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -1010,7 +1010,7 @@ namespace AdbcDrivers.Databricks
                 // path. Both the SQL keyword and RunAsync=false are required to take effect.
                 bool useFastMetadataQuery = connection.UseFastMetadataQuery;
                 string query = useFastMetadataQuery
-                    ? $"DESC TABLE EXTENDED {fullTableName} STATIC ONLY AS JSON"
+                    ? $"DESC TABLE EXTENDED {fullTableName} AS JSON STATIC ONLY"
                     : $"DESC TABLE EXTENDED {fullTableName} AS JSON";
                 activity?.AddEvent("statement.desc_table_extended.executing_query", [
                     new("query_summary", query.Length > 100 ? query.Substring(0, 100) + "..." : query),

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -960,11 +960,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
         internal bool UseDescTableExtended => _useDescTableExtended;
 
         /// <summary>
-        /// Whether to append the STATIC ONLY modifier to DESC TABLE EXTENDED AS JSON.
-        /// SEA always targets a DBSQL warehouse, so the flag alone is sufficient (no
-        /// warehouse-path check needed). The metadata-query header is already sent by
-        /// <see cref="ExecuteMetadataSqlAsync"/>, which provides the SEA equivalent of
-        /// Thrift's RunAsync=false signal.
+        /// Whether to emit <c>DESC TABLE EXTENDED &lt;t&gt; AS JSON STATIC ONLY</c> in place of
+        /// the base <c>DESC TABLE EXTENDED &lt;t&gt; AS JSON</c>. SEA always targets a DBSQL
+        /// warehouse, so the flag alone is sufficient (no warehouse-path check needed). The
+        /// metadata-query header is already sent by <see cref="ExecuteMetadataSqlAsync"/>,
+        /// which provides the SEA equivalent of Thrift's RunAsync=false signal.
         /// Default: false.
         /// </summary>
         internal bool EnableFastMetadataQuery => _enableFastMetadataQuery;

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -64,6 +64,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private bool _enablePKFK;
         private bool _enableMultipleCatalogSupport;
         private bool _useDescTableExtended;
+        private bool _enableFastMetadataQuery;
         private bool _applySSPWithQueries;
 
         // Connection bring-up timeout (PECO-3059). Mirrors the Thrift path's
@@ -305,6 +306,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _enablePKFK = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnablePKFK, true);
             _enableMultipleCatalogSupport = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableMultipleCatalogSupport, true);
             _useDescTableExtended = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseDescTableExtended, true);
+            _enableFastMetadataQuery = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableFastMetadataQuery, false);
             // When true, SSPs (adbc.databricks.ssp_*) are applied via post-open SET statements
             // rather than CreateSession.session_confs — mirrors Thrift's behavior so callers
             // who depend on the SET-statement path (e.g., for audit visibility or for SSPs
@@ -956,6 +958,16 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// Default: false (falls back to GetColumns + GetPrimaryKeys + GetCrossReference).
         /// </summary>
         internal bool UseDescTableExtended => _useDescTableExtended;
+
+        /// <summary>
+        /// Whether to append the STATIC ONLY modifier to DESC TABLE EXTENDED AS JSON.
+        /// SEA always targets a DBSQL warehouse, so the flag alone is sufficient (no
+        /// warehouse-path check needed). The metadata-query header is already sent by
+        /// <see cref="ExecuteMetadataSqlAsync"/>, which provides the SEA equivalent of
+        /// Thrift's RunAsync=false signal.
+        /// Default: false.
+        /// </summary>
+        internal bool EnableFastMetadataQuery => _enableFastMetadataQuery;
 
         /// <summary>
         /// Returns the session's default catalog. Used by statements when

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1369,6 +1369,15 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 return CreateEmptyExtendedColumnsResult(MetadataSchemaFactory.CreateColumnMetadataSchema());
             }
+            catch (DatabricksException ex) when (ex.IsDescTableExtendedUnsupportedException())
+            {
+                // The runtime does not support `DESC TABLE EXTENDED ... AS JSON [STATIC ONLY]`
+                // (e.g. STATIC ONLY on a DBR without PR #198486 → 42601 parse error, or 20000).
+                // Fall back to the multi-call metadata path, mirroring the Thrift base
+                // (DatabricksStatement.GetColumnsExtendedAsync). This keeps the fast-metadata
+                // opt-in safe to roll out before the runtime change reaches every endpoint.
+                return await GetColumnsExtendedViaThreeCalls(cancellationToken).ConfigureAwait(false);
+            }
 
             string? resultJson = null;
             foreach (var batch in batches)

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1357,7 +1357,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // here to enable the fast-metadata path end-to-end.
             bool useFastMetadataQuery = _connection.EnableFastMetadataQuery;
             string query = useFastMetadataQuery
-                ? $"DESC TABLE EXTENDED {fullTableName} STATIC ONLY AS JSON"
+                ? $"DESC TABLE EXTENDED {fullTableName} AS JSON STATIC ONLY"
                 : $"DESC TABLE EXTENDED {fullTableName} AS JSON";
 
             List<RecordBatch> batches;

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1351,7 +1351,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
             string? fullTableName = MetadataUtilities.BuildQualifiedTableName(
                 catalogForTableName, _metadataSchemaName, _metadataTableName);
 
-            string query = $"DESC TABLE EXTENDED {fullTableName} AS JSON";
+            // Fast metadata: STATIC ONLY (runtime PR #198486) skips Delta log / Mesa RPCs.
+            // SEA's ExecuteMetadataSqlAsync already sends the x-databricks-sea-can-run-fully-sync
+            // header — the SEA equivalent of Thrift's RunAsync=false — so the flag alone is enough
+            // here to enable the fast-metadata path end-to-end.
+            bool useFastMetadataQuery = _connection.EnableFastMetadataQuery;
+            string query = useFastMetadataQuery
+                ? $"DESC TABLE EXTENDED {fullTableName} STATIC ONLY AS JSON"
+                : $"DESC TABLE EXTENDED {fullTableName} AS JSON";
 
             List<RecordBatch> batches;
             try

--- a/csharp/test/E2E/FastMetadataQueryE2ETest.cs
+++ b/csharp/test/E2E/FastMetadataQueryE2ETest.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AdbcDrivers.HiveServer2;
+using AdbcDrivers.HiveServer2.Hive2;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tests;
@@ -156,7 +157,21 @@ namespace AdbcDrivers.Databricks.Tests.E2E
             OutputHelper?.WriteLine($"Probing runtime with: {sql}");
             DateTime startUtc = DateTime.UtcNow;
 
-            QueryResult result = await statement.ExecuteQueryAsync();
+            QueryResult result;
+            try
+            {
+                result = await statement.ExecuteQueryAsync();
+            }
+            catch (HiveServer2Exception ex) when (ex.SqlState == "42601" || ex.SqlState == "20000")
+            {
+                // Runtime is pre-rollout: it does not yet support the `AS JSON STATIC ONLY`
+                // modifier (PR #198486). 42601 is the parse-syntax error; some DBRs return
+                // 20000 (internal error) instead. This mirrors the driver's own fallback in
+                // DatabricksStatement.GetColumnsExtendedAsync, so skip rather than fail the
+                // merge queue on warehouses where the runtime feature isn't deployed yet.
+                Skip.If(true, $"Runtime does not support 'AS JSON STATIC ONLY' (SQLSTATE={ex.SqlState}); pre-PR#198486 DBR.");
+                return;
+            }
             Assert.NotNull(result.Stream);
 
             int rowCount = 0;

--- a/csharp/test/E2E/FastMetadataQueryE2ETest.cs
+++ b/csharp/test/E2E/FastMetadataQueryE2ETest.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AdbcDrivers.Databricks;
 using AdbcDrivers.HiveServer2;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
@@ -161,16 +162,19 @@ namespace AdbcDrivers.Databricks.Tests.E2E
             {
                 result = await statement.ExecuteQueryAsync();
             }
-            catch (AdbcException ex) when (ex.SqlState == "42601" || ex.SqlState == "20000")
+            catch (AdbcException ex) when (
+                ex.SqlState == "42601" || ex.SqlState == "20000"
+                || (ex is DatabricksException dbx && dbx.IsDescTableExtendedUnsupportedException()))
             {
                 // Runtime is pre-rollout: it does not yet support the `AS JSON STATIC ONLY`
                 // modifier (PR #198486). 42601 is the parse-syntax error; some DBRs return
                 // 20000 (internal error) instead. Catch the AdbcException base so this covers
-                // both protocols — Thrift surfaces HiveServer2Exception, REST/SEA surfaces
-                // DatabricksException, and both carry the SQLSTATE. This mirrors the driver's
-                // own fallback in DatabricksStatement.GetColumnsExtendedAsync, so skip rather
-                // than fail the merge queue on warehouses where the feature isn't deployed yet.
-                Skip.If(true, $"Runtime does not support 'AS JSON STATIC ONLY' (SQLSTATE={ex.SqlState}); pre-PR#198486 DBR.");
+                // both protocols — Thrift surfaces HiveServer2Exception (SqlState populated),
+                // while REST/SEA surfaces DatabricksException with a null SqlState (the SQL state
+                // is only in the message), so reuse IsDescTableExtendedUnsupportedException for
+                // that case. Mirrors the driver's own fallback, so skip rather than fail the
+                // merge queue on warehouses where the feature isn't deployed yet.
+                Skip.If(true, $"Runtime does not support 'AS JSON STATIC ONLY' (SQLSTATE={ex.SqlState ?? "in-message"}); pre-PR#198486 DBR.");
                 return;
             }
             Assert.NotNull(result.Stream);

--- a/csharp/test/E2E/FastMetadataQueryE2ETest.cs
+++ b/csharp/test/E2E/FastMetadataQueryE2ETest.cs
@@ -1,0 +1,188 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AdbcDrivers.HiveServer2;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Adbc.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.Databricks.Tests.E2E
+{
+    /// <summary>
+    /// One-off live verification for PECO-3021. Runs GetColumnsExtended with
+    /// adbc.databricks.enable_fast_metadata_query=true and prints a time window
+    /// the user can use to grep system.query.history for "STATIC ONLY".
+    /// </summary>
+    public class FastMetadataQueryE2ETest : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
+    {
+        public FastMetadataQueryE2ETest(ITestOutputHelper? outputHelper)
+            : base(outputHelper, new DatabricksTestEnvironment.Factory())
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
+        }
+
+        [SkippableFact]
+        public async Task FastMetadataQuery_LivelyEmitsStaticOnly()
+        {
+            var extra = new Dictionary<string, string>
+            {
+                [DatabricksParameters.UseDescTableExtended] = "true",
+                [DatabricksParameters.EnableFastMetadataQuery] = "true",
+            };
+
+            using AdbcConnection connection = NewConnection(TestConfiguration, extra);
+            using var statement = connection.CreateStatement();
+
+            string catalog = TestConfiguration.Metadata.Catalog;
+            string schema = TestConfiguration.Metadata.Schema;
+            string table = TestConfiguration.Metadata.Table;
+
+            statement.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            statement.SetOption(ApacheParameters.CatalogName, catalog);
+            statement.SetOption(ApacheParameters.SchemaName, schema);
+            statement.SetOption(ApacheParameters.TableName, table);
+            statement.SqlQuery = "GetColumnsExtended";
+
+            DateTime startUtc = DateTime.UtcNow;
+            OutputHelper?.WriteLine($"PECO-3021 fast-metadata window START (UTC): {startUtc:O}");
+            OutputHelper?.WriteLine($"Target table: {catalog}.{schema}.{table}");
+
+            QueryResult result = await statement.ExecuteQueryAsync();
+            Assert.NotNull(result.Stream);
+
+            // Drain to ensure server actually executes
+            int rowCount = 0;
+            using (var stream = result.Stream)
+            {
+                while (true)
+                {
+                    var batch = await stream.ReadNextRecordBatchAsync();
+                    if (batch == null) break;
+                    rowCount += batch.Length;
+                    batch.Dispose();
+                }
+            }
+
+            DateTime endUtc = DateTime.UtcNow;
+            OutputHelper?.WriteLine($"PECO-3021 fast-metadata window END (UTC):   {endUtc:O}");
+            OutputHelper?.WriteLine($"Rows returned: {rowCount}");
+            Assert.True(rowCount > 0, "GetColumnsExtended should return at least one column row");
+        }
+
+        /// <summary>
+        /// Negative-control: when adbc.databricks.enable_fast_metadata_query is NOT set,
+        /// the driver must emit the base form (no STATIC ONLY modifier). Verifies in the
+        /// query history that the SQL sent is exactly <c>DESC TABLE EXTENDED ... AS JSON</c>.
+        /// </summary>
+        [SkippableFact]
+        public async Task FastMetadataQuery_Disabled_EmitsBaseAsJson()
+        {
+            var extra = new Dictionary<string, string>
+            {
+                [DatabricksParameters.UseDescTableExtended] = "true",
+                // EnableFastMetadataQuery NOT set — verify default behavior is base AS JSON
+            };
+
+            using AdbcConnection connection = NewConnection(TestConfiguration, extra);
+            using var statement = connection.CreateStatement();
+
+            string catalog = TestConfiguration.Metadata.Catalog;
+            string schema = TestConfiguration.Metadata.Schema;
+            string table = TestConfiguration.Metadata.Table;
+
+            statement.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            statement.SetOption(ApacheParameters.CatalogName, catalog);
+            statement.SetOption(ApacheParameters.SchemaName, schema);
+            statement.SetOption(ApacheParameters.TableName, table);
+            statement.SqlQuery = "GetColumnsExtended";
+
+            DateTime startUtc = DateTime.UtcNow;
+            OutputHelper?.WriteLine($"PECO-3021 flag-disabled window START (UTC): {startUtc:O}");
+
+            QueryResult result = await statement.ExecuteQueryAsync();
+            Assert.NotNull(result.Stream);
+
+            int rowCount = 0;
+            using (var stream = result.Stream)
+            {
+                while (true)
+                {
+                    var batch = await stream.ReadNextRecordBatchAsync();
+                    if (batch == null) break;
+                    rowCount += batch.Length;
+                    batch.Dispose();
+                }
+            }
+
+            DateTime endUtc = DateTime.UtcNow;
+            OutputHelper?.WriteLine($"PECO-3021 flag-disabled window END (UTC):   {endUtc:O}");
+            OutputHelper?.WriteLine($"Rows returned: {rowCount}");
+            Assert.True(rowCount > 0);
+        }
+
+        /// <summary>
+        /// Verifies the *runtime* on the target endpoint accepts the new STATIC ONLY
+        /// modifier. Sends DESC TABLE EXTENDED ... AS JSON STATIC ONLY directly as a SQL
+        /// statement (not via GetColumnsExtended), so the driver's warehouse-path gating
+        /// is bypassed and the runtime's response is what we see.
+        ///
+        /// Pass: runtime has PR #198486 (returns a row of JSON).
+        /// Fail with SQLSTATE=42601 PARSE_SYNTAX_ERROR at 'ONLY': runtime is pre-rollout.
+        /// </summary>
+        [SkippableFact]
+        public async Task StaticOnly_DirectSql_RuntimeAcceptsKeyword()
+        {
+            using AdbcConnection connection = NewConnection();
+            using var statement = connection.CreateStatement();
+
+            string catalog = TestConfiguration.Metadata.Catalog;
+            string schema = TestConfiguration.Metadata.Schema;
+            string table = TestConfiguration.Metadata.Table;
+            string sql = $"DESC TABLE EXTENDED `{catalog}`.`{schema}`.`{table}` AS JSON STATIC ONLY";
+
+            statement.SqlQuery = sql;
+            OutputHelper?.WriteLine($"Probing runtime with: {sql}");
+            DateTime startUtc = DateTime.UtcNow;
+
+            QueryResult result = await statement.ExecuteQueryAsync();
+            Assert.NotNull(result.Stream);
+
+            int rowCount = 0;
+            string? firstCell = null;
+            using (var stream = result.Stream)
+            {
+                while (true)
+                {
+                    var batch = await stream.ReadNextRecordBatchAsync();
+                    if (batch == null) break;
+                    if (rowCount == 0 && batch.Length > 0 && batch.ColumnCount > 0
+                        && batch.Column(0) is StringArray sa)
+                    {
+                        firstCell = sa.GetString(0);
+                    }
+                    rowCount += batch.Length;
+                    batch.Dispose();
+                }
+            }
+            DateTime endUtc = DateTime.UtcNow;
+            OutputHelper?.WriteLine($"Runtime accepted STATIC ONLY — rows={rowCount}, took {(endUtc-startUtc).TotalMilliseconds:0}ms");
+            if (firstCell != null)
+            {
+                OutputHelper?.WriteLine($"Result preview (first {Math.Min(200, firstCell.Length)} chars): {firstCell.Substring(0, Math.Min(200, firstCell.Length))}");
+            }
+            Assert.True(rowCount > 0, "Runtime should return JSON metadata when STATIC ONLY is supported");
+        }
+    }
+}

--- a/csharp/test/E2E/FastMetadataQueryE2ETest.cs
+++ b/csharp/test/E2E/FastMetadataQueryE2ETest.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AdbcDrivers.HiveServer2;
-using AdbcDrivers.HiveServer2.Hive2;
 using Apache.Arrow;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tests;
@@ -162,13 +161,15 @@ namespace AdbcDrivers.Databricks.Tests.E2E
             {
                 result = await statement.ExecuteQueryAsync();
             }
-            catch (HiveServer2Exception ex) when (ex.SqlState == "42601" || ex.SqlState == "20000")
+            catch (AdbcException ex) when (ex.SqlState == "42601" || ex.SqlState == "20000")
             {
                 // Runtime is pre-rollout: it does not yet support the `AS JSON STATIC ONLY`
                 // modifier (PR #198486). 42601 is the parse-syntax error; some DBRs return
-                // 20000 (internal error) instead. This mirrors the driver's own fallback in
-                // DatabricksStatement.GetColumnsExtendedAsync, so skip rather than fail the
-                // merge queue on warehouses where the runtime feature isn't deployed yet.
+                // 20000 (internal error) instead. Catch the AdbcException base so this covers
+                // both protocols — Thrift surfaces HiveServer2Exception, REST/SEA surfaces
+                // DatabricksException, and both carry the SQLSTATE. This mirrors the driver's
+                // own fallback in DatabricksStatement.GetColumnsExtendedAsync, so skip rather
+                // than fail the merge queue on warehouses where the feature isn't deployed yet.
                 Skip.If(true, $"Runtime does not support 'AS JSON STATIC ONLY' (SQLSTATE={ex.SqlState}); pre-PR#198486 DBR.");
                 return;
             }

--- a/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
+++ b/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
@@ -210,7 +210,6 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
                 Assert.False(string.IsNullOrEmpty(actualHostUrl), "host_url should be populated");
                 Assert.Equal(expectedHost, actualHostUrl);
                 Assert.DoesNotContain("://", actualHostUrl);
-                Assert.DoesNotContain(":", actualHostUrl);
 
                 OutputHelper?.WriteLine($"✓ host_info.host_url: {actualHostUrl}");
             }

--- a/csharp/test/Unit/DatabricksConnectionUnitTests.cs
+++ b/csharp/test/Unit/DatabricksConnectionUnitTests.cs
@@ -169,6 +169,95 @@ namespace AdbcDrivers.Databricks.Tests
         }
 
         /// <summary>
+        /// Warehouse-style paths (/sql/1.0/warehouses/{id}, /sql/1.0/endpoints/{id}) — with or
+        /// without query strings — must be classified as DBSQL warehouse so the fast-metadata
+        /// flag can take effect on them.
+        /// </summary>
+        [Theory]
+        [InlineData("/sql/1.0/warehouses/abc123")]
+        [InlineData("/sql/1.0/warehouses/abc123/")]
+        [InlineData("/sql/1.0/warehouses/abc123?o=987654")]
+        [InlineData("/sql/1.0/endpoints/abc123")]
+        [InlineData("/sql/1.0/endpoints/abc123?o=111&foo=bar")]
+        public void IsWarehousePath_WarehousePaths_ReturnsTrue(string path)
+        {
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "test.databricks.com",
+                [SparkParameters.Token] = "test-token",
+                [SparkParameters.Path] = path
+            };
+            using var connection = new DatabricksConnection(properties);
+            Assert.True(connection.IsWarehousePath, $"Path '{path}' should be classified as a warehouse");
+        }
+
+        /// <summary>
+        /// General-cluster paths and empty paths must NOT be classified as warehouses, so the
+        /// fast-metadata flag is a no-op there even when enabled.
+        /// </summary>
+        [Theory]
+        [InlineData("/sql/protocolv1/o/123456789/0123-456789-abcdef")]
+        [InlineData("/sql/protocolv1/o/987/cluster-id")]
+        [InlineData("/some/other/path")]
+        [InlineData("")]
+        public void IsWarehousePath_NonWarehousePaths_ReturnsFalse(string path)
+        {
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "test.databricks.com",
+                [SparkParameters.Token] = "test-token"
+            };
+            if (!string.IsNullOrEmpty(path))
+            {
+                properties[SparkParameters.Path] = path;
+            }
+            using var connection = new DatabricksConnection(properties);
+            Assert.False(connection.IsWarehousePath, $"Path '{path}' should NOT be classified as a warehouse");
+        }
+
+        /// <summary>
+        /// IsWarehousePath should also resolve a path embedded in the AdbcOptions.Uri property
+        /// (the JDBC-style "uri" form) so users who configure that way still get the optimization.
+        /// </summary>
+        [Fact]
+        public void IsWarehousePath_PathFromUri_ReturnsTrue()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.Token] = "test-token",
+                [AdbcOptions.Uri] = "https://test.databricks.com/sql/1.0/warehouses/abc123?o=555"
+            };
+            using var connection = new DatabricksConnection(properties);
+            Assert.True(connection.IsWarehousePath);
+        }
+
+        /// <summary>
+        /// UseFastMetadataQuery requires BOTH the opt-in flag and a warehouse path. Verify the
+        /// AND-gating: flag without warehouse path stays false, warehouse without flag stays false,
+        /// only flag-and-warehouse-together returns true.
+        /// </summary>
+        [Theory]
+        [InlineData("true", "/sql/1.0/warehouses/abc123", true)]
+        [InlineData("true", "/sql/protocolv1/o/123/cluster", false)] // flag set but general cluster
+        [InlineData("false", "/sql/1.0/warehouses/abc123", false)]    // warehouse but flag off
+        [InlineData(null, "/sql/1.0/warehouses/abc123", false)]       // flag absent (default false)
+        public void UseFastMetadataQuery_RequiresFlagAndWarehousePath(string? flagValue, string path, bool expected)
+        {
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.HostName] = "test.databricks.com",
+                [SparkParameters.Token] = "test-token",
+                [SparkParameters.Path] = path
+            };
+            if (flagValue != null)
+            {
+                properties[DatabricksParameters.EnableFastMetadataQuery] = flagValue;
+            }
+            using var connection = new DatabricksConnection(properties);
+            Assert.Equal(expected, connection.UseFastMetadataQuery);
+        }
+
+        /// <summary>
         /// Tests that GetInfo returns correct driver information for DriverName and DriverArrowVersion.
         /// Note: VendorName and VendorVersion require a server connection and should be tested in E2E tests.
         /// </summary>

--- a/csharp/test/Unit/DatabricksExceptionTests.cs
+++ b/csharp/test/Unit/DatabricksExceptionTests.cs
@@ -125,5 +125,56 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             var ex = new DatabricksException("TABLE_OR_VIEW_NOT_FOUND occurred").SetSqlState("99999");
             Assert.True(ex.IsObjectNotFoundException());
         }
+
+        [Theory]
+        [InlineData("42601")]
+        [InlineData("20000")]
+        public void IsDescTableExtendedUnsupportedException_KnownSqlState_ReturnsTrue(string sqlState)
+        {
+            var ex = new DatabricksException("some message").SetSqlState(sqlState);
+            Assert.True(ex.IsDescTableExtendedUnsupportedException());
+        }
+
+        [Fact]
+        public void IsDescTableExtendedUnsupportedException_SqlStateInMessage_ReturnsTrue()
+        {
+            // SEA path: StatementExecutionClient builds the exception with only a message, so
+            // SqlState is null and the SQL state is carried inside the text. This is the exact
+            // shape that red-failed the REST merge-queue job for STATIC ONLY on a pre-rollout DBR.
+            var ex = new DatabricksException(
+                "Statement execution failed. State: FAILED. Error Code: BAD_REQUEST, Message: " +
+                "[PARSE_SYNTAX_ERROR] Syntax error at or near 'STATIC'. SQLSTATE: 42601 (line 1, pos 94)");
+            Assert.Null(ex.SqlState);
+            Assert.True(ex.IsDescTableExtendedUnsupportedException());
+        }
+
+        [Fact]
+        public void IsDescTableExtendedUnsupportedException_InternalErrorInMessage_ReturnsTrue()
+        {
+            var ex = new DatabricksException("Statement execution failed. ... SQLSTATE: 20000");
+            Assert.True(ex.IsDescTableExtendedUnsupportedException());
+        }
+
+        [Fact]
+        public void IsDescTableExtendedUnsupportedException_ObjectNotFound_ReturnsFalse()
+        {
+            // Not-found errors take the other fallback path (empty result), not the three-call path.
+            var ex = new DatabricksException("TABLE_OR_VIEW_NOT_FOUND occurred").SetSqlState("42704");
+            Assert.False(ex.IsDescTableExtendedUnsupportedException());
+        }
+
+        [Fact]
+        public void IsDescTableExtendedUnsupportedException_UnrelatedError_ReturnsFalse()
+        {
+            var ex = new DatabricksException("Connection timeout while executing query");
+            Assert.False(ex.IsDescTableExtendedUnsupportedException());
+        }
+
+        [Fact]
+        public void IsDescTableExtendedUnsupportedException_EmptyMessageNoSqlState_ReturnsFalse()
+        {
+            var ex = new DatabricksException("");
+            Assert.False(ex.IsDescTableExtendedUnsupportedException());
+        }
     }
 }

--- a/csharp/test/Unit/DatabricksParametersTests.cs
+++ b/csharp/test/Unit/DatabricksParametersTests.cs
@@ -73,6 +73,12 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         }
 
         [Fact]
+        public void TestEnableFastMetadataQueryParameterExists()
+        {
+            Assert.Equal("adbc.databricks.enable_fast_metadata_query", DatabricksParameters.EnableFastMetadataQuery);
+        }
+
+        [Fact]
         public void TestAllRestParametersUseCorrectPrefix()
         {
             // Verify REST-specific parameters use "adbc.databricks.rest." prefix


### PR DESCRIPTION
## Summary

Adds opt-in `adbc.databricks.enable_fast_metadata_query` flag (default `false`) that pairs the new SQL modifier `STATIC ONLY` (runtime PR #198486) on `DESC TABLE EXTENDED AS JSON` with the matching off-WLM routing signal per protocol.

Both signals are required together — `STATIC ONLY` alone still queues through WLM; off-WLM routing alone still does the full metadata scan.

| Protocol | SQL emitted | Off-WLM signal | Conditions |
|---|---|---|---|
| Thrift | `DESC TABLE EXTENDED <t> STATIC ONLY AS JSON` | `RunAsync=false` on descStmt | flag set AND warehouse path (`/sql/1.0/warehouses/{id}` or `/sql/1.0/endpoints/{id}`). General-cluster paths: flag is ignored. |
| SEA | `DESC TABLE EXTENDED <t> STATIC ONLY AS JSON` | `x-databricks-sea-can-run-fully-sync: true` (already sent by `ExecuteMetadataSqlAsync`) | flag set. SEA is always-warehouse. |

## Implementation

- `DatabricksConnection.IsWarehousePath` matches the path regex (cached) — only used to gate the Thrift opt-in.
- `DatabricksStatement.RunAsyncOverride` is a new internal nullable bool; when non-null it takes precedence over the connection-level `RunAsyncInThrift` inside `SetStatementProperties`. The override is set on the per-call descStmt in `GetColumnsExtendedAsync` rather than mutating connection state.
- `StatementExecutionConnection.EnableFastMetadataQuery` parses the same flag for SEA.

## Fallback safety

`STATIC ONLY` is rejected with parse error `42601` (`INVALID_STATIC_ONLY_USAGE`) on servers without PR #198486. The existing `catch (HiveServer2Exception ex) when (ex.SqlState == "42601" || ex.SqlState == "20000")` in `GetColumnsExtendedAsync` already handles that — falls back to `GetColumns + GetPrimaryKeys + GetCrossReference`.

## Test plan

- [x] Added unit tests for the new parameter constant.
- [x] Added unit tests for `IsWarehousePath` covering `/sql/1.0/warehouses/{id}`, `/sql/1.0/endpoints/{id}` (with/without trailing slash, with/without query strings), `/sql/protocolv1/...` clusters, empty path, and the `AdbcOptions.Uri` fallback.
- [x] Added unit tests for `UseFastMetadataQuery` covering all four combinations of `(flag, warehouse-path)`.
- [x] Full `dotnet test --filter "FullyQualifiedName~Unit."` suite: 638 passed, 0 failed.
- [ ] E2E verification against a DBSQL warehouse running PR #198486 is gated on that runtime change reaching the test env; existing 42601 fallback protects pre-rollout.

Closes PECO-3021

This pull request and its description were written by Isaac.