### PR TITLE
feat(csharp): honor cloudfetch.lz4.enabled on SEA path (PECO-3056)

### DIFF
--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -34,12 +34,32 @@ namespace AdbcDrivers.Databricks
         /// <summary>
         /// Whether to use CloudFetch for retrieving results.
         /// Default value is true if not specified.
+        ///
+        /// Honored by both protocols:
+        ///   - Thrift: controls the canUseCloudFetch flag on TFetchResultsReq.
+        ///   - SEA (REST): JDBC pairs <c>cloudfetch.enabled=false</c> with
+        ///     <c>disposition=INLINE</c> + <c>format=JSON_ARRAY</c>, because the
+        ///     SEA server rejects <c>ARROW_STREAM</c> with pure <c>INLINE</c>.
+        ///     The C# SEA driver does not yet ship a <c>JSON_ARRAY</c> reader,
+        ///     so requesting <c>cloudfetch.enabled=false</c> on the SEA path
+        ///     surfaces a clear <c>AdbcStatusCode.NotImplemented</c> error at
+        ///     connect time rather than silently ignoring the param. Once a
+        ///     JSON_ARRAY reader lands, this will flip to the JDBC behavior.
+        ///
+        /// Note: Reyden does not generate external links and will coerce results
+        /// to INLINE on the server side regardless of what the driver requests.
         /// </summary>
         public const string UseCloudFetch = "adbc.databricks.cloudfetch.enabled";
 
         /// <summary>
         /// Whether the client can decompress LZ4 compressed results.
         /// Default value is true if not specified.
+        ///
+        /// Honored by both protocols:
+        ///   - Thrift: controls canDecompressLZ4Result on TFetchResultsReq.
+        ///   - SEA (REST): when false, clears <c>result_compression</c> on the
+        ///     ExecuteStatement request (overriding any <see cref="ResultCompression"/>
+        ///     value). Mirrors JDBC's <c>CompressionCodec.NONE</c> branch.
         /// </summary>
         public const string CanDecompressLz4 = "adbc.databricks.cloudfetch.lz4.enabled";
 

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -37,14 +37,11 @@ namespace AdbcDrivers.Databricks
         ///
         /// Honored by both protocols:
         ///   - Thrift: controls the canUseCloudFetch flag on TFetchResultsReq.
-        ///   - SEA (REST): JDBC pairs <c>cloudfetch.enabled=false</c> with
-        ///     <c>disposition=INLINE</c> + <c>format=JSON_ARRAY</c>, because the
-        ///     SEA server rejects <c>ARROW_STREAM</c> with pure <c>INLINE</c>.
-        ///     The C# SEA driver does not yet ship a <c>JSON_ARRAY</c> reader,
-        ///     so requesting <c>cloudfetch.enabled=false</c> on the SEA path
-        ///     surfaces a clear <c>AdbcStatusCode.NotImplemented</c> error at
-        ///     connect time rather than silently ignoring the param. Once a
-        ///     JSON_ARRAY reader lands, this will flip to the JDBC behavior.
+        ///   - SEA (REST): not yet honored; the param is accepted but ignored.
+        ///     JDBC pairs <c>cloudfetch.enabled=false</c> with
+        ///     <c>disposition=INLINE</c> + <c>format=JSON_ARRAY</c>, but the
+        ///     C# SEA driver does not yet ship a JSON_ARRAY reader. Support
+        ///     is deferred until a JSON_ARRAY reader lands.
         ///
         /// Note: Reyden does not generate external links and will coerce results
         /// to INLINE on the server side regardless of what the driver requests.

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -38,10 +38,9 @@ namespace AdbcDrivers.Databricks
         /// Honored by both protocols:
         ///   - Thrift: controls the canUseCloudFetch flag on TFetchResultsReq.
         ///   - SEA (REST): not yet honored; the param is accepted but ignored.
-        ///     JDBC pairs <c>cloudfetch.enabled=false</c> with
-        ///     <c>disposition=INLINE</c> + <c>format=JSON_ARRAY</c>, but the
-        ///     C# SEA driver does not yet ship a JSON_ARRAY reader. Support
-        ///     is deferred until a JSON_ARRAY reader lands.
+        ///     Disabling CloudFetch on SEA requires the server to support
+        ///     <c>ARROW_STREAM</c> results with <c>INLINE</c> disposition.
+        ///     Support is deferred until that server-side capability lands.
         ///
         /// Note: Reyden does not generate external links and will coerce results
         /// to INLINE on the server side regardless of what the driver requests.

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -228,48 +228,17 @@ namespace AdbcDrivers.Databricks.StatementExecution
             //      (allow operators to explicitly select INLINE vs EXTERNAL_LINKS vs
             //       the hybrid INLINE_OR_EXTERNAL_LINKS, and pick a compression).
             //
-            // Semantics (mirroring JDBC where the C# reader supports it):
-            //   - cloudfetch.enabled=false: JDBC switches to disposition=INLINE +
-            //     format=JSON_ARRAY (the SEA server requires JSON_ARRAY for pure
-            //     INLINE — ARROW_STREAM is rejected by server-side validation).
-            //     The C# SEA driver does not yet implement a JSON_ARRAY reader,
-            //     so we surface this as a clear configuration error at connection
-            //     time rather than silently ignoring the param (the previous gap)
-            //     or letting the server reject the first request with an opaque
-            //     400. JSON_ARRAY support is tracked separately; see PECO-3056
-            //     for the rationale.
-            //   - cloudfetch.lz4.enabled=false: clears result_compression on the
-            //     wire (overrides any explicit result_compression value). Mirrors
-            //     JDBC's CompressionCodec.NONE branch.
+            // cloudfetch.enabled is not yet honored on SEA: JDBC pairs it with
+            // disposition=INLINE + format=JSON_ARRAY, but the C# driver has no
+            // JSON_ARRAY reader. The param is accepted and ignored for now.
             //
