### PR TITLE
feat(csharp): honor adbc.spark.connect_timeout_ms on SEA path (PECO-3059) [SEA]

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -483,21 +483,24 @@ namespace AdbcDrivers.Databricks.StatementExecution
                             var response = await _client.CreateSessionAsync(request, openToken).ConfigureAwait(false);
                             _sessionId = response.SessionId;
                         }
-                        catch (DatabricksException)
-                        {
-                            throw;
-                        }
+                        // PECO-3059: when the connect-timeout fired before the caller's token,
+                        // translate any exception (including DatabricksException-wrapped OAuth
+                        // cancellations) into TimeoutException for parity with HiveServer2Connection.
+                        // This filter must run BEFORE the unconditional DatabricksException
+                        // rethrow because OAuthClientCredentialsProvider wraps cancelled HTTP
+                        // calls as DatabricksException("Failed to acquire OAuth access token: …").
                         catch (Exception ex) when (
                             connectTimeoutCts != null &&
                             connectTimeoutCts.IsCancellationRequested &&
                             !cancellationToken.IsCancellationRequested)
                         {
-                            // PECO-3059: the connect-timeout fired before the caller's
-                            // token. Surface as TimeoutException for parity with
-                            // HiveServer2Connection.OpenAsync — same message phrasing.
                             throw new TimeoutException(
                                 "The operation timed out while attempting to open a session. Please try increasing connect timeout.",
                                 ex);
+                        }
+                        catch (DatabricksException)
+                        {
+                            throw;
                         }
                         catch (Exception ex)
                         {

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -44,7 +44,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private readonly string _warehouseId;
         private readonly string? _orgId;
         private string? _catalog;
-        private readonly string? _schema;
+        private string? _schema;
         private readonly HttpClient _httpClient;
         private readonly HttpClient _cloudFetchHttpClient; // Separate HttpClient without auth headers for CloudFetch downloads
         private readonly IReadOnlyDictionary<string, string> _properties;
@@ -54,35 +54,35 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string? _sessionId;
         private readonly SemaphoreSlim _sessionLock = new SemaphoreSlim(1, 1);
 
-        // Configuration for statement creation
-        private readonly string _resultDisposition;
-        private readonly string _resultFormat;
-        private readonly string? _resultCompression;
-        private readonly int _waitTimeoutSeconds;
-        private readonly int _pollingIntervalMs;
-        private readonly bool _enablePKFK;
-        private readonly bool _enableMultipleCatalogSupport;
-        private readonly bool _useDescTableExtended;
+        // Configuration for statement creation — assigned by ValidateOptions().
+        private string _resultDisposition = "INLINE_OR_EXTERNAL_LINKS";
+        private string _resultFormat = "ARROW_STREAM";
+        private string? _resultCompression;
+        private int _waitTimeoutSeconds = 10;
+        private int _pollingIntervalMs = 1000;
+        private bool _enablePKFK = true;
+        private bool _enableMultipleCatalogSupport = true;
+        private bool _useDescTableExtended = true;
 
         // Connection bring-up timeout (PECO-3059). Mirrors the Thrift path's
         // ConnectTimeoutMilliseconds — used as a CancellationToken bound on
         // CreateSession to honor adbc.spark.connect_timeout_ms on the SEA path.
         // Default matches HiveServer2Connection.ConnectTimeoutMillisecondsDefault (30 s).
         private const int ConnectTimeoutMillisecondsDefault = 30000;
-        private readonly int _connectTimeoutMilliseconds;
+        private int _connectTimeoutMilliseconds = ConnectTimeoutMillisecondsDefault;
 
         // Memory pooling (shared across connection)
         private readonly Microsoft.IO.RecyclableMemoryStreamManager _recyclableMemoryStreamManager;
         private readonly System.Buffers.ArrayPool<byte> _lz4BufferPool;
 
-        // Tracing propagation configuration
-        private readonly bool _tracePropagationEnabled;
-        private readonly string _traceParentHeaderName;
-        private readonly bool _traceStateEnabled;
-        private readonly bool _enableComplexDatatypeSupport;
+        // Tracing propagation configuration — assigned by ValidateOptions().
+        private bool _tracePropagationEnabled = true;
+        private string _traceParentHeaderName = "traceparent";
+        private bool _traceStateEnabled;
+        private bool _enableComplexDatatypeSupport;
 
-        // Authentication support
-        private readonly string? _identityFederationClientId;
+        // Authentication support — assigned by ValidateOptions().
+        private string? _identityFederationClientId;
 
         /// <summary>
         /// Creates a new Statement Execution connection with internally managed HTTP client.
@@ -207,59 +207,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
             }
             string baseUrl = $"https://{hostName}";
 
