### PR TITLE
feat(csharp): honor adbc.databricks.apply_ssp_with_queries on SEA path (PECO-3062) [SEA]

### DIFF
--- a/csharp/src/DatabricksDatabase.cs
+++ b/csharp/src/DatabricksDatabase.cs
@@ -103,6 +103,10 @@ namespace AdbcDrivers.Databricks
                     // Open the connection to create session if needed
                     var statementConnection = (StatementExecutionConnection)connection;
                     statementConnection.OpenAsync().Wait();
+                    // Mirrors Thrift wiring below: when apply_ssp_with_queries=true,
+                    // run post-open SET statements for each adbc.databricks.ssp_*.
+                    // No-op when the flag is false (SSPs already in CreateSession.session_confs).
+                    statementConnection.ApplyServerSidePropertiesAsync().Wait();
                 }
                 else if (protocol == "thrift")
                 {

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -63,6 +63,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private readonly bool _enablePKFK;
         private readonly bool _enableMultipleCatalogSupport;
         private readonly bool _useDescTableExtended;
+        private readonly bool _applySSPWithQueries;
 
         // Memory pooling (shared across connection)
         private readonly Microsoft.IO.RecyclableMemoryStreamManager _recyclableMemoryStreamManager;
@@ -204,6 +205,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _enablePKFK = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnablePKFK, true);
             _enableMultipleCatalogSupport = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.EnableMultipleCatalogSupport, true);
             _useDescTableExtended = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.UseDescTableExtended, true);
+            // When true, SSPs (adbc.databricks.ssp_*) are applied via post-open SET statements
+            // rather than CreateSession.session_confs — mirrors Thrift's behavior so callers
+            // who depend on the SET-statement path (e.g., for audit visibility or for SSPs
+            // the server validates differently in CreateSession vs SET) get the same semantics
+            // on SEA. JDBC has no equivalent flag — this is parity with the Thrift driver only.
+            _applySSPWithQueries = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.ApplySSPWithQueries, false);
 
             // Session configuration
             // Only supply catalog from connection properties when EnableMultipleCatalogSupport is true.
@@ -380,7 +387,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     // Double-check after acquiring lock
                     if (_sessionId == null)
                     {
-                        var sessionConfigs = ExtractServerSideProperties(_properties);
+                        // When apply_ssp_with_queries=true, SSPs are deferred to post-open SET
+                        // statements (see ApplyServerSidePropertiesAsync), so omit them here to
+                        // avoid double-setting and to match Thrift parity.
+                        var sessionConfigs = _applySSPWithQueries
+                            ? new Dictionary<string, string>()
+                            : ExtractServerSideProperties(_properties);
                         var request = new CreateSessionRequest
                         {
                             WarehouseId = _warehouseId,
@@ -887,6 +899,48 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 }
             }
             return result;
+        }
+
+        /// <summary>
+        /// Applies server-side properties (adbc.databricks.ssp_*) by executing
+        /// <c>SET key=value</c> statements after the session is open. No-op when
+        /// <c>apply_ssp_with_queries=false</c> — in that case the values are
+        /// already in <see cref="CreateSessionRequest.SessionConfigs"/> from
+        /// <see cref="OpenAsync"/>. Mirrors <c>DatabricksConnection.ApplyServerSidePropertiesAsync</c>
+        /// on the Thrift path so both protocols honor the same flag.
+        /// </summary>
+        public async Task ApplyServerSidePropertiesAsync(CancellationToken cancellationToken = default)
+        {
+            if (!_applySSPWithQueries)
+            {
+                return;
+            }
+
+            var serverSideProperties = ExtractServerSideProperties(_properties);
+            if (serverSideProperties.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var property in serverSideProperties)
+            {
+                // Backtick-escaped to match the Thrift path's SET escaping (DatabricksConnection.EscapeSqlString)
+                // — preserves values containing reserved characters while keeping a SET-compatible literal.
+                string escapedValue = "`" + property.Value.Replace("`", "``") + "`";
+                string query = $"SET {property.Key}={escapedValue}";
+
+                try
+                {
+                    using var stmt = (StatementExecutionStatement)CreateStatement();
+                    stmt.SqlQuery = query;
+                    await stmt.ExecuteUpdateAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // Best-effort, matching Thrift behavior — a single bad SSP value should not
+                    // tear down the whole session. The error is surfaced in tracing only.
+                }
+            }
         }
 
         /// <summary>

--- a/csharp/test/E2E/ServerSidePropertyE2ETest.cs
+++ b/csharp/test/E2E/ServerSidePropertyE2ETest.cs
@@ -88,5 +88,62 @@ namespace AdbcDrivers.Databricks.Tests
             Assert.True(returnedProperties.ContainsKey("statement_timeout"));
             Assert.Equal("12345", returnedProperties["statement_timeout"]);
         }