-            // Reyden caveat: Reyden does not currently generate external links
-            // and will coerce any disposition to INLINE on the server side. The
-            // driver-side request still carries whatever the user asked for —
-            // the overrides here govern only what the driver puts on the wire.
+            // cloudfetch.lz4.enabled=false clears result_compression on the wire,
+            // overriding any explicit result_compression value. Mirrors JDBC's
+            // CompressionCodec.NONE branch.
             _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
-            string userDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
+            _resultDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
             properties.TryGetValue(DatabricksParameters.ResultCompression, out string? userCompression);
-            bool useCloudFetch = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseCloudFetch, true);
             bool canDecompressLz4 = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.CanDecompressLz4, true);
-
-            if (!useCloudFetch)
-            {
-                // Throw an honest error rather than ignore the param. See comment
-                // above for why pure INLINE isn't yet wired up on SEA in C#.
-                throw new DatabricksException(
-                    $"'{DatabricksParameters.UseCloudFetch}=false' is not yet supported on the SEA " +
-                    "(adbc.databricks.protocol=rest) path. The SEA server requires " +
-                    "result_format=JSON_ARRAY for INLINE disposition, and the C# driver does not " +
-                    "yet ship a JSON_ARRAY reader. Workarounds: (1) remove the param and use the " +
-                    "default INLINE_OR_EXTERNAL_LINKS disposition so the server inlines small " +
-                    $"results automatically, or (2) set '{DatabricksParameters.Protocol}=thrift'.",
-                    AdbcStatusCode.NotImplemented);
-            }
-
-            _resultDisposition = userDisposition;
-            // cloudfetch.lz4.enabled=false clears compression on the wire — mirrors
-            // JDBC's CompressionCodec.NONE branch. Explicit result_compression is
-            // ignored in that case (the JDBC alias wins).
             _resultCompression = canDecompressLz4 ? userCompression : null;
 
             _waitTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(properties, DatabricksParameters.WaitTimeout, 10);

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -218,10 +218,59 @@ namespace AdbcDrivers.Databricks.StatementExecution
             }
             properties.TryGetValue(AdbcOptions.Connection.CurrentDbSchema, out _schema);
 
-            // Result configuration
-            _resultDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
+            // Result configuration.
+            //
+            // Two layered sets of parameters control how SEA returns results:
+            //   1. JDBC-compatible aliases: cloudfetch.enabled / cloudfetch.lz4.enabled
+            //      (these are also used by the Thrift path; we honor them here so
+            //       users carry a single set of params across protocols — PECO-3056).
+            //   2. SEA-specific: rest.result_disposition / rest.result_compression
+            //      (allow operators to explicitly select INLINE vs EXTERNAL_LINKS vs
+            //       the hybrid INLINE_OR_EXTERNAL_LINKS, and pick a compression).
+            //
+            // Semantics (mirroring JDBC where the C# reader supports it):
+            //   - cloudfetch.enabled=false: JDBC switches to disposition=INLINE +
+            //     format=JSON_ARRAY (the SEA server requires JSON_ARRAY for pure
+            //     INLINE — ARROW_STREAM is rejected by server-side validation).
+            //     The C# SEA driver does not yet implement a JSON_ARRAY reader,
+            //     so we surface this as a clear configuration error at connection
+            //     time rather than silently ignoring the param (the previous gap)
+            //     or letting the server reject the first request with an opaque
+            //     400. JSON_ARRAY support is tracked separately; see PECO-3056
+            //     for the rationale.
+            //   - cloudfetch.lz4.enabled=false: clears result_compression on the
+            //     wire (overrides any explicit result_compression value). Mirrors
+            //     JDBC's CompressionCodec.NONE branch.
+            //
+            // Reyden caveat: Reyden does not currently generate external links
+            // and will coerce any disposition to INLINE on the server side. The
+            // driver-side request still carries whatever the user asked for —
+            // the overrides here govern only what the driver puts on the wire.
             _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
-            properties.TryGetValue(DatabricksParameters.ResultCompression, out _resultCompression);
+            string userDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
+            properties.TryGetValue(DatabricksParameters.ResultCompression, out string? userCompression);
+            bool useCloudFetch = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseCloudFetch, true);
+            bool canDecompressLz4 = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.CanDecompressLz4, true);
+
+            if (!useCloudFetch)
+            {
+                // Throw an honest error rather than ignore the param. See comment
+                // above for why pure INLINE isn't yet wired up on SEA in C#.
+                throw new DatabricksException(
+                    $"'{DatabricksParameters.UseCloudFetch}=false' is not yet supported on the SEA " +
+                    "(adbc.databricks.protocol=rest) path. The SEA server requires " +
+                    "result_format=JSON_ARRAY for INLINE disposition, and the C# driver does not " +
+                    "yet ship a JSON_ARRAY reader. Workarounds: (1) remove the param and use the " +
+                    "default INLINE_OR_EXTERNAL_LINKS disposition so the server inlines small " +
+                    $"results automatically, or (2) set '{DatabricksParameters.Protocol}=thrift'.",
+                    AdbcStatusCode.NotImplemented);
+            }
+
+            _resultDisposition = userDisposition;
+            // cloudfetch.lz4.enabled=false clears compression on the wire — mirrors
+            // JDBC's CompressionCodec.NONE branch. Explicit result_compression is
+            // ignored in that case (the JDBC alias wins).
+            _resultCompression = canDecompressLz4 ? userCompression : null;
 
             _waitTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(properties, DatabricksParameters.WaitTimeout, 10);
             if (properties.TryGetValue(DatabricksParameters.EnableDirectResults, out var directResults) &&

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -219,27 +219,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
             properties.TryGetValue(AdbcOptions.Connection.CurrentDbSchema, out _schema);
 
             // Result configuration.
-            //
-            // Two layered sets of parameters control how SEA returns results:
-            //   1. JDBC-compatible aliases: cloudfetch.enabled / cloudfetch.lz4.enabled
-            //      (these are also used by the Thrift path; we honor them here so
-            //       users carry a single set of params across protocols — PECO-3056).
-            //   2. SEA-specific: rest.result_disposition / rest.result_compression
-            //      (allow operators to explicitly select INLINE vs EXTERNAL_LINKS vs
-            //       the hybrid INLINE_OR_EXTERNAL_LINKS, and pick a compression).
-            //
-            // cloudfetch.enabled is not yet honored on SEA: JDBC pairs it with
-            // disposition=INLINE + format=JSON_ARRAY, but the C# driver has no
-            // JSON_ARRAY reader. The param is accepted and ignored for now.
-            //
-            // cloudfetch.lz4.enabled=false clears result_compression on the wire,
-            // overriding any explicit result_compression value. Mirrors JDBC's
-            // CompressionCodec.NONE branch.
+            // The driver only implements LZ4_FRAME decompression; gzip is not supported.
+            // cloudfetch.lz4.enabled=true (default) → request LZ4_FRAME compression.
+            // cloudfetch.lz4.enabled=false → null (no compression).
             _resultDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
             _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
-            properties.TryGetValue(DatabricksParameters.ResultCompression, out string? userCompression);
             bool canDecompressLz4 = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.CanDecompressLz4, true);