-            // Connection feature flags — parse before catalog/schema loading that depends on them
-            _enablePKFK = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnablePKFK, true);
-            _enableMultipleCatalogSupport = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableMultipleCatalogSupport, true);
-            _useDescTableExtended = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseDescTableExtended, true);
-
-            // Session configuration
-            // Only supply catalog from connection properties when EnableMultipleCatalogSupport is true.
-            // This matches DatabricksConnection (Thrift) behavior: when flag=false, the session uses
-            // the server's default catalog rather than a client-specified one.
-            if (_enableMultipleCatalogSupport)
-            {
-                properties.TryGetValue(AdbcOptions.Connection.CurrentCatalog, out _catalog);
-                // Match Thrift behavior: SPARK is a legacy alias — map it to null so the
-                // runtime falls back to the workspace default (typically hive_metastore).
-                _catalog = DatabricksConnection.HandleSparkCatalog(_catalog);
-            }
-            properties.TryGetValue(AdbcOptions.Connection.CurrentDbSchema, out _schema);
-
-            // Result configuration
-            _resultDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
-            _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
-            properties.TryGetValue(DatabricksParameters.ResultCompression, out _resultCompression);
-
-            _waitTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(properties, DatabricksParameters.WaitTimeout, 10);
-            if (properties.TryGetValue(DatabricksParameters.EnableDirectResults, out var directResults) &&
-                directResults.Equals("false", StringComparison.OrdinalIgnoreCase))
-            {
-                _waitTimeoutSeconds = 0;
-            }
-            _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(properties, DatabricksParameters.PollingInterval, 1000);
-
-            // PECO-3059: honor adbc.spark.connect_timeout_ms on the SEA path. The Thrift
-            // path uses this value as a CancellationToken bound on OpenSession; mirror
-            // that here for CreateSession. 0 means infinite. Negative values are invalid
-            // (matches Thrift's SparkHttpConnection.ValidateOptions).
-            _connectTimeoutMilliseconds = ParseConnectTimeoutMilliseconds(properties);
+            // Centralized option parsing / validation. Mirrors DatabricksConnection.ValidateOptions:
+            // every property-driven field is parsed and validated in one place so the constructor
+            // body stays focused on wiring.
+            ValidateOptions();
 
             // Memory pooling
             _recyclableMemoryStreamManager = memoryStreamManager ?? new Microsoft.IO.RecyclableMemoryStreamManager();
             _lz4BufferPool = lz4BufferPool ?? System.Buffers.ArrayPool<byte>.Create(maxArrayLength: 4 * 1024 * 1024, maxArraysPerBucket: 10);
-
-            // Tracing propagation configuration
-            // Base class (TracingConnection) already handles ActivityTrace initialization
-            _tracePropagationEnabled = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.TracePropagationEnabled, true);
-            _traceParentHeaderName = PropertyHelper.GetStringProperty(properties, DatabricksParameters.TraceParentHeaderName, "traceparent");
-            _traceStateEnabled = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.TraceStateEnabled, false);
-            _enableComplexDatatypeSupport = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableComplexDatatypeSupport, false);
-
-            // Authentication configuration
-            if (properties.TryGetValue(DatabricksParameters.IdentityFederationClientId, out string? identityFederationClientId))
-            {
-                _identityFederationClientId = identityFederationClientId;
-            }
 
             // Create or use provided HTTP client
             if (httpClient != null)
@@ -338,14 +293,60 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
-        /// Parses adbc.spark.connect_timeout_ms with Thrift-compatible validation and applies
-        /// the same TemporarilyUnavailableRetry adjustment as DatabricksConnection
-        /// (ValidateOptions, lines 967-972): when temporarily-unavailable retry is enabled,
-        /// the connect timeout must be at least as large as the retry budget — otherwise the
-        /// connect-timeout token would cancel mid-retry-loop before the server warms up.
+        /// Parses and validates every property-driven option for this connection in one place.
+        /// Mirrors <see cref="DatabricksConnection.ValidateOptions"/> on the Thrift path so all
+        /// option-handling logic lives next to itself rather than scattered through the constructor.
         /// </summary>
-        private static int ParseConnectTimeoutMilliseconds(IReadOnlyDictionary<string, string> properties)
+        private void ValidateOptions()
         {
+            var properties = _properties;
+
+            // Connection feature flags — must be parsed before catalog loading (depends on _enableMultipleCatalogSupport).
+            _enablePKFK = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnablePKFK, true);
+            _enableMultipleCatalogSupport = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableMultipleCatalogSupport, true);
+            _useDescTableExtended = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseDescTableExtended, true);
+
+            // Session configuration.
+            // Only supply catalog from connection properties when EnableMultipleCatalogSupport is true.
+            // This matches DatabricksConnection (Thrift) behavior: when flag=false, the session uses
+            // the server's default catalog rather than a client-specified one.
+            if (_enableMultipleCatalogSupport)
+            {
+                properties.TryGetValue(AdbcOptions.Connection.CurrentCatalog, out _catalog);
+                // Match Thrift behavior: SPARK is a legacy alias — map it to null so the
+                // runtime falls back to the workspace default (typically hive_metastore).
+                _catalog = DatabricksConnection.HandleSparkCatalog(_catalog);
+            }
+            properties.TryGetValue(AdbcOptions.Connection.CurrentDbSchema, out _schema);
+
+            // Result configuration.
+            _resultDisposition = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultDisposition, "INLINE_OR_EXTERNAL_LINKS");
+            _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
+            properties.TryGetValue(DatabricksParameters.ResultCompression, out _resultCompression);
+
+            _waitTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(properties, DatabricksParameters.WaitTimeout, 10);
+            if (properties.TryGetValue(DatabricksParameters.EnableDirectResults, out var directResults) &&
+                directResults.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                _waitTimeoutSeconds = 0;
+            }
+            _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(properties, DatabricksParameters.PollingInterval, 1000);
+
+            // Tracing propagation configuration. Base class (TracingConnection) already handles ActivityTrace init.
+            _tracePropagationEnabled = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.TracePropagationEnabled, true);
+            _traceParentHeaderName = PropertyHelper.GetStringProperty(properties, DatabricksParameters.TraceParentHeaderName, "traceparent");
+            _traceStateEnabled = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.TraceStateEnabled, false);
+            _enableComplexDatatypeSupport = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableComplexDatatypeSupport, false);
+
+            // Authentication configuration.
+            if (properties.TryGetValue(DatabricksParameters.IdentityFederationClientId, out string? identityFederationClientId))
+            {
+                _identityFederationClientId = identityFederationClientId;
+            }
+
+            // PECO-3059: honor adbc.spark.connect_timeout_ms on the SEA path. The Thrift path uses
+            // this value as a CancellationToken bound on OpenSession; mirror that here for CreateSession.
+            // 0 means infinite. Negative values are invalid (matches Thrift's SparkHttpConnection.ValidateOptions).
             int connectTimeoutMs = ConnectTimeoutMillisecondsDefault;
             if (properties.TryGetValue(SparkParameters.ConnectTimeoutMilliseconds, out string? connectTimeoutStr))
             {
@@ -361,8 +362,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 connectTimeoutMs = parsed;
             }
 