+
+        /// <summary>
+        /// PECO-3062: on the SEA path (protocol=rest), the
+        /// <c>adbc.databricks.apply_ssp_with_queries</c> flag must be honored end-to-end.
+        /// Whether the SSPs ride in <c>CreateSession.session_confs</c> (flag=false) or
+        /// are pushed via post-open <c>SET key=value</c> statements (flag=true), the
+        /// final observable state must be the same — both <c>use_cached_result</c> and
+        /// <c>statement_timeout</c> visible via <c>SET</c>.
+        ///
+        /// Before this fix, the SEA path ignored the flag and always used session_confs.
+        /// With the flag plumbed through, the post-open SET path runs and reaches the
+        /// same end state. This test exercises the live SEA endpoint to confirm parity.
+        /// </summary>
+        [SkippableTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestServerSidePropertyOnSeaPath(bool applyWithQueries)
+        {
+            var additionalConnectionParams = new Dictionary<string, string>()
+            {
+                // Force the SEA path regardless of the test config's default protocol.
+                [DatabricksParameters.Protocol] = "rest",
+                [DatabricksParameters.ServerSidePropertyPrefix + "use_cached_result"] = "false",
+                [DatabricksParameters.ServerSidePropertyPrefix + "statement_timeout"] = "12345",
+                [DatabricksParameters.ApplySSPWithQueries] = applyWithQueries.ToString().ToLower()
+            };
+            using var connection = NewConnection(TestConfiguration, additionalConnectionParams);
+
+            using var statement = connection.CreateStatement();
+            statement.SqlQuery = "SET";
+
+            var result = await statement.ExecuteQueryAsync();
+            Assert.NotNull(result.Stream);
+
+            var batch = await result.Stream.ReadNextRecordBatchAsync();
+            Assert.NotNull(batch);
+            Assert.True(batch.Length > 0);
+            Assert.Equal(2, batch.ColumnCount);
+
+            var returnedProperties = new Dictionary<string, string>();
+            var keys = (StringArray)batch.Column(0);
+            var values = (StringArray)batch.Column(1);
+            for (int i = 0; i < batch.Length; i++)
+            {
+                returnedProperties[keys.GetString(i)] = values.GetString(i);
+            }
+
+            Assert.True(
+                returnedProperties.ContainsKey("use_cached_result"),
+                $"SEA path (apply_ssp_with_queries={applyWithQueries}) failed to set use_cached_result");
+            Assert.Equal("false", returnedProperties["use_cached_result"]);
+
+            Assert.True(
+                returnedProperties.ContainsKey("statement_timeout"),
+                $"SEA path (apply_ssp_with_queries={applyWithQueries}) failed to set statement_timeout");
+            Assert.Equal("12345", returnedProperties["statement_timeout"]);
+        }
     }
 }

--- a/csharp/test/Unit/StatementExecution/StatementExecutionConnectionSspTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionConnectionSspTests.cs
@@ -178,5 +178,55 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
             // CreateSession should only be called once
             Assert.Single(bodies);
         }
+
+        /// <summary>
+        /// PECO-3062: when <c>adbc.databricks.apply_ssp_with_queries=true</c>, SSPs must
+        /// NOT be sent in <c>CreateSession.session_confs</c>. Instead, they are applied
+        /// via post-open <c>SET key=value</c> statements (mirrors the Thrift path).
+        ///
+        /// This is a deterministic wire-proof: the assertion fails on the broken code
+        /// (which always packs SSPs into session_confs regardless of the flag) and
+        /// passes once <c>StatementExecutionConnection</c> honors the flag.
+        /// </summary>
+        [Fact]
+        public async Task OpenAsync_WithApplySSPWithQueries_OmitsSessionConfs()
+        {
+            var (httpClient, _, bodies) = CreateCapturingHttpClient();
+            var properties = BaseProperties();
+            properties["adbc.databricks.ssp_ansi_mode"] = "true";
+            properties["adbc.databricks.ssp_timezone"] = "UTC";
+            properties[DatabricksParameters.ApplySSPWithQueries] = "true";
+
+            using var conn = new StatementExecutionConnection(properties, httpClient);
+            await conn.OpenAsync(CancellationToken.None);
+
+            Assert.Single(bodies);
+            // The CreateSession body must not contain session_confs nor the SSP values —
+            // they are deferred to post-open SET statements.
+            Assert.DoesNotContain("session_confs", bodies[0]);
+            Assert.DoesNotContain("ansi_mode", bodies[0]);
+            Assert.DoesNotContain("UTC", bodies[0]);
+        }
+
+        /// <summary>
+        /// PECO-3062: when <c>apply_ssp_with_queries=false</c> (the default), SSPs
+        /// continue to ride in <c>CreateSession.session_confs</c> as before. Locks
+        /// the existing behavior so the new flag handling doesn't regress callers.
+        /// </summary>
+        [Fact]
+        public async Task OpenAsync_WithApplySSPWithQueriesFalse_KeepsSessionConfs()
+        {
+            var (httpClient, _, bodies) = CreateCapturingHttpClient();
+            var properties = BaseProperties();
+            properties["adbc.databricks.ssp_ansi_mode"] = "true";
+            properties[DatabricksParameters.ApplySSPWithQueries] = "false";
+
+            using var conn = new StatementExecutionConnection(properties, httpClient);
+            await conn.OpenAsync(CancellationToken.None);
+
+            Assert.Single(bodies);
+            Assert.Contains("\"session_confs\"", bodies[0]);
+            Assert.Contains("ansi_mode", bodies[0]);
+        }
     }
 }