-            _resultCompression = canDecompressLz4 ? userCompression : null;
+            _resultCompression = canDecompressLz4 ? "LZ4_FRAME" : null;
 
             _waitTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(properties, DatabricksParameters.WaitTimeout, 10);
             if (properties.TryGetValue(DatabricksParameters.EnableDirectResults, out var directResults) &&

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -235,8 +235,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // cloudfetch.lz4.enabled=false clears result_compression on the wire,
             // overriding any explicit result_compression value. Mirrors JDBC's
             // CompressionCodec.NONE branch.
-            _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
             _resultDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
+            _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
             properties.TryGetValue(DatabricksParameters.ResultCompression, out string? userCompression);
             bool canDecompressLz4 = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.CanDecompressLz4, true);
             _resultCompression = canDecompressLz4 ? userCompression : null;

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -76,6 +76,19 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string? _currentStatementId;
         private string? _sqlQuery;
 
+        // Last ExecuteStatement request sent on the wire. Exposed as an internal
+        // test seam (PECO-3056) so that E2E tests can assert what disposition /
+        // compression the driver actually emitted, without intercepting HTTP.
+        // Not used by production code paths.
+        private ExecuteStatementRequest? _lastExecuteRequest;
+
+        /// <summary>
+        /// The most recent <see cref="ExecuteStatementRequest"/> built by this
+        /// statement and handed to the SEA client. Test-only observability seam;
+        /// null until the statement has executed at least once.
+        /// </summary>
+        internal ExecuteStatementRequest? LastExecuteRequest => _lastExecuteRequest;
+
         // Cancel support
         private readonly object _cancelLock = new();
         private CancellationTokenSource? _executeCts;
@@ -340,6 +353,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 IsMetadata = isMetadataExecution,
                 QueryTags = ParseQueryTags(_queryTags)
             };
+            _lastExecuteRequest = request;
 
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);
@@ -680,6 +694,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 IsMetadata = false,
                 QueryTags = ParseQueryTags(_queryTags)
             };
+            _lastExecuteRequest = request;
 
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -76,6 +76,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string? _currentStatementId;
         private string? _sqlQuery;
 
+        // Internal test seam: captures the last request built by this statement so
+        // E2E tests can assert the exact field values sent on the wire without HTTP
+        // interception. There is no behavioral substitute — a query succeeding does
+        // not prove a specific compression or disposition value was requested.
+        private ExecuteStatementRequest? _lastExecuteRequest;
+        internal ExecuteStatementRequest? LastExecuteRequest => _lastExecuteRequest;
+
         // Cancel support
         private readonly object _cancelLock = new();
         private CancellationTokenSource? _executeCts;
@@ -340,7 +347,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 IsMetadata = isMetadataExecution,
                 QueryTags = ParseQueryTags(_queryTags)
             };
-
+            _lastExecuteRequest = request;
 
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);
@@ -681,7 +688,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 IsMetadata = false,
                 QueryTags = ParseQueryTags(_queryTags)
             };
-
+            _lastExecuteRequest = request;
 
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -76,19 +76,6 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string? _currentStatementId;
         private string? _sqlQuery;
 
-        // Last ExecuteStatement request sent on the wire. Exposed as an internal
-        // test seam (PECO-3056) so that E2E tests can assert what disposition /
-        // compression the driver actually emitted, without intercepting HTTP.
-        // Not used by production code paths.
-        private ExecuteStatementRequest? _lastExecuteRequest;
-
-        /// <summary>
-        /// The most recent <see cref="ExecuteStatementRequest"/> built by this
-        /// statement and handed to the SEA client. Test-only observability seam;
-        /// null until the statement has executed at least once.
-        /// </summary>
-        internal ExecuteStatementRequest? LastExecuteRequest => _lastExecuteRequest;
-
         // Cancel support
         private readonly object _cancelLock = new();
         private CancellationTokenSource? _executeCts;
@@ -353,7 +340,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 IsMetadata = isMetadataExecution,
                 QueryTags = ParseQueryTags(_queryTags)
             };
-            _lastExecuteRequest = request;
+
 
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);
@@ -694,7 +681,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 IsMetadata = false,
                 QueryTags = ParseQueryTags(_queryTags)
             };
-            _lastExecuteRequest = request;
+
 
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);

--- a/csharp/test/E2E/CloudFetchE2ETest.cs
+++ b/csharp/test/E2E/CloudFetchE2ETest.cs
@@ -146,10 +146,21 @@ namespace AdbcDrivers.Databricks.Tests
         /// Integration test for running queries against a real Databricks cluster with different CloudFetch settings.
         /// Tests both Thrift and Statement Execution REST API protocols.
         /// </summary>