-            // Mirror DatabricksConnection.ValidateOptions: when temporarily-unavailable
-            // retry is on, the retry budget must fit inside the connect-timeout token.
+            // Mirror DatabricksConnection.ValidateOptions: when temporarily-unavailable retry is on,
+            // the retry budget must fit inside the connect-timeout token — otherwise the connect-timeout
+            // would cancel mid-retry-loop before the server warms up.
             bool temporarilyUnavailableRetry = PropertyHelper.GetBooleanPropertyWithValidation(
                 properties, DatabricksParameters.TemporarilyUnavailableRetry, true);
             int temporarilyUnavailableRetryTimeout = PropertyHelper.GetIntPropertyWithValidation(
@@ -373,12 +375,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 temporarilyUnavailableRetryTimeout * 1000L > connectTimeoutMs &&
                 connectTimeoutMs != 0) // 0 == infinite — don't shrink it
             {
-                // Use checked arithmetic implicitly: clamp to int.MaxValue.
                 long bumped = temporarilyUnavailableRetryTimeout * 1000L;
                 connectTimeoutMs = bumped > int.MaxValue ? int.MaxValue : (int)bumped;
             }
-
-            return connectTimeoutMs;
+            _connectTimeoutMilliseconds = connectTimeoutMs;
         }
 
         /// <summary>
@@ -443,64 +443,62 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     : null;
                 CancellationToken openToken = linkedCts?.Token ?? cancellationToken;
 
+                // Track lock ownership so the single finally only releases when we actually acquired it.
+                // This collapses the previous outer/inner try pair into one — see PR #466 review feedback.
+                bool lockAcquired = false;
                 try
                 {
                     await _sessionLock.WaitAsync(openToken).ConfigureAwait(false);
-                    try
+                    lockAcquired = true;
+
+                    // Double-check after acquiring lock
+                    if (_sessionId == null)
                     {
-                        // Double-check after acquiring lock
-                        if (_sessionId == null)
+                        var sessionConfigs = ExtractServerSideProperties(_properties);
+                        var request = new CreateSessionRequest
                         {
-                            var sessionConfigs = ExtractServerSideProperties(_properties);
-                            var request = new CreateSessionRequest
-                            {
-                                WarehouseId = _warehouseId,
-                                Catalog = _catalog,
-                                Schema = _schema,
-                                SessionConfigs = sessionConfigs.Count > 0 ? sessionConfigs : null
-                            };
+                            WarehouseId = _warehouseId,
+                            Catalog = _catalog,
+                            Schema = _schema,
+                            SessionConfigs = sessionConfigs.Count > 0 ? sessionConfigs : null
+                        };
 
-                            try
-                            {
-                                var response = await _client.CreateSessionAsync(request, openToken).ConfigureAwait(false);
-                                _sessionId = response.SessionId;
-                            }
-                            catch (DatabricksException)
-                            {
-                                throw;
-                            }
-                            catch (Exception ex) when (
-                                connectTimeoutCts != null &&
-                                connectTimeoutCts.IsCancellationRequested &&
-                                !cancellationToken.IsCancellationRequested)
-                            {
-                                // PECO-3059: the connect-timeout fired before the caller's
-                                // token. Surface as TimeoutException for parity with
-                                // HiveServer2Connection.OpenAsync — same message phrasing.
-                                throw new TimeoutException(
-                                    "The operation timed out while attempting to open a session. Please try increasing connect timeout.",
-                                    ex);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw new DatabricksException(
-                                    $"Failed to connect to Databricks: {ex.GetBaseException().Message}",
-                                    AdbcStatusCode.IOError,
-                                    ex);
-                            }
-
-                            // If user didn't specify a catalog, discover the server's default.
-                            // In Thrift, the server returns this in OpenSessionResp.InitialNamespace.
-                            // SEA's CreateSession response doesn't include it, so we query explicitly.
-                            if (_catalog == null && _enableMultipleCatalogSupport)
-                            {
-                                _catalog = GetCurrentCatalog();
-                            }
+                        try
+                        {
+                            var response = await _client.CreateSessionAsync(request, openToken).ConfigureAwait(false);
+                            _sessionId = response.SessionId;
                         }
-                    }
-                    finally
-                    {
-                        _sessionLock.Release();
+                        catch (DatabricksException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex) when (
+                            connectTimeoutCts != null &&
+                            connectTimeoutCts.IsCancellationRequested &&
+                            !cancellationToken.IsCancellationRequested)
+                        {
+                            // PECO-3059: the connect-timeout fired before the caller's
+                            // token. Surface as TimeoutException for parity with
+                            // HiveServer2Connection.OpenAsync — same message phrasing.
+                            throw new TimeoutException(
+                                "The operation timed out while attempting to open a session. Please try increasing connect timeout.",
+                                ex);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new DatabricksException(
+                                $"Failed to connect to Databricks: {ex.GetBaseException().Message}",
+                                AdbcStatusCode.IOError,
+                                ex);
+                        }
+
+                        // If user didn't specify a catalog, discover the server's default.
+                        // In Thrift, the server returns this in OpenSessionResp.InitialNamespace.
+                        // SEA's CreateSession response doesn't include it, so we query explicitly.
+                        if (_catalog == null && _enableMultipleCatalogSupport)
+                        {
+                            _catalog = GetCurrentCatalog();
+                        }
                     }
                 }
                 catch (OperationCanceledException ex) when (
@@ -508,11 +506,18 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     connectTimeoutCts.IsCancellationRequested &&
                     !cancellationToken.IsCancellationRequested)
                 {
-                    // Covers the case where the semaphore wait itself was cancelled by the
-                    // connect-timeout token (rare but possible under contention).
+                    // The semaphore wait itself was cancelled by the connect-timeout token
+                    // (rare but possible under contention).
                     throw new TimeoutException(
                         "The operation timed out while attempting to open a session. Please try increasing connect timeout.",
                         ex);
+                }
+                finally
+                {
+                    if (lockAcquired)
+                    {
+                        _sessionLock.Release();
+                    }
                 }
             }
         }

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -64,6 +64,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private readonly bool _enableMultipleCatalogSupport;
         private readonly bool _useDescTableExtended;
 