### PR DESCRIPTION
## What's Changed

The SEA path silently ignored the `adbc.databricks.apply_ssp_with_queries` flag — SSPs (`adbc.databricks.ssp_*`) were always packed into `CreateSession.session_confs` regardless of the user's choice, breaking parity with the Thrift driver where the flag controls whether SSPs ride in `OpenSession.Configuration` (flag=false) or are applied via post-open `SET key=value` statements (flag=true).

This PR plumbs the flag through `StatementExecutionConnection`, gates the `CreateSessionRequest.SessionConfigs` payload on `!apply_ssp_with_queries`, and adds an `ApplyServerSidePropertiesAsync()` helper that mirrors the Thrift path's SET-statement loop. `DatabricksDatabase.Connect` now invokes the helper after the SEA `OpenAsync`, directly mirroring the existing Thrift wiring two lines below.

## Why

PECO-3062 — `adbc.databricks.apply_ssp_with_queries` M3 remaining parameter gap.

**Scope note:** the ticket envelope mentioned passing SSPs via the SEA `ExecuteStatement` request body. Verified against `StatementExecutionModels.cs` and the JDBC reference (`databricks-jdbc/src/main/java/com/databricks/jdbc/model/client/sqlexec/ExecuteStatementRequest.java`): the SEA API has no per-statement `session_configs` field. JDBC has the same constraint — and JDBC doesn't expose `apply_ssp_with_queries` at all (always uses session_confs). The achievable parity is therefore "mirror Thrift's two-mode behavior", which this PR delivers. The session retains SET state for subsequent statements, so the observable end-state matches Thrift in both modes.

## Red → Green proof

**Unit test (deterministic wire proof) — `OpenAsync_WithApplySSPWithQueries_OmitsSessionConfs`:**

Before fix:
```
[xUnit.net 00:00:00.24]     AdbcDrivers.Databricks.Tests.Unit.StatementExecution.StatementExecutionConnectionSspTests.OpenAsync_WithApplySSPWithQueries_OmitsSessionConfs [FAIL]
  Error Message:
   Assert.DoesNotContain() Failure: Sub-string found
                                ↓ (pos 51)
String: ···"","catalog":"main","session_confs":{"ansi"···
Found:  "session_confs"
Failed!  - Failed: 1, Passed: 1, Skipped: 0, Total: 2
```

After fix:
```
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2, Duration: 71 ms - AdbcDrivers.Databricks.Tests.dll (net8.0)
```

**E2E tests against live pecotesting warehouse — `TestServerSidePropertyOnSeaPath`:**

```
  Passed AdbcDrivers.Databricks.Tests.ServerSidePropertyE2ETest.TestServerSidePropertyOnSeaPath(applyWithQueries: True) [2 s]
Property: ansi_mode = false
Property: enable_photon = true
Property: spark.thriftserver.arrowBasedRowSet.timestampAsString = false
Property: statement_timeout = 12345
Property: use_cached_result = false
  Passed AdbcDrivers.Databricks.Tests.ServerSidePropertyE2ETest.TestServerSidePropertyOnSeaPath(applyWithQueries: False) [1 s]
Test Run Successful.
Total tests: 2  Passed: 2
```

Full `ServerSidePropertyE2ETest` class (4 tests including the pre-existing Thrift cases) all green:
```
Test Run Successful.
Total tests: 4  Passed: 4  Total time: 5.8088 Seconds
```

## Files touched

- `csharp/src/StatementExecution/StatementExecutionConnection.cs` — parse flag; gate session_confs; add `ApplyServerSidePropertiesAsync`.
- `csharp/src/DatabricksDatabase.cs` — invoke `ApplyServerSidePropertiesAsync` on SEA path after `OpenAsync` (one-line wiring mirroring the existing Thrift call directly below).
- `csharp/test/E2E/ServerSidePropertyE2ETest.cs` — new `[SkippableTheory]` `TestServerSidePropertyOnSeaPath(applyWithQueries)` forcing `protocol=rest`.
- `csharp/test/Unit/StatementExecution/StatementExecutionConnectionSspTests.cs` — added two unit tests for the wire-level behavior.

## Manual verification

- [x] Build green on `netstandard2.0` + `net8.0` (macOS does not include `net472` in the build matrix)
- [x] All 9 unit tests in `StatementExecutionConnectionSspTests` pass
- [x] All 4 E2E tests in `ServerSidePropertyE2ETest` pass against live warehouse
- [ ] `pre-commit run --all-files` — environmental failure (sandbox blocks network for ruff/golangci installs); no C# pre-commit hook configured

PECO-3062