-        [Theory]
+        [SkippableTheory]
         [MemberData(nameof(TestCases))]
         public async Task TestCloudFetch(string query, int rowCount, bool useCloudFetch, bool enableDirectResults, string protocol)
         {
+            // PECO-3056: cloudfetch.enabled=false on the SEA path requires
+            // result_format=JSON_ARRAY (pure INLINE disposition), which the C#
+            // driver does not yet read. The connection now throws at construction
+            // time when this combination is requested; skip the case here until
+            // a JSON_ARRAY reader is added. Prior to PECO-3056 this combination
+            // was silently ignored (the param had no effect on the wire), so
+            // these test cases were accidentally validating "useCloudFetch=true"
+            // behavior under a "useCloudFetch=false" label.
+            Skip.If(protocol == "rest" && !useCloudFetch,
+                "PECO-3056: useCloudFetch=false on SEA throws by design; pending JSON_ARRAY reader.");
+
             var parameters = new Dictionary<string, string>
             {
                 [DatabricksParameters.Protocol] = protocol,

--- a/csharp/test/E2E/CloudFetchE2ETest.cs
+++ b/csharp/test/E2E/CloudFetchE2ETest.cs
@@ -146,21 +146,10 @@ namespace AdbcDrivers.Databricks.Tests
         /// Integration test for running queries against a real Databricks cluster with different CloudFetch settings.
         /// Tests both Thrift and Statement Execution REST API protocols.
         /// </summary>
-        [SkippableTheory]
+        [Theory]
         [MemberData(nameof(TestCases))]
         public async Task TestCloudFetch(string query, int rowCount, bool useCloudFetch, bool enableDirectResults, string protocol)
         {
-            // PECO-3056: cloudfetch.enabled=false on the SEA path requires
-            // result_format=JSON_ARRAY (pure INLINE disposition), which the C#
-            // driver does not yet read. The connection now throws at construction
-            // time when this combination is requested; skip the case here until
-            // a JSON_ARRAY reader is added. Prior to PECO-3056 this combination
-            // was silently ignored (the param had no effect on the wire), so
-            // these test cases were accidentally validating "useCloudFetch=true"
-            // behavior under a "useCloudFetch=false" label.
-            Skip.If(protocol == "rest" && !useCloudFetch,
-                "PECO-3056: useCloudFetch=false on SEA throws by design; pending JSON_ARRAY reader.");
-
             var parameters = new Dictionary<string, string>
             {
                 [DatabricksParameters.Protocol] = protocol,

--- a/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
@@ -15,7 +15,6 @@
 */
 
 using System.Collections.Generic;
-using AdbcDrivers.Databricks.StatementExecution;
 using AdbcDrivers.HiveServer2.Spark;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tests;
@@ -29,14 +28,14 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
     /// honored on the SEA path (PECO-3056). This is a connection-level param on
     /// JDBC; the SEA driver previously ignored it.
     ///
-    /// Tests assert on the request the driver actually built — exposed via the
-    /// internal <see cref="StatementExecutionStatement.LastExecuteRequest"/> test
-    /// seam — rather than on observable server-side behavior, so wire-level intent
-    /// is verified cheaply with a single SELECT 1 round-trip.
+    /// Tests execute a real query and verify the result to confirm end-to-end
+    /// correctness: if the driver sends the wrong <c>result_compression</c> value
+    /// the server will either reject the request or return data the driver cannot
+    /// decode, causing an exception before the assertion is reached.
     ///
     /// Note: <c>cloudfetch.enabled=false</c> is not yet honored on SEA (requires
-    /// a JSON_ARRAY reader that is not yet implemented) and is intentionally left
-    /// as a silent no-op. It will be wired up in a follow-on ticket.
+    /// server-side support for ARROW_STREAM with INLINE disposition) and is
+    /// intentionally left as a silent no-op.
     /// </summary>
     public class SeaCloudFetchParamsE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {
@@ -82,71 +81,62 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             return database.Connect(null);
         }
 
+        private static long DrainStream(QueryResult result)
+        {
+            long rows = 0;
+            using var stream = result.Stream;
+            while (stream != null && stream.ReadNextRecordBatchAsync().Result is { } batch)
+                rows += batch.Length;
+            return rows;
+        }
+
         /// <summary>
-        /// With <c>cloudfetch.enabled=true</c> (default) and no explicit
-        /// <c>result_disposition</c>, the SEA driver continues to use the
-        /// existing default of <c>INLINE_OR_EXTERNAL_LINKS</c>. Locks in the
-        /// no-regression contract for the default path.
+        /// Default config (lz4=true): query executes and returns the expected row.
+        /// Locks in the no-regression contract for the default path.
         /// </summary>
         [SkippableFact]
-        public void CloudFetchEnabledTrue_KeepsDefaultDisposition()
+        public void DefaultConfig_QuerySucceeds()
         {
             SkipIfNotConfigured();
 
-            // No extra params — exercise the default path.
             using var connection = CreateRestConnection(new Dictionary<string, string>());
             using var statement = connection.CreateStatement();
             statement.SqlQuery = "SELECT 1 AS value";
             var result = statement.ExecuteQuery();
-            using (var reader = result.Stream)
-            {
-                while (reader != null && reader.ReadNextRecordBatchAsync().Result != null) { }
-            }
-
-            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
-            Assert.NotNull(seaStmt.LastExecuteRequest);
-            Assert.Equal("INLINE_OR_EXTERNAL_LINKS", seaStmt.LastExecuteRequest!.Disposition);
+            Assert.Equal(1L, DrainStream(result));
         }
 
         /// <summary>
-        /// With <c>cloudfetch.lz4.enabled=false</c> the SEA driver must clear
-        /// <c>result_compression</c> on the wire (null / unset → server treats
-        /// as no compression). Mirrors JDBC's <c>CompressionCodec.NONE</c> branch
-        /// when LZ4 is disabled.
+        /// With <c>cloudfetch.lz4.enabled=false</c> the driver must clear
+        /// <c>result_compression</c> on the wire. Verified by a successful round-trip:
+        /// if the server returns uncompressed data and the driver handles it correctly,
+        /// the query completes and returns the expected row count.
         /// </summary>
         [SkippableFact]
-        public void Lz4EnabledFalse_ClearsResultCompression()
+        public void Lz4EnabledFalse_QuerySucceeds()
         {
             SkipIfNotConfigured();
 
             var extras = new Dictionary<string, string>
             {
                 [DatabricksParameters.CanDecompressLz4] = "false",
-                // Set an explicit result_compression to prove the lz4 param overrides it.
-                [DatabricksParameters.ResultCompression] = "LZ4_FRAME",
             };
 
             using var connection = CreateRestConnection(extras);
             using var statement = connection.CreateStatement();
             statement.SqlQuery = "SELECT 1 AS value";
             var result = statement.ExecuteQuery();
-            using (var reader = result.Stream)
-            {
-                while (reader != null && reader.ReadNextRecordBatchAsync().Result != null) { }
-            }
-
-            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
-            Assert.NotNull(seaStmt.LastExecuteRequest);
-            Assert.Null(seaStmt.LastExecuteRequest!.ResultCompression);
+            Assert.Equal(1L, DrainStream(result));
         }
 
         /// <summary>
-        /// With <c>cloudfetch.lz4.enabled=true</c> (default) the SEA driver must
-        /// request <c>LZ4_FRAME</c> compression on the wire. The driver only
-        /// implements LZ4 decompression, so this is the only valid non-null value.
+        /// With <c>cloudfetch.lz4.enabled=true</c> (default) the driver requests
+        /// LZ4_FRAME compression. Verified by a successful round-trip: if the server
+        /// sends LZ4-compressed data and the driver decompresses it correctly, the
+        /// query completes and returns the expected row count.
         /// </summary>
         [SkippableFact]
-        public void Lz4EnabledTrue_UsesLz4Compression()
+        public void Lz4EnabledTrue_QuerySucceeds()
         {
             SkipIfNotConfigured();
 
@@ -154,14 +144,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             using var statement = connection.CreateStatement();
             statement.SqlQuery = "SELECT 1 AS value";
             var result = statement.ExecuteQuery();
-            using (var reader = result.Stream)
-            {
-                while (reader != null && reader.ReadNextRecordBatchAsync().Result != null) { }
-            }
-
-            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
-            Assert.NotNull(seaStmt.LastExecuteRequest);
-            Assert.Equal("LZ4_FRAME", seaStmt.LastExecuteRequest!.ResultCompression);
+            Assert.Equal(1L, DrainStream(result));
         }
     }
 }

--- a/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
@@ -15,6 +15,7 @@
 */
 
 using System.Collections.Generic;
+using AdbcDrivers.Databricks.StatementExecution;
 using AdbcDrivers.HiveServer2.Spark;
 using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tests;
@@ -25,13 +26,14 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
 {
     /// <summary>
     /// E2E tests proving that <c>adbc.databricks.cloudfetch.lz4.enabled</c> is
-    /// honored on the SEA path (PECO-3056). This is a connection-level param on
-    /// JDBC; the SEA driver previously ignored it.
+    /// honored on the SEA path (PECO-3056).
     ///
-    /// Tests execute a real query and verify the result to confirm end-to-end
-    /// correctness: if the driver sends the wrong <c>result_compression</c> value
-    /// the server will either reject the request or return data the driver cannot
-    /// decode, causing an exception before the assertion is reached.
+    /// Tests assert on the <c>result_compression</c> field of the request the
+    /// driver actually built, exposed via the internal
+    /// <see cref="StatementExecutionStatement.LastExecuteRequest"/> test seam.
+    /// A behavioral "query succeeds" test is not a substitute: a query can succeed
+    /// regardless of what compression value was sent, so the seam is the only way
+    /// to verify the driver's intent without full HTTP interception.
     ///
     /// Note: <c>cloudfetch.enabled=false</c> is not yet honored on SEA (requires
     /// server-side support for ARROW_STREAM with INLINE disposition) and is
@@ -81,39 +83,38 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             return database.Connect(null);
         }
 
-        private static long DrainStream(QueryResult result)
+        private static void DrainStream(QueryResult result)
         {
-            long rows = 0;
             using var stream = result.Stream;
-            while (stream != null && stream.ReadNextRecordBatchAsync().Result is { } batch)
-                rows += batch.Length;
-            return rows;
+            while (stream != null && stream.ReadNextRecordBatchAsync().Result != null) { }
         }
 
         /// <summary>
-        /// Default config (lz4=true): query executes and returns the expected row.
-        /// Locks in the no-regression contract for the default path.
+        /// With no explicit params the driver uses the default disposition
+        /// <c>INLINE_OR_EXTERNAL_LINKS</c>. Locks in the no-regression contract
+        /// for the default path.
         /// </summary>
         [SkippableFact]
-        public void DefaultConfig_QuerySucceeds()
+        public void DefaultConfig_UsesDefaultDisposition()
         {
             SkipIfNotConfigured();
 
             using var connection = CreateRestConnection(new Dictionary<string, string>());
             using var statement = connection.CreateStatement();
             statement.SqlQuery = "SELECT 1 AS value";
-            var result = statement.ExecuteQuery();
-            Assert.Equal(1L, DrainStream(result));
+            DrainStream(statement.ExecuteQuery());
+
+            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
+            Assert.NotNull(seaStmt.LastExecuteRequest);
+            Assert.Equal("INLINE_OR_EXTERNAL_LINKS", seaStmt.LastExecuteRequest!.Disposition);
         }
 
         /// <summary>
         /// With <c>cloudfetch.lz4.enabled=false</c> the driver must clear
-        /// <c>result_compression</c> on the wire. Verified by a successful round-trip:
-        /// if the server returns uncompressed data and the driver handles it correctly,
-        /// the query completes and returns the expected row count.
+        /// <c>result_compression</c> on the wire (null / unset).
         /// </summary>
         [SkippableFact]
-        public void Lz4EnabledFalse_QuerySucceeds()
+        public void Lz4EnabledFalse_ClearsResultCompression()
         {
             SkipIfNotConfigured();
 
@@ -125,26 +126,30 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             using var connection = CreateRestConnection(extras);
             using var statement = connection.CreateStatement();
             statement.SqlQuery = "SELECT 1 AS value";
-            var result = statement.ExecuteQuery();
-            Assert.Equal(1L, DrainStream(result));
+            DrainStream(statement.ExecuteQuery());
+
+            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
+            Assert.NotNull(seaStmt.LastExecuteRequest);
+            Assert.Null(seaStmt.LastExecuteRequest!.ResultCompression);
         }
 
         /// <summary>
-        /// With <c>cloudfetch.lz4.enabled=true</c> (default) the driver requests
-        /// LZ4_FRAME compression. Verified by a successful round-trip: if the server
-        /// sends LZ4-compressed data and the driver decompresses it correctly, the
-        /// query completes and returns the expected row count.
+        /// With <c>cloudfetch.lz4.enabled=true</c> (default) the driver must
+        /// request <c>LZ4_FRAME</c> compression on the wire.
         /// </summary>
         [SkippableFact]
-        public void Lz4EnabledTrue_QuerySucceeds()
+        public void Lz4EnabledTrue_RequestsLz4Compression()
         {
             SkipIfNotConfigured();
 
             using var connection = CreateRestConnection(new Dictionary<string, string>());
             using var statement = connection.CreateStatement();
             statement.SqlQuery = "SELECT 1 AS value";
-            var result = statement.ExecuteQuery();
-            Assert.Equal(1L, DrainStream(result));
+            DrainStream(statement.ExecuteQuery());
+
+            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
+            Assert.NotNull(seaStmt.LastExecuteRequest);
+            Assert.Equal("LZ4_FRAME", seaStmt.LastExecuteRequest!.ResultCompression);
         }
     }
 }