+        // Connection bring-up timeout (PECO-3059). Mirrors the Thrift path's
+        // ConnectTimeoutMilliseconds — used as a CancellationToken bound on
+        // CreateSession to honor adbc.spark.connect_timeout_ms on the SEA path.
+        // Default matches HiveServer2Connection.ConnectTimeoutMillisecondsDefault (30 s).
+        private const int ConnectTimeoutMillisecondsDefault = 30000;
+        private readonly int _connectTimeoutMilliseconds;
+
         // Memory pooling (shared across connection)
         private readonly Microsoft.IO.RecyclableMemoryStreamManager _recyclableMemoryStreamManager;
         private readonly System.Buffers.ArrayPool<byte> _lz4BufferPool;
@@ -231,6 +238,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
             }
             _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(properties, DatabricksParameters.PollingInterval, 1000);
 
+            // PECO-3059: honor adbc.spark.connect_timeout_ms on the SEA path. The Thrift
+            // path uses this value as a CancellationToken bound on OpenSession; mirror
+            // that here for CreateSession. 0 means infinite. Negative values are invalid
+            // (matches Thrift's SparkHttpConnection.ValidateOptions).
+            _connectTimeoutMilliseconds = ParseConnectTimeoutMilliseconds(properties);
+
             // Memory pooling
             _recyclableMemoryStreamManager = memoryStreamManager ?? new Microsoft.IO.RecyclableMemoryStreamManager();
             _lz4BufferPool = lz4BufferPool ?? System.Buffers.ArrayPool<byte>.Create(maxArrayLength: 4 * 1024 * 1024, maxArraysPerBucket: 10);
@@ -325,6 +338,50 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
+        /// Parses adbc.spark.connect_timeout_ms with Thrift-compatible validation and applies
+        /// the same TemporarilyUnavailableRetry adjustment as DatabricksConnection
+        /// (ValidateOptions, lines 967-972): when temporarily-unavailable retry is enabled,
+        /// the connect timeout must be at least as large as the retry budget — otherwise the
+        /// connect-timeout token would cancel mid-retry-loop before the server warms up.
+        /// </summary>
+        private static int ParseConnectTimeoutMilliseconds(IReadOnlyDictionary<string, string> properties)
+        {
+            int connectTimeoutMs = ConnectTimeoutMillisecondsDefault;
+            if (properties.TryGetValue(SparkParameters.ConnectTimeoutMilliseconds, out string? connectTimeoutStr))
+            {
+                if (!int.TryParse(connectTimeoutStr, System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out int parsed) ||
+                    parsed < 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        SparkParameters.ConnectTimeoutMilliseconds,
+                        connectTimeoutStr,
+                        $"must be a value of 0 (infinite) or between 1 .. {int.MaxValue}. default is {ConnectTimeoutMillisecondsDefault} milliseconds.");
+                }
+                connectTimeoutMs = parsed;
+            }
+
+            // Mirror DatabricksConnection.ValidateOptions: when temporarily-unavailable
+            // retry is on, the retry budget must fit inside the connect-timeout token.
+            bool temporarilyUnavailableRetry = PropertyHelper.GetBooleanPropertyWithValidation(
+                properties, DatabricksParameters.TemporarilyUnavailableRetry, true);
+            int temporarilyUnavailableRetryTimeout = PropertyHelper.GetIntPropertyWithValidation(
+                properties,
+                DatabricksParameters.TemporarilyUnavailableRetryTimeout,
+                DatabricksConstants.DefaultTemporarilyUnavailableRetryTimeout);
+            if (temporarilyUnavailableRetry &&
+                temporarilyUnavailableRetryTimeout * 1000L > connectTimeoutMs &&
+                connectTimeoutMs != 0) // 0 == infinite — don't shrink it
+            {
+                // Use checked arithmetic implicitly: clamp to int.MaxValue.
+                long bumped = temporarilyUnavailableRetryTimeout * 1000L;
+                connectTimeoutMs = bumped > int.MaxValue ? int.MaxValue : (int)bumped;
+            }
+
+            return connectTimeoutMs;
+        }
+
+        /// <summary>
         /// Gets the host from the connection properties.
         /// </summary>
         /// <param name="properties">Connection properties.</param>