--- a/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
@@ -141,22 +141,16 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         }
 
         /// <summary>
-        /// With <c>cloudfetch.lz4.enabled=true</c> (default) and an explicit
-        /// <c>result_compression</c>, the SEA driver must pass that compression
-        /// through to the wire unchanged. Locks in the no-regression contract
-        /// for the explicit compression path.
+        /// With <c>cloudfetch.lz4.enabled=true</c> (default) the SEA driver must
+        /// request <c>LZ4_FRAME</c> compression on the wire. The driver only
+        /// implements LZ4 decompression, so this is the only valid non-null value.
         /// </summary>
         [SkippableFact]
-        public void Lz4EnabledTrue_PassesThroughExplicitResultCompression()
+        public void Lz4EnabledTrue_UsesLz4Compression()
         {
             SkipIfNotConfigured();
 
-            var extras = new Dictionary<string, string>
-            {
-                [DatabricksParameters.ResultCompression] = "LZ4_FRAME",
-            };
-
-            using var connection = CreateRestConnection(extras);
+            using var connection = CreateRestConnection(new Dictionary<string, string>());
             using var statement = connection.CreateStatement();
             statement.SqlQuery = "SELECT 1 AS value";
             var result = statement.ExecuteQuery();

--- a/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
@@ -93,37 +93,6 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         }
 
         /// <summary>
-        /// With <c>cloudfetch.enabled=false</c> the SEA driver should NOT
-        /// silently fall back to <c>INLINE_OR_EXTERNAL_LINKS</c> (the pre-fix
-        /// behavior); instead it must surface a clear configuration error
-        /// because pure <c>INLINE</c> on SEA requires <c>format=JSON_ARRAY</c>
-        /// which the C# driver does not yet read.
-        ///
-        /// This is the honest-signal contract for PECO-3056: the param is
-        /// recognized, not ignored, and the user gets actionable feedback.
-        ///
-        /// Reyden caveat: Reyden does not currently generate external links,
-        /// so a future implementation could safely send <c>disposition=INLINE</c>
-        /// against Reyden — but that's a property of the backend, not the param
-        /// semantic. The driver behavior here is correct against any SEA backend.
-        /// </summary>
-        [SkippableFact]
-        public void CloudFetchEnabledFalse_ThrowsNotImplementedOnSea()
-        {
-            SkipIfNotConfigured();
-
-            var extras = new Dictionary<string, string>
-            {
-                [DatabricksParameters.UseCloudFetch] = "false",
-            };
-
-            var ex = Assert.Throws<DatabricksException>(() => CreateRestConnection(extras));
-            Assert.Equal(AdbcStatusCode.NotImplemented, ex.Status);
-            Assert.Contains(DatabricksParameters.UseCloudFetch, ex.Message);
-            Assert.Contains("JSON_ARRAY", ex.Message);
-        }
-
-        /// <summary>
         /// With <c>cloudfetch.enabled=true</c> (default) and no explicit
         /// <c>result_disposition</c>, the SEA driver continues to use the
         /// existing default of <c>INLINE_OR_EXTERNAL_LINKS</c>. Locks in the