@@ -374,50 +431,88 @@ namespace AdbcDrivers.Databricks.StatementExecution
         {
             if (_sessionId == null)
             {
-                await _sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                // PECO-3059: bound the session bring-up with adbc.spark.connect_timeout_ms.
+                // The Thrift path applies this same timeout to OpenSession via a
+                // CancellationToken; we mirror that here. 0 means infinite — skip the
+                // timer entirely so we don't fight an external caller-supplied token.
+                using var connectTimeoutCts = _connectTimeoutMilliseconds > 0
+                    ? new CancellationTokenSource(TimeSpan.FromMilliseconds(_connectTimeoutMilliseconds))
+                    : null;
+                using var linkedCts = connectTimeoutCts != null
+                    ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectTimeoutCts.Token)
+                    : null;
+                CancellationToken openToken = linkedCts?.Token ?? cancellationToken;
+
                 try
                 {
-                    // Double-check after acquiring lock
-                    if (_sessionId == null)
+                    await _sessionLock.WaitAsync(openToken).ConfigureAwait(false);
+                    try
                     {
-                        var sessionConfigs = ExtractServerSideProperties(_properties);
-                        var request = new CreateSessionRequest
+                        // Double-check after acquiring lock
+                        if (_sessionId == null)
                         {
-                            WarehouseId = _warehouseId,
-                            Catalog = _catalog,
-                            Schema = _schema,
-                            SessionConfigs = sessionConfigs.Count > 0 ? sessionConfigs : null
-                        };
+                            var sessionConfigs = ExtractServerSideProperties(_properties);
+                            var request = new CreateSessionRequest
+                            {
+                                WarehouseId = _warehouseId,
+                                Catalog = _catalog,
+                                Schema = _schema,
+                                SessionConfigs = sessionConfigs.Count > 0 ? sessionConfigs : null
+                            };
 
-                        try
-                        {
-                            var response = await _client.CreateSessionAsync(request, cancellationToken).ConfigureAwait(false);
-                            _sessionId = response.SessionId;
-                        }
-                        catch (DatabricksException)
-                        {
-                            throw;
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new DatabricksException(
-                                $"Failed to connect to Databricks: {ex.GetBaseException().Message}",
-                                AdbcStatusCode.IOError,
-                                ex);
-                        }
+                            try
+                            {
+                                var response = await _client.CreateSessionAsync(request, openToken).ConfigureAwait(false);
+                                _sessionId = response.SessionId;
+                            }
+                            catch (DatabricksException)
+                            {
+                                throw;
+                            }
+                            catch (Exception ex) when (
+                                connectTimeoutCts != null &&
+                                connectTimeoutCts.IsCancellationRequested &&
+                                !cancellationToken.IsCancellationRequested)
+                            {
+                                // PECO-3059: the connect-timeout fired before the caller's
+                                // token. Surface as TimeoutException for parity with
+                                // HiveServer2Connection.OpenAsync — same message phrasing.
+                                throw new TimeoutException(
+                                    "The operation timed out while attempting to open a session. Please try increasing connect timeout.",
+                                    ex);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new DatabricksException(
+                                    $"Failed to connect to Databricks: {ex.GetBaseException().Message}",
+                                    AdbcStatusCode.IOError,
+                                    ex);
+                            }
 
-                        // If user didn't specify a catalog, discover the server's default.
-                        // In Thrift, the server returns this in OpenSessionResp.InitialNamespace.
-                        // SEA's CreateSession response doesn't include it, so we query explicitly.
-                        if (_catalog == null && _enableMultipleCatalogSupport)
-                        {
-                            _catalog = GetCurrentCatalog();
+                            // If user didn't specify a catalog, discover the server's default.
+                            // In Thrift, the server returns this in OpenSessionResp.InitialNamespace.
+                            // SEA's CreateSession response doesn't include it, so we query explicitly.
+                            if (_catalog == null && _enableMultipleCatalogSupport)
+                            {
+                                _catalog = GetCurrentCatalog();
+                            }
                         }
                     }
+                    finally
+                    {
+                        _sessionLock.Release();
+                    }
                 }
-                finally
+                catch (OperationCanceledException ex) when (
+                    connectTimeoutCts != null &&
+                    connectTimeoutCts.IsCancellationRequested &&
+                    !cancellationToken.IsCancellationRequested)
                 {
-                    _sessionLock.Release();
+                    // Covers the case where the semaphore wait itself was cancelled by the
+                    // connect-timeout token (rare but possible under contention).
+                    throw new TimeoutException(
+                        "The operation timed out while attempting to open a session. Please try increasing connect timeout.",
+                        ex);
                 }
             }
         }

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -54,34 +54,34 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string? _sessionId;
         private readonly SemaphoreSlim _sessionLock = new SemaphoreSlim(1, 1);
 
-        // Configuration for statement creation — assigned by ValidateOptions().
-        private string _resultDisposition = "INLINE_OR_EXTERNAL_LINKS";
-        private string _resultFormat = "ARROW_STREAM";
+        // Configuration for statement creation — assigned by ValidateProperties().
+        private string _resultDisposition = null!;
+        private string _resultFormat = null!;
         private string? _resultCompression;
-        private int _waitTimeoutSeconds = 10;
-        private int _pollingIntervalMs = 1000;
-        private bool _enablePKFK = true;
-        private bool _enableMultipleCatalogSupport = true;
-        private bool _useDescTableExtended = true;
+        private int _waitTimeoutSeconds;
+        private int _pollingIntervalMs;
+        private bool _enablePKFK;
+        private bool _enableMultipleCatalogSupport;
+        private bool _useDescTableExtended;
 
         // Connection bring-up timeout (PECO-3059). Mirrors the Thrift path's
         // ConnectTimeoutMilliseconds — used as a CancellationToken bound on
         // CreateSession to honor adbc.spark.connect_timeout_ms on the SEA path.
         // Default matches HiveServer2Connection.ConnectTimeoutMillisecondsDefault (30 s).
         private const int ConnectTimeoutMillisecondsDefault = 30000;
-        private int _connectTimeoutMilliseconds = ConnectTimeoutMillisecondsDefault;
+        private int _connectTimeoutMilliseconds;
 
         // Memory pooling (shared across connection)
         private readonly Microsoft.IO.RecyclableMemoryStreamManager _recyclableMemoryStreamManager;
         private readonly System.Buffers.ArrayPool<byte> _lz4BufferPool;
 
-        // Tracing propagation configuration — assigned by ValidateOptions().
-        private bool _tracePropagationEnabled = true;
-        private string _traceParentHeaderName = "traceparent";
+        // Tracing propagation configuration — assigned by ValidateProperties().
+        private bool _tracePropagationEnabled;
+        private string _traceParentHeaderName = null!;
         private bool _traceStateEnabled;
         private bool _enableComplexDatatypeSupport;
 
-        // Authentication support — assigned by ValidateOptions().
+        // Authentication support — assigned by ValidateProperties().
         private string? _identityFederationClientId;
 
         /// <summary>
@@ -207,10 +207,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
             }
             string baseUrl = $"https://{hostName}";
 
-            // Centralized option parsing / validation. Mirrors DatabricksConnection.ValidateOptions:
-            // every property-driven field is parsed and validated in one place so the constructor
-            // body stays focused on wiring.
-            ValidateOptions();
+            // Centralized property parsing / validation. Every property-driven field is parsed
+            // and validated in one place so the constructor body stays focused on wiring.
+            ValidateProperties();
 
             // Memory pooling
             _recyclableMemoryStreamManager = memoryStreamManager ?? new Microsoft.IO.RecyclableMemoryStreamManager();
@@ -293,11 +292,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
-        /// Parses and validates every property-driven option for this connection in one place.
-        /// Mirrors <see cref="DatabricksConnection.ValidateOptions"/> on the Thrift path so all
-        /// option-handling logic lives next to itself rather than scattered through the constructor.
+        /// Parses and validates every property-driven option for this connection in one place,
+        /// keeping option-handling logic centralized rather than scattered through the constructor.
         /// </summary>
-        private void ValidateOptions()
+        private void ValidateProperties()
         {
             var properties = _properties;
 
@@ -346,7 +344,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
             // PECO-3059: honor adbc.spark.connect_timeout_ms on the SEA path. The Thrift path uses
             // this value as a CancellationToken bound on OpenSession; mirror that here for CreateSession.
-            // 0 means infinite. Negative values are invalid (matches Thrift's SparkHttpConnection.ValidateOptions).
+            // 0 means infinite. Negative values are invalid (matches Thrift's SparkHttpConnection validation).
             int connectTimeoutMs = ConnectTimeoutMillisecondsDefault;
             if (properties.TryGetValue(SparkParameters.ConnectTimeoutMilliseconds, out string? connectTimeoutStr))
             {
@@ -362,7 +360,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 connectTimeoutMs = parsed;
             }
 
-            // Mirror DatabricksConnection.ValidateOptions: when temporarily-unavailable retry is on,
+            // Mirror DatabricksConnection.ValidateOptions parity-bump: when temporarily-unavailable retry is on,
             // the retry budget must fit inside the connect-timeout token — otherwise the connect-timeout
             // would cancel mid-retry-loop before the server warms up.
             bool temporarilyUnavailableRetry = PropertyHelper.GetBooleanPropertyWithValidation(

--- a/csharp/test/E2E/DatabricksConnectionTest.cs
+++ b/csharp/test/E2E/DatabricksConnectionTest.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Threading.Tasks;
@@ -169,6 +170,79 @@ namespace AdbcDrivers.Databricks.Tests
                     throw;
                 }
             }