--- a/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
@@ -1,0 +1,214 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using AdbcDrivers.Databricks.StatementExecution;
+using AdbcDrivers.HiveServer2.Spark;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Adbc.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
+{
+    /// <summary>
+    /// E2E tests proving that <c>adbc.databricks.cloudfetch.enabled</c> and
+    /// <c>adbc.databricks.cloudfetch.lz4.enabled</c> are honored on the SEA path
+    /// (PECO-3056). These are connection-level params on JDBC; the SEA driver
+    /// previously ignored them, so the disposition / compression flowing into
+    /// <see cref="ExecuteStatementRequest"/> matched only the explicit SEA-only
+    /// params (<c>result_disposition</c> / <c>result_compression</c>).
+    ///
+    /// The "happy-path" tests assert on the request that the driver actually
+    /// built — exposed via the internal
+    /// <see cref="StatementExecutionStatement.LastExecuteRequest"/> test seam —
+    /// rather than on observable server-side behavior. This lets the test verify
+    /// wire-level intent cheaply (one SELECT 1 round-trip) without depending on
+    /// data-volume heuristics inside the warehouse.
+    ///
+    /// One test covers the <c>cloudfetch.enabled=false</c> case where the C#
+    /// SEA driver cannot yet honor the param (the SEA server requires
+    /// <c>format=JSON_ARRAY</c> for pure <c>INLINE</c> disposition, and the C#
+    /// driver only ships an ARROW reader). The driver surfaces this as a clear
+    /// <see cref="AdbcException"/> at connect time rather than silently ignoring
+    /// the param (the pre-PECO-3056 behavior) or letting the server reject the
+    /// first execute with an opaque 400.
+    /// </summary>
+    public class SeaCloudFetchParamsE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
+    {
+        public SeaCloudFetchParamsE2ETests(ITestOutputHelper? outputHelper)
+            : base(outputHelper, new DatabricksTestEnvironment.Factory())
+        {
+        }
+
+        private void SkipIfNotConfigured()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable), "Test configuration not available");
+        }
+
+        private AdbcConnection CreateRestConnection(Dictionary<string, string> extraProperties)
+        {
+            var properties = new Dictionary<string, string>
+            {
+                [DatabricksParameters.Protocol] = "rest",
+            };
+
+            if (!string.IsNullOrEmpty(TestConfiguration.Uri))
+            {
+                properties[AdbcOptions.Uri] = TestConfiguration.Uri;
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(TestConfiguration.HostName))
+                    properties[SparkParameters.HostName] = TestConfiguration.HostName;
+                if (!string.IsNullOrEmpty(TestConfiguration.Path))
+                    properties[SparkParameters.Path] = TestConfiguration.Path;
+            }
+
+            if (!string.IsNullOrEmpty(TestConfiguration.Token))
+                properties[SparkParameters.Token] = TestConfiguration.Token;
+            if (!string.IsNullOrEmpty(TestConfiguration.AccessToken))
+                properties[SparkParameters.AccessToken] = TestConfiguration.AccessToken;
+
+            foreach (var kvp in extraProperties)
+                properties[kvp.Key] = kvp.Value;
+
+            var driver = new DatabricksDriver();
+            var database = driver.Open(properties);
+            return database.Connect(null);
+        }
+
+        /// <summary>
+        /// With <c>cloudfetch.enabled=false</c> the SEA driver should NOT
+        /// silently fall back to <c>INLINE_OR_EXTERNAL_LINKS</c> (the pre-fix
+        /// behavior); instead it must surface a clear configuration error
+        /// because pure <c>INLINE</c> on SEA requires <c>format=JSON_ARRAY</c>
+        /// which the C# driver does not yet read.
+        ///
+        /// This is the honest-signal contract for PECO-3056: the param is
+        /// recognized, not ignored, and the user gets actionable feedback.
+        ///
+        /// Reyden caveat: Reyden does not currently generate external links,
+        /// so a future implementation could safely send <c>disposition=INLINE</c>
+        /// against Reyden — but that's a property of the backend, not the param
+        /// semantic. The driver behavior here is correct against any SEA backend.
+        /// </summary>
+        [SkippableFact]
+        public void CloudFetchEnabledFalse_ThrowsNotImplementedOnSea()
+        {
+            SkipIfNotConfigured();
+
+            var extras = new Dictionary<string, string>
+            {
+                [DatabricksParameters.UseCloudFetch] = "false",
+            };
+
+            var ex = Assert.Throws<DatabricksException>(() => CreateRestConnection(extras));
+            Assert.Equal(AdbcStatusCode.NotImplemented, ex.Status);
+            Assert.Contains(DatabricksParameters.UseCloudFetch, ex.Message);
+            Assert.Contains("JSON_ARRAY", ex.Message);
+        }
+
+        /// <summary>
+        /// With <c>cloudfetch.enabled=true</c> (default) and no explicit
+        /// <c>result_disposition</c>, the SEA driver continues to use the
+        /// existing default of <c>INLINE_OR_EXTERNAL_LINKS</c>. Locks in the
+        /// no-regression contract for the default path.
+        /// </summary>
+        [SkippableFact]
+        public void CloudFetchEnabledTrue_KeepsDefaultDisposition()
+        {
+            SkipIfNotConfigured();
+
+            // No extra params — exercise the default path.
+            using var connection = CreateRestConnection(new Dictionary<string, string>());
+            using var statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 1 AS value";
+            var result = statement.ExecuteQuery();
+            using (var reader = result.Stream)
+            {
+                while (reader != null && reader.ReadNextRecordBatchAsync().Result != null) { }
+            }
+
+            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
+            Assert.NotNull(seaStmt.LastExecuteRequest);
+            Assert.Equal("INLINE_OR_EXTERNAL_LINKS", seaStmt.LastExecuteRequest!.Disposition);
+        }
+
+        /// <summary>
+        /// With <c>cloudfetch.lz4.enabled=false</c> the SEA driver must clear
+        /// <c>result_compression</c> on the wire (null / unset → server treats
+        /// as no compression). Mirrors JDBC's <c>CompressionCodec.NONE</c> branch
+        /// when LZ4 is disabled.
+        /// </summary>
+        [SkippableFact]
+        public void Lz4EnabledFalse_ClearsResultCompression()
+        {
+            SkipIfNotConfigured();
+
+            var extras = new Dictionary<string, string>
+            {
+                [DatabricksParameters.CanDecompressLz4] = "false",
+                // Set an explicit result_compression to prove the lz4 param overrides it.
+                [DatabricksParameters.ResultCompression] = "LZ4_FRAME",
+            };
+
+            using var connection = CreateRestConnection(extras);
+            using var statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 1 AS value";
+            var result = statement.ExecuteQuery();
+            using (var reader = result.Stream)
+            {
+                while (reader != null && reader.ReadNextRecordBatchAsync().Result != null) { }
+            }
+
+            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
+            Assert.NotNull(seaStmt.LastExecuteRequest);
+            Assert.Null(seaStmt.LastExecuteRequest!.ResultCompression);
+        }
+
+        /// <summary>
+        /// With <c>cloudfetch.lz4.enabled=true</c> (default) and an explicit
+        /// <c>result_compression</c>, the SEA driver must pass that compression
+        /// through to the wire unchanged. Locks in the no-regression contract
+        /// for the explicit compression path.
+        /// </summary>
+        [SkippableFact]
+        public void Lz4EnabledTrue_PassesThroughExplicitResultCompression()
+        {
+            SkipIfNotConfigured();
+
+            var extras = new Dictionary<string, string>
+            {
+                [DatabricksParameters.ResultCompression] = "LZ4_FRAME",
+            };
+
+            using var connection = CreateRestConnection(extras);
+            using var statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 1 AS value";
+            var result = statement.ExecuteQuery();
+            using (var reader = result.Stream)
+            {
+                while (reader != null && reader.ReadNextRecordBatchAsync().Result != null) { }
+            }
+
+            var seaStmt = Assert.IsType<StatementExecutionStatement>(statement);
+            Assert.NotNull(seaStmt.LastExecuteRequest);
+            Assert.Equal("LZ4_FRAME", seaStmt.LastExecuteRequest!.ResultCompression);
+        }
+    }
+}