+        }
+
+        /// <summary>
+        /// PECO-3059: the SEA path must honor adbc.spark.connect_timeout_ms when opening
+        /// the session, matching the Thrift path's semantics. With an impossibly short
+        /// connect timeout (1 ms), creating a connection must fail fast (well under the
+        /// HttpClient default 100s) with a TimeoutException — not hang, succeed, or take
+        /// the full HTTP timeout budget.
+        ///
+        /// Note: temporarily_unavailable_retry is disabled explicitly so the Thrift-parity
+        /// "bump connect-timeout to retry budget" path (see DatabricksConnection.ValidateOptions
+        /// lines 967-972 and the mirrored logic in StatementExecutionConnection) doesn't
+        /// rewrite the 1 ms back up to 900 s. The fix itself is exercised; the bump logic
+        /// is covered separately by the existing Thrift ConnectionTimeoutTest.
+        ///
+        /// Red proof (before fix): NewConnection() either succeeds (the timeout is
+        /// silently ignored) or fails only after the HttpClient.Timeout (minutes) elapses.
+        /// Green proof (after fix): NewConnection() throws TimeoutException within a few
+        /// seconds, matching the Thrift ConnectionTimeoutTest behavior at the same value.
+        /// </summary>
+        [SkippableFact]
+        public void SeaConnectionTimeout_HonorsConnectTimeoutMs()
+        {
+            DatabricksTestConfiguration testConfiguration = (DatabricksTestConfiguration)TestConfiguration.Clone();
+            // Force the SEA (REST) path regardless of the global test-config protocol.
+            testConfiguration.Protocol = "rest";
+            // Impossibly short — guarantees the timer fires before the TCP/TLS handshake
+            // completes against a real Databricks workspace.
+            testConfiguration.ConnectTimeoutMilliseconds = "1";
+
+            // Build driver parameters and disable temporarily_unavailable_retry so the
+            // parity-bump path (see ParseConnectTimeoutMilliseconds) doesn't rewrite the
+            // 1 ms value up to the 900 s retry budget. The retry-bump behavior itself is
+            // exercised by the Thrift ConnectionTimeoutTest.
+            var parameters = GetDriverParameters(testConfiguration);
+            parameters[DatabricksParameters.TemporarilyUnavailableRetry] = "false";
+
+            OutputHelper?.WriteLine($"[PECO-3059] Forcing SEA protocol with ConnectTimeoutMilliseconds=1, retry disabled");
+
+            var stopwatch = Stopwatch.StartNew();
+            Exception? caught = null;
+            try
+            {
+                AdbcDatabase database = NewDriver.Open(parameters);
+                using var _ = database.Connect(new Dictionary<string, string>());
+            }
+            catch (Exception ex)
+            {
+                caught = ex;
+            }
+            stopwatch.Stop();
+
+            OutputHelper?.WriteLine($"[PECO-3059] Elapsed: {stopwatch.ElapsedMilliseconds} ms. Exception: {caught?.GetType().FullName ?? "<none>"}");
+
+            // The connect timeout MUST fire long before the HttpClient overall timeout
+            // (which defaults to minutes on the SEA path). Allow a generous 10 s budget
+            // for TLS abort + handler unwind on a slow machine; the actual signal we
+            // care about is "fails fast", not "takes the full HTTP timeout".
+            Assert.NotNull(caught);
+            Assert.True(
+                stopwatch.ElapsedMilliseconds < 10_000,
+                $"Expected the SEA connect-timeout to fire within ~10s when adbc.spark.connect_timeout_ms=1; " +
+                $"actual elapsed was {stopwatch.ElapsedMilliseconds} ms (exception: {caught?.GetType().FullName}). " +
+                $"This indicates adbc.spark.connect_timeout_ms is not wired through to the SEA HttpClient call.");
+
+            // For parity with the Thrift ConnectionTimeoutTest the exception chain must
+            // surface a TimeoutException (Thrift translates the cancelled OpenSession into
+            // a TimeoutException — the SEA path should do the same).
+            bool hasTimeoutException = ApacheUtility.ContainsException(caught!, typeof(TimeoutException), out _);
+            Assert.True(
+                hasTimeoutException,
+                $"Expected TimeoutException somewhere in the exception chain (parity with Thrift); " +
+                $"got {caught!.GetType().FullName}: {caught.Message}");
         }
 
         /// <summary>

--- a/csharp/test/E2E/DatabricksConnectionTest.cs
+++ b/csharp/test/E2E/DatabricksConnectionTest.cs
@@ -224,14 +224,14 @@ namespace AdbcDrivers.Databricks.Tests
 
             OutputHelper?.WriteLine($"[PECO-3059] Elapsed: {stopwatch.ElapsedMilliseconds} ms. Exception: {caught?.GetType().FullName ?? "<none>"}");
 
-            // The connect timeout MUST fire long before the HttpClient overall timeout
-            // (which defaults to minutes on the SEA path). Allow a generous 10 s budget
-            // for TLS abort + handler unwind on a slow machine; the actual signal we
-            // care about is "fails fast", not "takes the full HTTP timeout".
+            // With adbc.spark.connect_timeout_ms=1 the timer must fire essentially immediately;
+            // green runs complete in ~25-50 ms. A 1 s budget leaves ample slack for TLS abort
+            // and handler unwind on a slow CI box without being so loose that a regression
+            // (e.g. falling back to the HttpClient.Timeout of minutes) would still pass.
             Assert.NotNull(caught);
             Assert.True(
-                stopwatch.ElapsedMilliseconds < 10_000,
-                $"Expected the SEA connect-timeout to fire within ~10s when adbc.spark.connect_timeout_ms=1; " +
+                stopwatch.ElapsedMilliseconds < 1_000,
+                $"Expected the SEA connect-timeout to fire within ~1s when adbc.spark.connect_timeout_ms=1; " +
                 $"actual elapsed was {stopwatch.ElapsedMilliseconds} ms (exception: {caught?.GetType().FullName}). " +
                 $"This indicates adbc.spark.connect_timeout_ms is not wired through to the SEA HttpClient call.");
 


### PR DESCRIPTION
## What's Changed

Wires `adbc.spark.connect_timeout_ms` through `StatementExecutionConnection` so the SEA (Statement Execution REST) path bounds session bring-up with the same semantics as the Thrift / HiveServer2 path. Before this PR, the parameter was silently ignored on the SEA path: `CreateSessionAsync` ran with no cancellation token, so a hung warehouse would wait for the full `HttpClient.Timeout` (minutes) before failing.

The fix:
- Parses `adbc.spark.connect_timeout_ms` in `StatementExecutionConnection`'s constructor with Thrift-compatible validation (0 = infinite, negative = invalid, default 30000 ms — matches `HiveServer2Connection.ConnectTimeoutMillisecondsDefault`).
- Mirrors `DatabricksConnection.ValidateOptions` (lines 967-972): bumps the connect-timeout up to `temporarily_unavailable_retry_timeout * 1000` when retry is enabled, so the connect-timeout token doesn't cancel mid-retry-loop.
- Wraps `CreateSessionAsync` (and the semaphore wait) inside `OpenAsync` with a linked `CancellationTokenSource` so either the caller's token or the connect-timeout can cancel. Cancellations triggered by the connect-timeout (and not the caller's token) are translated to `TimeoutException` for exception-type parity with `HiveServer2Connection.OpenAsync`.

## Why

PECO-3059 — M3 remaining parameter gap. Connection-timeout handling on the SEA path needed parity with Thrift before the Jun 10 cutoff.

## Red → Green proof

E2E test: `AdbcDrivers.Databricks.Tests.DatabricksConnectionTest.SeaConnectionTimeout_HonorsConnectTimeoutMs` — forces `adbc.databricks.protocol=rest`, sets `adbc.spark.connect_timeout_ms=1`, and disables `temporarily_unavailable_retry` to bypass the parity-bump. The test runs against the live `pecotesting` warehouse.

**Before fix (red, with the production change reverted):**

```
[xUnit.net 00:00:00.91]     AdbcDrivers.Databricks.Tests.DatabricksConnectionTest.SeaConnectionTimeout_HonorsConnectTimeoutMs [FAIL]
  Failed AdbcDrivers.Databricks.Tests.DatabricksConnectionTest.SeaConnectionTimeout_HonorsConnectTimeoutMs [643 ms]
  Error Message:
   Assert.NotNull() Failure: Value is null
  Standard Output Messages:
 [PECO-3059] Forcing SEA protocol with ConnectTimeoutMilliseconds=1, retry disabled
 [PECO-3059] Elapsed: 640 ms. Exception: <none>

Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1
```

The connection succeeded in 640 ms — the 1 ms connect-timeout was silently ignored.

**After fix (green):**

```
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 26 ms - AdbcDrivers.Databricks.Tests.dll (net8.0)
```

Connection fails fast (~26 ms total test duration including teardown) with a `TimeoutException` in the chain, matching the Thrift `ConnectionTimeoutTest`.

## Files touched

- `csharp/src/StatementExecution/StatementExecutionConnection.cs` — parse the timeout, apply Thrift-parity bump, gate `CreateSessionAsync` with linked CTS, translate cancellation → `TimeoutException`.
- `csharp/test/E2E/DatabricksConnectionTest.cs` — new `[SkippableFact]` E2E test asserting the SEA path fails fast under `connect_timeout_ms=1`.

## Safety

- Full `DatabricksConnectionTest` class: 93 passed, 0 failed (42 s).
- Full `StatementExecution*` E2E tests: 225 passed, 0 failed (1m 9s).
- `dotnet build` succeeds for `netstandard2.0`, `net472`, `net8.0`.

## Manual verification

- [x] E2E test (`SeaConnectionTimeout_HonorsConnectTimeoutMs`) passes against `pecotesting`
- [x] Full `DatabricksConnectionTest` class passes (no regression)
- [x] Full `StatementExecution*` test class passes (no regression)
- [x] Build green on all TFMs
- [ ] pre-commit run (skipped — sandbox blocked network access for hook env install; will run in CI)

PECO-3059