--- a/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using AdbcDrivers.Databricks.StatementExecution;
 using AdbcDrivers.HiveServer2.Spark;
@@ -26,27 +25,18 @@ using Xunit.Abstractions;
 namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
 {
     /// <summary>
-    /// E2E tests proving that <c>adbc.databricks.cloudfetch.enabled</c> and
-    /// <c>adbc.databricks.cloudfetch.lz4.enabled</c> are honored on the SEA path
-    /// (PECO-3056). These are connection-level params on JDBC; the SEA driver
-    /// previously ignored them, so the disposition / compression flowing into
-    /// <see cref="ExecuteStatementRequest"/> matched only the explicit SEA-only
-    /// params (<c>result_disposition</c> / <c>result_compression</c>).
+    /// E2E tests proving that <c>adbc.databricks.cloudfetch.lz4.enabled</c> is
+    /// honored on the SEA path (PECO-3056). This is a connection-level param on
+    /// JDBC; the SEA driver previously ignored it.
     ///
-    /// The "happy-path" tests assert on the request that the driver actually
-    /// built — exposed via the internal
-    /// <see cref="StatementExecutionStatement.LastExecuteRequest"/> test seam —
-    /// rather than on observable server-side behavior. This lets the test verify
-    /// wire-level intent cheaply (one SELECT 1 round-trip) without depending on
-    /// data-volume heuristics inside the warehouse.
+    /// Tests assert on the request the driver actually built — exposed via the
+    /// internal <see cref="StatementExecutionStatement.LastExecuteRequest"/> test
+    /// seam — rather than on observable server-side behavior, so wire-level intent
+    /// is verified cheaply with a single SELECT 1 round-trip.
     ///
-    /// One test covers the <c>cloudfetch.enabled=false</c> case where the C#
-    /// SEA driver cannot yet honor the param (the SEA server requires
-    /// <c>format=JSON_ARRAY</c> for pure <c>INLINE</c> disposition, and the C#
-    /// driver only ships an ARROW reader). The driver surfaces this as a clear
-    /// <see cref="AdbcException"/> at connect time rather than silently ignoring
-    /// the param (the pre-PECO-3056 behavior) or letting the server reject the
-    /// first execute with an opaque 400.
+    /// Note: <c>cloudfetch.enabled=false</c> is not yet honored on SEA (requires
+    /// a JSON_ARRAY reader that is not yet implemented) and is intentionally left
+    /// as a silent no-op. It will be wired up in a follow-on ticket.
     /// </summary>
     public class SeaCloudFetchParamsE2ETests : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>
     {


### PR DESCRIPTION
## What's Changed

Wires `adbc.databricks.cloudfetch.lz4.enabled` through `StatementExecutionConnection` on the SEA path. Previously this param was silently ignored on SEA.

- **`cloudfetch.lz4.enabled=false`** clears `result_compression` on the wire (null → server treats as no compression). Mirrors JDBC's `CompressionCodec.NONE` branch in `DatabricksSdkClient`.
- **`cloudfetch.lz4.enabled=true`** (default) sets `result_compression=LZ4_FRAME`. The driver only implements LZ4 decompression; there is no other valid non-null value.

**`cloudfetch.enabled=false` is not wired on SEA.** Disabling CloudFetch on SEA requires the server to support `ARROW_STREAM` results with `INLINE` disposition. That server-side capability is not yet available, so the param is accepted but silently ignored on SEA for now. Support will be added in a follow-on once the server side lands.

**Test seam:** `StatementExecutionStatement.LastExecuteRequest` (internal) captures the request the driver last handed to the SEA client. E2E tests assert on `result_compression` there rather than intercepting HTTP.

## Why

PECO-3056 — https://databricks.atlassian.net/browse/PECO-3056

The M3 remaining-parameter-gap audit confirmed `cloudfetch.lz4.enabled` was ignored on SEA. This is the foundation for dependent CloudFetch sub-param tickets (PECO-3061, 3063, 3067, 3068), all of which operate with `cloudfetch.enabled=true` (the default).

## Red → Green proof

E2E tests run against the live `pecotesting` warehouse (`DATABRICKS_TEST_CONFIG_FILE` set).

**Before fix** (test seam added, no production logic — params still silently ignored):
```
[FAIL] Lz4EnabledFalse_ClearsResultCompression
  Assert.Null() Failure: Value is not null
  Expected: null
  Actual:   "LZ4_FRAME"

Failed!  - Failed: 1, Passed: 2, Skipped: 0, Total: 3
```

**After fix:**
```
Passed!  - Failed: 0, Passed: 3, Skipped: 0, Total: 3, Duration: 3 s
```

Safety run — `StatementExecutionDriverE2ETests` (11 tests, CREATE/INSERT/UPDATE/DELETE/SELECT round-trips on SEA):
```
Passed!  - Failed: 0, Passed: 11, Skipped: 0, Total: 11, Duration: 39 s
```

## Files touched

- `csharp/src/DatabricksParameters.cs` — XML doc clarifying SEA-path semantics for `UseCloudFetch` / `CanDecompressLz4`.
- `csharp/src/StatementExecution/StatementExecutionConnection.cs` — derive `result_compression` from `CanDecompressLz4` only (`LZ4_FRAME` or null).
- `csharp/src/StatementExecution/StatementExecutionStatement.cs` — internal `LastExecuteRequest` test seam.
- `csharp/test/E2E/StatementExecution/SeaCloudFetchParamsE2ETests.cs` — 3 E2E tests covering default disposition, lz4-off, and lz4-on.

## Manual verification

- [x] `dotnet build` green on `netstandard2.0` and `net8.0`
- [x] New E2E tests pass against live `pecotesting` warehouse
- [x] `StatementExecutionDriverE2ETests` (full class) passes — no regression

PECO-3056