### PR TITLE
fix(csharp)!: consolidate SEA polling interval onto polltime_ms (PECO-3064) [SEA]

### DIFF
--- a/csharp/README.md
+++ b/csharp/README.md
@@ -286,7 +286,7 @@ The driver supports both Thrift/HiveServer2 protocol (default) and Statement Exe
 
 **REST API Configuration (SEA-only):**
 
-These properties apply only when `adbc.databricks.protocol=rest`. The cross-protocol polling interval is controlled by `adbc.apache.statement.polltime_ms` (see *Core Spark Properties* — SEA default `1000` ms).
+These properties apply only when `adbc.databricks.protocol=rest`.
 
 | Property | Description | SEA Default |
 |----------|-------------|-------------|

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -191,23 +191,21 @@ The Databricks driver supports two protocols: **Thrift** (default, HiveServer2) 
 | Property | Description | Thrift Default | SEA Default |
 |----------|-------------|----------------|-------------|
 | `uri` | Full connection URI (alternative to host/port/path) | (required if no host/path) | (required if no host/path) |
-| `adbc.spark.type` | Server type: `http` | `http` | `http` |
+| `adbc.spark.type` | Server type: `http` | `http` | Not Supported (SEA is always HTTPS) |
 | `adbc.spark.host` | Hostname without scheme/port | (required) | (required) |
-| `adbc.spark.port` | Connection port | `443` | `443` |
+| `adbc.spark.port` | Connection port | `443` | Not Supported (HTTPS port from URI) |
 | `adbc.spark.path` | URI path on server | (required) | (required) |
-| `adbc.spark.token` | Token for token-based authentication | (none) | (none) |
-| `username` | Username for basic authentication | Not Supported | Not Supported |
-| `password` | Password for basic authentication | Not Supported | Not Supported |
+| `adbc.spark.token` | Token for token-based authentication | (none) | Not Supported (use `adbc.spark.auth_type=oauth` + `adbc.spark.access_token`) |
 | `adbc.spark.connect_timeout_ms` | Session establishment timeout (ms) | `30000` | Not Supported |
 | `adbc.apache.statement.query_timeout_s` | Query execution timeout (s) | `60` | Not Supported |
 | `adbc.apache.statement.polltime_ms` | Query status polling interval (ms) | `100` (Apache base: `500`) | `1000` |
 | `adbc.apache.statement.batch_size` | Max rows per batch request | `2000000` (Apache base: `50000`) | Not Supported |
-| `adbc.spark.data_type_conv` | Data type conversion: `none` or `scalar` | `scalar` | `scalar` |
+| `adbc.spark.data_type_conv` | Data type conversion: `none` or `scalar` | `scalar` | Not Supported (SEA already returns native Arrow types) |
 | `adbc.spark.user_agent_entry` | Additional user agent string appended to driver user agent | (none) | (none) |
 
 **Notes:**
 - Either `uri` or the combination of `adbc.spark.host` + `adbc.spark.path` is required.
-- Basic auth (`username` / `password`) is not supported on either protocol; use `adbc.spark.auth_type=oauth`.
+- Basic auth (`username` / `password`) is not supported against Databricks workspaces; use `adbc.spark.auth_type=oauth`. The Thrift base layer accepts the parameters and emits a Basic auth header, but the Databricks gateway rejects it; the SEA path doesn't wire the parameters through at all.
 - `polltime_ms` has divergent defaults: Thrift polls cheap RPCs at 100 ms; SEA polls HTTP/JSON at 1000 ms.
 
 #### Databricks-Specific Properties

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -197,7 +197,7 @@ The Databricks driver supports two protocols: **Thrift** (default, HiveServer2) 
 | `adbc.spark.path` | URI path on server | (required) | (required) |
 | `adbc.spark.token` | Token for token-based authentication | (none) | Not Supported (use `adbc.spark.auth_type=oauth` + `adbc.spark.access_token`) |
 | `adbc.spark.connect_timeout_ms` | Session establishment timeout (ms) | `30000` | Not Supported |
-| `adbc.apache.statement.query_timeout_s` | Query execution timeout (s) | `60` | Not Supported |
+| `adbc.apache.statement.query_timeout_s` | Query execution timeout (s); `0` means no timeout | `60` | `0` |
 | `adbc.apache.statement.polltime_ms` | Query status polling interval (ms) | `100` (Apache base: `500`) | `1000` |
 | `adbc.apache.statement.batch_size` | Max rows per batch request | `2000000` (Apache base: `50000`) | Not Supported |
 | `adbc.spark.data_type_conv` | Data type conversion: `none` or `scalar` | `scalar` | Not Supported (SEA already returns native Arrow types) |

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -184,7 +184,7 @@ var config = new Dictionary<string, string>
 
 ### Connection Properties
 
-The Databricks driver supports two protocols: **Thrift** (default, HiveServer2) and **SEA** (Statement Execution REST API, opt-in via `adbc.databricks.protocol=rest`). The tables below show per-protocol defaults; an em-dash (`—`) means the property is not honored on that protocol.
+The Databricks driver supports two protocols: **Thrift** (default, HiveServer2) and **SEA** (Statement Execution REST API, opt-in via `adbc.databricks.protocol=rest`). The tables below show per-protocol defaults; `Not Supported` means the property is not honored on that protocol.
 
 #### Core Spark Properties (Inherited)
 
@@ -196,12 +196,12 @@ The Databricks driver supports two protocols: **Thrift** (default, HiveServer2) 
 | `adbc.spark.port` | Connection port | `443` | `443` |
 | `adbc.spark.path` | URI path on server | (required) | (required) |
 | `adbc.spark.token` | Token for token-based authentication | (none) | (none) |
-| `username` | Username for basic authentication | — | — |
-| `password` | Password for basic authentication | — | — |
-| `adbc.spark.connect_timeout_ms` | Session establishment timeout (ms) | `30000` | — |
-| `adbc.apache.statement.query_timeout_s` | Query execution timeout (s) | `60` | — |
+| `username` | Username for basic authentication | Not Supported | Not Supported |
+| `password` | Password for basic authentication | Not Supported | Not Supported |
+| `adbc.spark.connect_timeout_ms` | Session establishment timeout (ms) | `30000` | Not Supported |
+| `adbc.apache.statement.query_timeout_s` | Query execution timeout (s) | `60` | Not Supported |
 | `adbc.apache.statement.polltime_ms` | Query status polling interval (ms) | `100` (Apache base: `500`) | `1000` |
-| `adbc.apache.statement.batch_size` | Max rows per batch request | `2000000` (Apache base: `50000`) | — |
+| `adbc.apache.statement.batch_size` | Max rows per batch request | `2000000` (Apache base: `50000`) | Not Supported |
 | `adbc.spark.data_type_conv` | Data type conversion: `none` or `scalar` | `scalar` | `scalar` |
 | `adbc.spark.user_agent_entry` | Additional user agent string appended to driver user agent | (none) | (none) |
 
@@ -217,24 +217,24 @@ The Databricks driver supports two protocols: **Thrift** (default, HiveServer2) 
 | `adbc.connection.catalog` | Default catalog for session | (server default) | (server default) |
 | `adbc.connection.db_schema` | Default schema for session | (server default) | (server default) |
 | `adbc.databricks.enable_direct_results` | Use direct results when executing | `true` | `true` |
-| `adbc.databricks.max_bytes_per_fetch_request` | Max bytes per fetch request (supports B, KB, MB, GB) | `400MB` | — |
-| `adbc.databricks.apply_ssp_with_queries` | Apply server-side properties with queries | `false` | — |
+| `adbc.databricks.max_bytes_per_fetch_request` | Max bytes per fetch request (supports B, KB, MB, GB) | `400MB` | Not Supported |
+| `adbc.databricks.apply_ssp_with_queries` | Apply server-side properties with queries | `false` | Not Supported |
 | `adbc.databricks.enable_multiple_catalog_support` | Support multiple catalogs | `true` | `true` |
 | `adbc.databricks.enable_pk_fk` | Enable primary/foreign key metadata | `true` | `true` |
 | `adbc.databricks.use_desc_table_extended` | Use DESC TABLE EXTENDED when supported | `true` | `true` |
-| `adbc.databricks.enable_run_async_thrift` | Enable RunAsync flag | `true` | — (Thrift-only concept) |
+| `adbc.databricks.enable_run_async_thrift` | Enable RunAsync flag | `true` | Not Supported (Thrift-only concept) |
 | `adbc.databricks.enable_complex_datatype_support` | Return native Arrow types for ARRAY/MAP/STRUCT | `false` | `false` |
-| `adbc.databricks.fetch_heartbeat_interval` | Heartbeat interval for long operations (s) | `60` | — (no fetch-handle to keep warm) |
-| `adbc.databricks.operation_status_request_timeout` | Timeout for status polling requests (s) | `30` | — |
+| `adbc.databricks.fetch_heartbeat_interval` | Heartbeat interval for long operations (s) | `60` | Not Supported (no fetch-handle to keep warm) |
+| `adbc.databricks.operation_status_request_timeout` | Timeout for status polling requests (s) | `30` | Not Supported |
 | `adbc.spark.temporarily_unavailable_retry` | Retry on 408/502/503/504 responses | `true` | `true` |
 | `adbc.spark.temporarily_unavailable_retry_timeout` | Max retry time for 4xx/5xx errors (s) | `900` | `900` |
 | `adbc.databricks.rate_limit_retry` | Retry on HTTP 429 (rate limit) responses | `true` | `true` |
 | `adbc.databricks.rate_limit_retry_timeout` | Max retry time for rate limits (s) | `120` | `120` |
 | `adbc.databricks.query_tags` | Key-value tags attached to queries (e.g. `key1=val1,key2=val2`) | (none) | (none) |
 | `adbc.databricks.identity_federation_client_id` | Service principal client ID for workload identity | (none) | (none) |
-| `adbc.databricks.feature_flag_cache_enabled` | Fetch and apply server-side feature flags | `true` | — |
-| `adbc.databricks.feature_flag_timeout_seconds` | Timeout for feature flag fetch requests | `10` | — |
-| `adbc.databricks.feature_flag_cache_ttl_seconds` | TTL for cached feature flags | `900` | — |
+| `adbc.databricks.feature_flag_cache_enabled` | Fetch and apply server-side feature flags | `true` | Not Supported |
+| `adbc.databricks.feature_flag_timeout_seconds` | Timeout for feature flag fetch requests | `10` | Not Supported |
+| `adbc.databricks.feature_flag_cache_ttl_seconds` | TTL for cached feature flags | `900` | Not Supported |
 | `adbc.databricks.ssp_<name>` | Pass session configuration (e.g., `ssp_use_cached_result=true`) | (none) | (none) |
 
 **Performance Notes:**
@@ -251,18 +251,18 @@ On the SEA path, CloudFetch-equivalent behavior is controlled via `adbc.databric
 
 | Property | Description | Thrift Default | SEA Default |
 |----------|-------------|----------------|-------------|
-| `adbc.databricks.cloudfetch.enabled` | Enable/disable CloudFetch | `true` | — |
-| `adbc.databricks.cloudfetch.lz4.enabled` | Enable LZ4 decompression | `true` | — |
-| `adbc.databricks.cloudfetch.max_bytes_per_file` | Max bytes per file (supports KB, MB, GB) | `20MB` | — |
-| `adbc.databricks.cloudfetch.parallel_downloads` | Max parallel downloads | `3` | — |
-| `adbc.databricks.cloudfetch.prefetch_count` | Files to prefetch ahead | `2` | — |
-| `adbc.databricks.cloudfetch.memory_buffer_size_mb` | Max memory buffer in MB | `200` | — |
-| `adbc.databricks.cloudfetch.prefetch_enabled` | Enable prefetch | `true` | — |
-| `adbc.databricks.cloudfetch.max_retries` | Max retry attempts | `3` | — |
-| `adbc.databricks.cloudfetch.retry_delay_ms` | Delay between retries (ms) | `500` | — |
+| `adbc.databricks.cloudfetch.enabled` | Enable/disable CloudFetch | `true` | Not Supported |
+| `adbc.databricks.cloudfetch.lz4.enabled` | Enable LZ4 decompression | `true` | Not Supported |
+| `adbc.databricks.cloudfetch.max_bytes_per_file` | Max bytes per file (supports KB, MB, GB) | `20MB` | Not Supported |
+| `adbc.databricks.cloudfetch.parallel_downloads` | Max parallel downloads | `3` | Not Supported |
+| `adbc.databricks.cloudfetch.prefetch_count` | Files to prefetch ahead | `2` | Not Supported |
+| `adbc.databricks.cloudfetch.memory_buffer_size_mb` | Max memory buffer in MB | `200` | Not Supported |
+| `adbc.databricks.cloudfetch.prefetch_enabled` | Enable prefetch | `true` | Not Supported |
+| `adbc.databricks.cloudfetch.max_retries` | Max retry attempts | `3` | Not Supported |
+| `adbc.databricks.cloudfetch.retry_delay_ms` | Delay between retries (ms) | `500` | Not Supported |
 | `adbc.databricks.cloudfetch.timeout_minutes` | HTTP operation timeout (min) | `5` | `5` (via shared HttpClient timeout) |
-| `adbc.databricks.cloudfetch.url_expiration_buffer_seconds` | URL refresh buffer (s) | `60` | — |
-| `adbc.databricks.cloudfetch.max_url_refresh_attempts` | Max URL refresh attempts | `3` | — |
+| `adbc.databricks.cloudfetch.url_expiration_buffer_seconds` | URL refresh buffer (s) | `60` | Not Supported |
+| `adbc.databricks.cloudfetch.max_url_refresh_attempts` | Max URL refresh attempts | `3` | Not Supported |
 
 **Example Configuration:**
 ```csharp

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -167,7 +167,7 @@ var config = new Dictionary<string, string>
 
 **Note:** OAuth U2M (User-to-Machine) authentication support is planned for a future release.
 
-**Authentication Properties:**
+**Authentication Properties** (apply to both Thrift and SEA):
 
 | Property | Description | Default |
 |----------|-------------|---------|
@@ -184,54 +184,62 @@ var config = new Dictionary<string, string>
 
 ### Connection Properties
 
+The Databricks driver supports two protocols: **Thrift** (default, HiveServer2) and **SEA** (Statement Execution REST API, opt-in via `adbc.databricks.protocol=rest`). The tables below show per-protocol defaults; an em-dash (`—`) means the property is not honored on that protocol.
+
 #### Core Spark Properties (Inherited)
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `uri` | Full connection URI (alternative to host/port/path) | |
-| `adbc.spark.type` | Server type: `http` | `http` |
-| `adbc.spark.host` | Hostname without scheme/port | |
-| `adbc.spark.port` | Connection port | `443` |
-| `adbc.spark.path` | URI path on server | |
-| `adbc.spark.token` | Token for token-based authentication | |
-| `username` | Username for basic authentication | |
-| `password` | Password for basic authentication | |
-| `adbc.spark.connect_timeout_ms` | Session establishment timeout | `30000` |
-| `adbc.apache.statement.query_timeout_s` | Query execution timeout | `60` |
-| `adbc.apache.statement.polltime_ms` | Query status polling interval | `500` (Databricks: `100`) |
-| `adbc.apache.statement.batch_size` | Max rows per batch request | `50000` (Databricks: `2000000`) |
-| `adbc.spark.data_type_conv` | Data type conversion: `none` or `scalar` | `scalar` |
-| `adbc.spark.user_agent_entry` | Additional user agent string appended to driver user agent | |
+| Property | Description | Thrift Default | SEA Default |
+|----------|-------------|----------------|-------------|
+| `uri` | Full connection URI (alternative to host/port/path) | (required if no host/path) | (required if no host/path) |
+| `adbc.spark.type` | Server type: `http` | `http` | `http` |
+| `adbc.spark.host` | Hostname without scheme/port | (required) | (required) |
+| `adbc.spark.port` | Connection port | `443` | `443` |
+| `adbc.spark.path` | URI path on server | (required) | (required) |
+| `adbc.spark.token` | Token for token-based authentication | (none) | (none) |
+| `username` | Username for basic authentication | — | — |
+| `password` | Password for basic authentication | — | — |
+| `adbc.spark.connect_timeout_ms` | Session establishment timeout (ms) | `30000` | — |
+| `adbc.apache.statement.query_timeout_s` | Query execution timeout (s) | `60` | — |
+| `adbc.apache.statement.polltime_ms` | Query status polling interval (ms) | `100` (Apache base: `500`) | `1000` |
+| `adbc.apache.statement.batch_size` | Max rows per batch request | `2000000` (Apache base: `50000`) | — |
+| `adbc.spark.data_type_conv` | Data type conversion: `none` or `scalar` | `scalar` | `scalar` |
+| `adbc.spark.user_agent_entry` | Additional user agent string appended to driver user agent | (none) | (none) |
 
-**Note:** Either `uri` or the combination of `adbc.spark.host` + `adbc.spark.path` is required.
+**Notes:**
+- Either `uri` or the combination of `adbc.spark.host` + `adbc.spark.path` is required.
+- Basic auth (`username` / `password`) is not supported on either protocol; use `adbc.spark.auth_type=oauth`.
+- `polltime_ms` has divergent defaults: Thrift polls cheap RPCs at 100 ms; SEA polls HTTP/JSON at 1000 ms.
 
 #### Databricks-Specific Properties
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `adbc.connection.catalog` | Default catalog for session | |
-| `adbc.connection.db_schema` | Default schema for session | |
-| `adbc.databricks.enable_direct_results` | Use direct results when executing | `true` |
-| `adbc.databricks.max_bytes_per_fetch_request` | Max bytes per fetch request (supports B, KB, MB, GB) | `400MB` |
-| `adbc.databricks.apply_ssp_with_queries` | Apply server-side properties with queries | `false` |
-| `adbc.databricks.enable_multiple_catalog_support` | Support multiple catalogs | `true` |
-| `adbc.databricks.enable_pk_fk` | Enable primary/foreign key metadata | `true` |
-| `adbc.databricks.use_desc_table_extended` | Use DESC TABLE EXTENDED when supported | `true` |
-| `adbc.databricks.enable_run_async_thrift` | Enable RunAsync flag | `true` |
-| `adbc.databricks.fetch_heartbeat_interval` | Heartbeat interval for long operations (seconds) | `60` |
-| `adbc.databricks.operation_status_request_timeout` | Timeout for status polling requests (seconds) | `30` |
-| `adbc.spark.temporarily_unavailable_retry` | Retry on 408/502/503/504 responses | `true` |
-| `adbc.spark.temporarily_unavailable_retry_timeout` | Max retry time for 4xx/5xx errors (seconds) | `900` |
-| `adbc.databricks.rate_limit_retry` | Retry on HTTP 429 (rate limit) responses | `true` |
-| `adbc.databricks.rate_limit_retry_timeout` | Max retry time for rate limits (seconds) | `120` |
-| `adbc.databricks.query_tags` | Key-value tags attached to queries (e.g. `key1=val1,key2=val2`) | |
-| `adbc.databricks.feature_flag_cache_enabled` | Fetch and apply server-side feature flags | `true` |
-| `adbc.databricks.feature_flag_timeout_seconds` | Timeout for feature flag fetch requests | `10` |
-| `adbc.databricks.feature_flag_cache_ttl_seconds` | TTL for cached feature flags | `900` |
+| Property | Description | Thrift Default | SEA Default |
+|----------|-------------|----------------|-------------|
+| `adbc.connection.catalog` | Default catalog for session | (server default) | (server default) |
+| `adbc.connection.db_schema` | Default schema for session | (server default) | (server default) |
+| `adbc.databricks.enable_direct_results` | Use direct results when executing | `true` | `true` |
+| `adbc.databricks.max_bytes_per_fetch_request` | Max bytes per fetch request (supports B, KB, MB, GB) | `400MB` | — |
+| `adbc.databricks.apply_ssp_with_queries` | Apply server-side properties with queries | `false` | — |
+| `adbc.databricks.enable_multiple_catalog_support` | Support multiple catalogs | `true` | `true` |
+| `adbc.databricks.enable_pk_fk` | Enable primary/foreign key metadata | `true` | `true` |
+| `adbc.databricks.use_desc_table_extended` | Use DESC TABLE EXTENDED when supported | `true` | `true` |
+| `adbc.databricks.enable_run_async_thrift` | Enable RunAsync flag | `true` | — (Thrift-only concept) |
+| `adbc.databricks.enable_complex_datatype_support` | Return native Arrow types for ARRAY/MAP/STRUCT | `false` | `false` |
+| `adbc.databricks.fetch_heartbeat_interval` | Heartbeat interval for long operations (s) | `60` | — (no fetch-handle to keep warm) |
+| `adbc.databricks.operation_status_request_timeout` | Timeout for status polling requests (s) | `30` | — |
+| `adbc.spark.temporarily_unavailable_retry` | Retry on 408/502/503/504 responses | `true` | `true` |
+| `adbc.spark.temporarily_unavailable_retry_timeout` | Max retry time for 4xx/5xx errors (s) | `900` | `900` |
+| `adbc.databricks.rate_limit_retry` | Retry on HTTP 429 (rate limit) responses | `true` | `true` |
+| `adbc.databricks.rate_limit_retry_timeout` | Max retry time for rate limits (s) | `120` | `120` |
+| `adbc.databricks.query_tags` | Key-value tags attached to queries (e.g. `key1=val1,key2=val2`) | (none) | (none) |
+| `adbc.databricks.identity_federation_client_id` | Service principal client ID for workload identity | (none) | (none) |
+| `adbc.databricks.feature_flag_cache_enabled` | Fetch and apply server-side feature flags | `true` | — |
+| `adbc.databricks.feature_flag_timeout_seconds` | Timeout for feature flag fetch requests | `10` | — |
+| `adbc.databricks.feature_flag_cache_ttl_seconds` | TTL for cached feature flags | `900` | — |
+| `adbc.databricks.ssp_<name>` | Pass session configuration (e.g., `ssp_use_cached_result=true`) | (none) | (none) |
 
 **Performance Notes:**
-- Databricks default `batch_size` is `2000000` (vs Spark's `50000`) - optimized for CloudFetch's 1024MB limit
-- Databricks default `polltime_ms` is `100` (vs Spark's `500`) - faster query status feedback
+- Databricks Thrift default `batch_size` is `2000000` (vs Apache Spark's `50000`) — optimized for CloudFetch's 1024MB limit.
+- `polltime_ms` defaults differ by protocol (see Core Spark Properties table); SEA's 1000 ms reflects heavier HTTP/JSON polling cost.
 
 ### CloudFetch Configuration
 
@@ -239,20 +247,22 @@ CloudFetch is Databricks' high-performance result retrieval system that download
 
 **CloudFetch Properties:**
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `adbc.databricks.cloudfetch.enabled` | Enable/disable CloudFetch | `true` |
-| `adbc.databricks.cloudfetch.lz4.enabled` | Enable LZ4 decompression | `true` |
-| `adbc.databricks.cloudfetch.max_bytes_per_file` | Max bytes per file (supports KB, MB, GB) | `20MB` |
-| `adbc.databricks.cloudfetch.parallel_downloads` | Max parallel downloads | `3` |
-| `adbc.databricks.cloudfetch.prefetch_count` | Files to prefetch ahead | `2` |
-| `adbc.databricks.cloudfetch.memory_buffer_size_mb` | Max memory buffer in MB | `200` |
-| `adbc.databricks.cloudfetch.prefetch_enabled` | Enable prefetch | `true` |
-| `adbc.databricks.cloudfetch.max_retries` | Max retry attempts | `3` |
-| `adbc.databricks.cloudfetch.retry_delay_ms` | Delay between retries | `500` |
-| `adbc.databricks.cloudfetch.timeout_minutes` | HTTP operation timeout | `5` |
-| `adbc.databricks.cloudfetch.url_expiration_buffer_seconds` | URL refresh buffer | `60` |
-| `adbc.databricks.cloudfetch.max_url_refresh_attempts` | Max URL refresh attempts | `3` |
+On the SEA path, CloudFetch-equivalent behavior is controlled via `adbc.databricks.rest.result_disposition` (see *REST API Configuration* below). The `adbc.databricks.cloudfetch.*` keys below apply to the Thrift path only.
+
+| Property | Description | Thrift Default | SEA Default |
+|----------|-------------|----------------|-------------|
+| `adbc.databricks.cloudfetch.enabled` | Enable/disable CloudFetch | `true` | — |
+| `adbc.databricks.cloudfetch.lz4.enabled` | Enable LZ4 decompression | `true` | — |
+| `adbc.databricks.cloudfetch.max_bytes_per_file` | Max bytes per file (supports KB, MB, GB) | `20MB` | — |
+| `adbc.databricks.cloudfetch.parallel_downloads` | Max parallel downloads | `3` | — |
+| `adbc.databricks.cloudfetch.prefetch_count` | Files to prefetch ahead | `2` | — |
+| `adbc.databricks.cloudfetch.memory_buffer_size_mb` | Max memory buffer in MB | `200` | — |
+| `adbc.databricks.cloudfetch.prefetch_enabled` | Enable prefetch | `true` | — |
+| `adbc.databricks.cloudfetch.max_retries` | Max retry attempts | `3` | — |
+| `adbc.databricks.cloudfetch.retry_delay_ms` | Delay between retries (ms) | `500` | — |
+| `adbc.databricks.cloudfetch.timeout_minutes` | HTTP operation timeout (min) | `5` | `5` (via shared HttpClient timeout) |
+| `adbc.databricks.cloudfetch.url_expiration_buffer_seconds` | URL refresh buffer (s) | `60` | — |
+| `adbc.databricks.cloudfetch.max_url_refresh_attempts` | Max URL refresh attempts | `3` | — |
 
 **Example Configuration:**
 ```csharp
@@ -276,15 +286,16 @@ The driver supports both Thrift/HiveServer2 protocol (default) and Statement Exe
 | `adbc.databricks.protocol` | Protocol: `thrift` or `rest` | `thrift` |
 | `adbc.databricks.warehouse_id` | Warehouse ID for query execution | (required for REST) |
 
-**REST API Configuration:**
+**REST API Configuration (SEA-only):**
 
-| Property | Description | Default |
-|----------|-------------|---------|
+These properties apply only when `adbc.databricks.protocol=rest`. The cross-protocol polling interval is controlled by `adbc.apache.statement.polltime_ms` (see *Core Spark Properties* — SEA default `1000` ms).
+
+| Property | Description | SEA Default |
+|----------|-------------|-------------|
 | `adbc.databricks.rest.result_disposition` | Result mode: `inline`, `external_links`, or `inline_or_external_links` | `inline_or_external_links` |
 | `adbc.databricks.rest.result_format` | Format: `arrow_stream`, `json_array`, or `csv` | `arrow_stream` |
 | `adbc.databricks.rest.result_compression` | Compression: `lz4`, `gzip`, or `none` | (auto) |
 | `adbc.databricks.rest.wait_timeout` | Wait timeout in seconds (0=async, 5-50=sync) | `10` |
-| `adbc.databricks.rest.polling_interval_ms` | Polling interval for async execution (ms) | `1000` |
 | `adbc.databricks.rest.enable_session_management` | Enable session management | `true` |
 
 **Example - Using REST Protocol:**
@@ -302,6 +313,8 @@ var config = new Dictionary<string, string>
 ```
 
 ### TLS/SSL Configuration
+
+Applies to both Thrift and SEA.
 
 | Property | Description | Default |
 |----------|-------------|---------|
@@ -339,7 +352,7 @@ var config = new Dictionary<string, string>
 
 ### Proxy Configuration
 
-The driver supports HTTP proxy configuration for enterprise network environments.
+The driver supports HTTP proxy configuration for enterprise network environments. Applies to both Thrift and SEA.
 
 | Property | Description | Default |
 |----------|-------------|---------|
@@ -421,7 +434,7 @@ var config = new Dictionary<string, string>
 
 The driver includes built-in tracing support via OpenTelemetry.
 
-**Tracing Properties:**
+**Tracing Properties** (apply to both Thrift and SEA):
 
 | Property | Description | Default |
 |----------|-------------|---------|

--- a/csharp/doc/statement-execution-api-design.md
+++ b/csharp/doc/statement-execution-api-design.md
@@ -613,11 +613,9 @@ public const string WaitTimeout = "adbc.databricks.rest.wait_timeout";
 /// </summary>
 public const string EnableDirectResults = "adbc.databricks.enable_direct_results";
 
-/// <summary>
-/// Statement polling interval in milliseconds for async execution.
-/// Default: 1000ms (1 second)
-/// </summary>
-public const string PollingInterval = "adbc.databricks.rest.polling_interval_ms";
+// Statement polling interval is shared with the Thrift path via
+// ApacheParameters.PollTimeMilliseconds (adbc.apache.statement.polltime_ms).
+// SEA default: 1000 ms (Thrift default: 100 ms).
 
 /// <summary>
 /// Enable session management for Statement Execution API.
@@ -1106,11 +1104,11 @@ internal class StatementExecutionStatement : AdbcStatement
             // First poll happens immediately (no delay)
             if (pollCount > 0)
             {
-                await Task.Delay(_connection.PollingInterval, cancellationToken);
+                await Task.Delay(_connection.PollingIntervalMs, cancellationToken);
             }
 
             // Check timeout
-            if (QueryTimeout > 0 && pollCount * _connection.PollingInterval > QueryTimeout * 1000)
+            if (QueryTimeout > 0 && pollCount * _connection.PollingIntervalMs > QueryTimeout * 1000)
             {
                 await _client.CancelStatementAsync(_statementId, cancellationToken);
                 throw new DatabricksTimeoutException(
@@ -2393,7 +2391,7 @@ internal class StatementExecutionResultFetcher : BaseResultFetcher
   "adbc.databricks.enable_session_management": "true",
   "adbc.databricks.enable_direct_results": "false",
   "adbc.databricks.rest.wait_timeout": "10",
-  "adbc.databricks.rest.polling_interval_ms": "1000",
+  "adbc.apache.statement.polltime_ms": "1000",
   "adbc.connection.catalog": "main",
   "adbc.connection.db_schema": "default",
   "adbc.spark.auth_type": "oauth",
@@ -2430,7 +2428,7 @@ internal class StatementExecutionResultFetcher : BaseResultFetcher
   "adbc.databricks.rest.wait_timeout": "10",
 
   // Polling interval for async queries
-  "adbc.databricks.rest.polling_interval_ms": "1000",
+  "adbc.apache.statement.polltime_ms": "1000",
 
   // CloudFetch configuration
   "adbc.databricks.cloudfetch.parallel_downloads": "3",
@@ -2585,7 +2583,6 @@ internal class StatementExecutionResultFetcher : BaseResultFetcher
    - [ ] Add `EnableDirectResults` parameter
    - [ ] Add `EnableSessionManagement` parameter
    - [ ] Add `WaitTimeout` parameter
-   - [ ] Add `PollingInterval` parameter
    - [ ] Add `WarehouseId` parameter
 
 6. **`DatabricksConnection.cs`**

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -412,6 +412,9 @@ namespace AdbcDrivers.Databricks
         /// Statement polling interval in milliseconds for async execution.
         /// Default: 1000ms (1 second)
         /// Only applicable when Protocol is "rest".
+        /// PECO-3064: <c>adbc.apache.statement.polltime_ms</c> (the Thrift-side key) is honored
+        /// as a legacy alias — if this canonical key is unset, the SEA path falls back to the
+        /// value of <c>polltime_ms</c>. When both are set, this canonical key takes precedence.
         /// </summary>
         public const string PollingInterval = "adbc.databricks.rest.polling_interval_ms";
 

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -409,16 +409,6 @@ namespace AdbcDrivers.Databricks
         public const string WaitTimeout = "adbc.databricks.rest.wait_timeout";
 
         /// <summary>
-        /// Statement polling interval in milliseconds for async execution.
-        /// Default: 1000ms (1 second)
-        /// Only applicable when Protocol is "rest".
-        /// PECO-3064: <c>adbc.apache.statement.polltime_ms</c> (the Thrift-side key) is honored
-        /// as a legacy alias — if this canonical key is unset, the SEA path falls back to the
-        /// value of <c>polltime_ms</c>. When both are set, this canonical key takes precedence.
-        /// </summary>
-        public const string PollingInterval = "adbc.databricks.rest.polling_interval_ms";
-
-        /// <summary>
         /// Enable session management for Statement Execution API.
         /// When true, creates and reuses session across statements in a connection.
         /// When false, each statement executes without session context.

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -230,16 +230,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 _waitTimeoutSeconds = 0;
             }
-            // PECO-3064: Honor the legacy adbc.apache.statement.polltime_ms key as a fallback
-            // for the SEA-native adbc.databricks.rest.polling_interval_ms. The canonical SEA
-            // key takes precedence when both are set; when only polltime_ms is set, it drives
-            // SEA's polling cadence so users don't silently fall back to the 1000ms default.
-            // (JDBC consolidates these under a single asyncexecpollinterval; we keep both keys
-            // for backward compatibility and document the precedence.)
-            int legacyPollTimeMs = PropertyHelper.GetPositiveIntPropertyWithValidation(
-                properties, ApacheParameters.PollTimeMilliseconds, defaultValue: 1000);
+            // PECO-3064: adbc.apache.statement.polltime_ms is the single key for SEA polling cadence
+            // (consolidated with the Thrift path). SEA defaults to 1000 ms — HTTP/JSON polls are
+            // heavier than Thrift's 100 ms default — but both protocols share the same property.
             _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(
-                properties, DatabricksParameters.PollingInterval, defaultValue: legacyPollTimeMs);
+                properties, ApacheParameters.PollTimeMilliseconds, defaultValue: 1000);
 
             // Memory pooling
             _recyclableMemoryStreamManager = memoryStreamManager ?? new Microsoft.IO.RecyclableMemoryStreamManager();

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -21,6 +21,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.Http;
+using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Hive2;
 using AdbcDrivers.Databricks.StatementExecution.MetadataCommands;
 using AdbcDrivers.HiveServer2.Spark;
@@ -229,7 +230,16 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 _waitTimeoutSeconds = 0;
             }
-            _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(properties, DatabricksParameters.PollingInterval, 1000);
+            // PECO-3064: Honor the legacy adbc.apache.statement.polltime_ms key as a fallback
+            // for the SEA-native adbc.databricks.rest.polling_interval_ms. The canonical SEA
+            // key takes precedence when both are set; when only polltime_ms is set, it drives
+            // SEA's polling cadence so users don't silently fall back to the 1000ms default.
+            // (JDBC consolidates these under a single asyncexecpollinterval; we keep both keys
+            // for backward compatibility and document the precedence.)
+            int legacyPollTimeMs = PropertyHelper.GetPositiveIntPropertyWithValidation(
+                properties, ApacheParameters.PollTimeMilliseconds, defaultValue: 1000);
+            _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(
+                properties, DatabricksParameters.PollingInterval, defaultValue: legacyPollTimeMs);
 
             // Memory pooling
             _recyclableMemoryStreamManager = memoryStreamManager ?? new Microsoft.IO.RecyclableMemoryStreamManager();

--- a/csharp/test/E2E/StatementExecution/StatementExecutionDriverE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/StatementExecutionDriverE2ETests.cs
@@ -444,31 +444,26 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             Assert.Equal(1, batch.Length);
         }
 
-        // PECO-3064: adbc.apache.statement.polltime_ms must be honored as an alias for
-        // adbc.databricks.rest.polling_interval_ms on the SEA path. The polling cadence drives
-        // total wall-clock for queries that complete async (wait_timeout=0): time-to-completion
-        // is dominated by the polling interval since the first GetStatement happens only after
-        // Task.Delay(_pollingIntervalMs). We exploit this to observe the effective interval.
+        // PECO-3064: adbc.apache.statement.polltime_ms is the single key driving SEA's polling
+        // cadence (consolidated with the Thrift path). The polling cadence dominates wall-clock
+        // for async queries (wait_timeout=0): the first GetStatement happens only after
+        // Task.Delay(_pollingIntervalMs), so an unusually large interval is directly observable.
         //
-        // Strategy:
         //  - wait_timeout=0 forces async-then-poll (no server-side block).
-        //  - polltime_ms=2000 is the only key set; canonical rest.polling_interval_ms is absent.
-        //  - With the fix, _pollingIntervalMs resolves to 2000ms → total wall-clock ~2s+.
-        //  - Pre-fix, polltime_ms is ignored, falling back to 1000ms default → wall-clock ~1s.
-        //  - Assert elapsed >= 1800ms to distinguish reliably (margin for fast/slow networks).
+        //  - enable_direct_results=false ensures wait_timeout isn't overridden by the connection.
+        //  - polltime_ms=2000 → total wall-clock >= 1800ms.
+        //  - If the SEA path were to ignore polltime_ms and fall back to the 1000ms default,
+        //    wall-clock would be ~1100ms and this test fails.
         [SkippableFact]
-        public void ExecuteQuery_PollTimeMsAlias_IsHonoredOnSeaPath()
+        public void ExecuteQuery_PollTimeMs_DrivesSeaPollingCadence()
         {
             SkipIfNotConfigured();
 
             const int slowPollMs = 2000;
             var extra = new Dictionary<string, string>
             {
-                // Legacy key only — no canonical rest.polling_interval_ms set.
                 [ApacheParameters.PollTimeMilliseconds] = slowPollMs.ToString(),
-                // Force the async-then-poll code path so the polling interval dominates wall-clock.
                 [DatabricksParameters.WaitTimeout] = "0",
-                // Also disable direct results so wait_timeout is not overridden by the connection.
                 [DatabricksParameters.EnableDirectResults] = "false",
             };
 
@@ -479,82 +474,14 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             var sw = Stopwatch.StartNew();
             var result = statement.ExecuteQuery();
             using var reader = result.Stream;
-            // Drain the stream so polling has fully completed.
             while (reader.ReadNextRecordBatchAsync().Result != null) { }
             sw.Stop();
 
-            // With polltime_ms honored as the SEA polling interval, the first GetStatement happens
-            // ~2000ms after ExecuteStatement returns PENDING, so wall-clock must be >= 1800ms.
-            // Pre-fix, polltime_ms is dropped, the default 1000ms applies, and wall-clock is ~1100ms.
             Assert.True(
                 sw.ElapsedMilliseconds >= 1800,
                 $"Expected polltime_ms={slowPollMs} to drive SEA polling cadence, but query " +
                 $"completed in {sw.ElapsedMilliseconds}ms (expected >= 1800ms). " +
-                $"This indicates the legacy polltime_ms alias is not wired into SEA's polling interval.");
-        }
-
-        // Sanity check: the canonical SEA key continues to work standalone (regression guard).
-        [SkippableFact]
-        public void ExecuteQuery_RestPollingIntervalMs_ContinuesToWork()
-        {
-            SkipIfNotConfigured();
-
-            const int slowPollMs = 2000;
-            var extra = new Dictionary<string, string>
-            {
-                [DatabricksParameters.PollingInterval] = slowPollMs.ToString(),
-                [DatabricksParameters.WaitTimeout] = "0",
-                [DatabricksParameters.EnableDirectResults] = "false",
-            };
-
-            using var connection = CreateRestConnection(extra);
-            using var statement = connection.CreateStatement();
-            statement.SqlQuery = "SELECT 1 AS value";
-
-            var sw = Stopwatch.StartNew();
-            var result = statement.ExecuteQuery();
-            using var reader = result.Stream;
-            while (reader.ReadNextRecordBatchAsync().Result != null) { }
-            sw.Stop();
-
-            Assert.True(
-                sw.ElapsedMilliseconds >= 1800,
-                $"Expected rest.polling_interval_ms={slowPollMs} to drive polling cadence, but " +
-                $"query completed in {sw.ElapsedMilliseconds}ms (expected >= 1800ms).");
-        }
-
-        // Precedence: when both keys are set, the SEA-native key wins (canonical key takes precedence).
-        // polltime_ms=2000 (slow), rest.polling_interval_ms=200 (fast) → fast wins → wall-clock < 1500ms.
-        [SkippableFact]
-        public void ExecuteQuery_BothKeys_CanonicalSeaKeyWins()
-        {
-            SkipIfNotConfigured();
-
-            var extra = new Dictionary<string, string>
-            {
-                [ApacheParameters.PollTimeMilliseconds] = "2000",  // legacy
-                [DatabricksParameters.PollingInterval] = "200",    // canonical — should win
-                [DatabricksParameters.WaitTimeout] = "0",
-                [DatabricksParameters.EnableDirectResults] = "false",
-            };
-
-            using var connection = CreateRestConnection(extra);
-            using var statement = connection.CreateStatement();
-            statement.SqlQuery = "SELECT 1 AS value";
-
-            var sw = Stopwatch.StartNew();
-            var result = statement.ExecuteQuery();
-            using var reader = result.Stream;
-            while (reader.ReadNextRecordBatchAsync().Result != null) { }
-            sw.Stop();
-
-            // Canonical key (200ms) must win over legacy (2000ms). Total wall-clock should be
-            // well under 1500ms (allowing for network round-trips). If polltime_ms incorrectly
-            // takes precedence, wall-clock would be ~2000ms+ and this assertion fails.
-            Assert.True(
-                sw.ElapsedMilliseconds < 1500,
-                $"Expected canonical rest.polling_interval_ms=200 to win over legacy " +
-                $"polltime_ms=2000, but query took {sw.ElapsedMilliseconds}ms (expected < 1500ms).");
+                $"This indicates polltime_ms is not wired into SEA's polling interval.");
         }
     }
 }

--- a/csharp/test/E2E/StatementExecution/StatementExecutionDriverE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/StatementExecutionDriverE2ETests.cs
@@ -16,8 +16,10 @@
 
 using System;
 using System.Collections.Generic;
-using Apache.Arrow.Adbc;
+using System.Diagnostics;
+using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Spark;
+using Apache.Arrow.Adbc;
 using Apache.Arrow.Adbc.Tests;
 using Xunit;
 using Xunit.Abstractions;
@@ -43,7 +45,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             // and OAuth M2M (client_credentials) flow (implemented in PECO-2857).
         }
 
-        private AdbcConnection CreateRestConnection()
+        private AdbcConnection CreateRestConnection(IReadOnlyDictionary<string, string>? extraProperties = null)
         {
             var properties = new Dictionary<string, string>
             {
@@ -98,6 +100,15 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             if (!string.IsNullOrEmpty(TestConfiguration.OAuthScope))
             {
                 properties[DatabricksParameters.OAuthScope] = TestConfiguration.OAuthScope;
+            }
+
+            // Test-specific overrides take precedence over TestConfiguration defaults.
+            if (extraProperties != null)
+            {
+                foreach (var kv in extraProperties)
+                {
+                    properties[kv.Key] = kv.Value;
+                }
             }
 
             var driver = new DatabricksDriver();
@@ -431,6 +442,119 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             var batch = reader.ReadNextRecordBatchAsync().Result;
             Assert.NotNull(batch);
             Assert.Equal(1, batch.Length);
+        }
+
+        // PECO-3064: adbc.apache.statement.polltime_ms must be honored as an alias for
+        // adbc.databricks.rest.polling_interval_ms on the SEA path. The polling cadence drives
+        // total wall-clock for queries that complete async (wait_timeout=0): time-to-completion
+        // is dominated by the polling interval since the first GetStatement happens only after
+        // Task.Delay(_pollingIntervalMs). We exploit this to observe the effective interval.
+        //
+        // Strategy:
+        //  - wait_timeout=0 forces async-then-poll (no server-side block).
+        //  - polltime_ms=2000 is the only key set; canonical rest.polling_interval_ms is absent.
+        //  - With the fix, _pollingIntervalMs resolves to 2000ms → total wall-clock ~2s+.
+        //  - Pre-fix, polltime_ms is ignored, falling back to 1000ms default → wall-clock ~1s.
+        //  - Assert elapsed >= 1800ms to distinguish reliably (margin for fast/slow networks).
+        [SkippableFact]
+        public void ExecuteQuery_PollTimeMsAlias_IsHonoredOnSeaPath()
+        {
+            SkipIfNotConfigured();
+
+            const int slowPollMs = 2000;
+            var extra = new Dictionary<string, string>
+            {
+                // Legacy key only — no canonical rest.polling_interval_ms set.
+                [ApacheParameters.PollTimeMilliseconds] = slowPollMs.ToString(),
+                // Force the async-then-poll code path so the polling interval dominates wall-clock.
+                [DatabricksParameters.WaitTimeout] = "0",
+                // Also disable direct results so wait_timeout is not overridden by the connection.
+                [DatabricksParameters.EnableDirectResults] = "false",
+            };
+
+            using var connection = CreateRestConnection(extra);
+            using var statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 1 AS value";
+
+            var sw = Stopwatch.StartNew();
+            var result = statement.ExecuteQuery();
+            using var reader = result.Stream;
+            // Drain the stream so polling has fully completed.
+            while (reader.ReadNextRecordBatchAsync().Result != null) { }
+            sw.Stop();
+
+            // With polltime_ms honored as the SEA polling interval, the first GetStatement happens
+            // ~2000ms after ExecuteStatement returns PENDING, so wall-clock must be >= 1800ms.
+            // Pre-fix, polltime_ms is dropped, the default 1000ms applies, and wall-clock is ~1100ms.
+            Assert.True(
+                sw.ElapsedMilliseconds >= 1800,
+                $"Expected polltime_ms={slowPollMs} to drive SEA polling cadence, but query " +
+                $"completed in {sw.ElapsedMilliseconds}ms (expected >= 1800ms). " +
+                $"This indicates the legacy polltime_ms alias is not wired into SEA's polling interval.");
+        }
+
+        // Sanity check: the canonical SEA key continues to work standalone (regression guard).
+        [SkippableFact]
+        public void ExecuteQuery_RestPollingIntervalMs_ContinuesToWork()
+        {
+            SkipIfNotConfigured();
+
+            const int slowPollMs = 2000;
+            var extra = new Dictionary<string, string>
+            {
+                [DatabricksParameters.PollingInterval] = slowPollMs.ToString(),
+                [DatabricksParameters.WaitTimeout] = "0",
+                [DatabricksParameters.EnableDirectResults] = "false",
+            };
+
+            using var connection = CreateRestConnection(extra);
+            using var statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 1 AS value";
+
+            var sw = Stopwatch.StartNew();
+            var result = statement.ExecuteQuery();
+            using var reader = result.Stream;
+            while (reader.ReadNextRecordBatchAsync().Result != null) { }
+            sw.Stop();
+
+            Assert.True(
+                sw.ElapsedMilliseconds >= 1800,
+                $"Expected rest.polling_interval_ms={slowPollMs} to drive polling cadence, but " +
+                $"query completed in {sw.ElapsedMilliseconds}ms (expected >= 1800ms).");
+        }
+
+        // Precedence: when both keys are set, the SEA-native key wins (canonical key takes precedence).
+        // polltime_ms=2000 (slow), rest.polling_interval_ms=200 (fast) → fast wins → wall-clock < 1500ms.
+        [SkippableFact]
+        public void ExecuteQuery_BothKeys_CanonicalSeaKeyWins()
+        {
+            SkipIfNotConfigured();
+
+            var extra = new Dictionary<string, string>
+            {
+                [ApacheParameters.PollTimeMilliseconds] = "2000",  // legacy
+                [DatabricksParameters.PollingInterval] = "200",    // canonical — should win
+                [DatabricksParameters.WaitTimeout] = "0",
+                [DatabricksParameters.EnableDirectResults] = "false",
+            };
+
+            using var connection = CreateRestConnection(extra);
+            using var statement = connection.CreateStatement();
+            statement.SqlQuery = "SELECT 1 AS value";
+
+            var sw = Stopwatch.StartNew();
+            var result = statement.ExecuteQuery();
+            using var reader = result.Stream;
+            while (reader.ReadNextRecordBatchAsync().Result != null) { }
+            sw.Stop();
+
+            // Canonical key (200ms) must win over legacy (2000ms). Total wall-clock should be
+            // well under 1500ms (allowing for network round-trips). If polltime_ms incorrectly
+            // takes precedence, wall-clock would be ~2000ms+ and this assertion fails.
+            Assert.True(
+                sw.ElapsedMilliseconds < 1500,
+                $"Expected canonical rest.polling_interval_ms=200 to win over legacy " +
+                $"polltime_ms=2000, but query took {sw.ElapsedMilliseconds}ms (expected < 1500ms).");
         }
     }
 }

--- a/csharp/test/Unit/DatabricksParametersTests.cs
+++ b/csharp/test/Unit/DatabricksParametersTests.cs
@@ -54,12 +54,6 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         }
 
         [Fact]
-        public void TestPollingIntervalParameterExists()
-        {
-            Assert.Equal("adbc.databricks.rest.polling_interval_ms", DatabricksParameters.PollingInterval);
-        }
-
-        [Fact]
         public void TestEnableSessionManagementParameterExists()
         {
             Assert.Equal("adbc.databricks.rest.enable_session_management", DatabricksParameters.EnableSessionManagement);
@@ -86,7 +80,6 @@ namespace AdbcDrivers.Databricks.Tests.Unit
             Assert.StartsWith("adbc.databricks.rest.", DatabricksParameters.ResultFormat);
             Assert.StartsWith("adbc.databricks.rest.", DatabricksParameters.ResultCompression);
             Assert.StartsWith("adbc.databricks.rest.", DatabricksParameters.WaitTimeout);
-            Assert.StartsWith("adbc.databricks.rest.", DatabricksParameters.PollingInterval);
         }
 
         [Fact]


### PR DESCRIPTION
## What's Changed

The SEA path previously read only `adbc.databricks.rest.polling_interval_ms` and ignored `adbc.apache.statement.polltime_ms`. Rather than adding `polltime_ms` as a legacy alias (the original direction in cc4f69d), this PR **consolidates onto a single canonical key** — `adbc.apache.statement.polltime_ms` — for both protocols.

Resolution: SEA reads `adbc.apache.statement.polltime_ms` (default 1000 ms); Thrift continues to read the same key (default 100 ms). The property name is shared; only the protocol-specific default differs, since HTTP/JSON polls are heavier than Thrift RPCs.

### Breaking change

`adbc.databricks.rest.polling_interval_ms` is removed. Anyone setting that key on the SEA path must migrate to `adbc.apache.statement.polltime_ms`. SEA is opt-in (`adbc.databricks.protocol=rest`), so blast radius is bounded.

Title uses `fix(csharp)!:` per the conventional-commits guideline in CLAUDE.md.

## Why

PECO-3064 — M3 parameter gap, with a follow-up question raised in PR review: *"why have two variables for the same purpose?"* Consolidation eliminates the "two ways to do it" anti-pattern, matches JDBC's single-key convention (`asyncexecpollinterval`), and keeps protocol-specific defaults in code where they belong.

## Red → Green proof

E2E test `ExecuteQuery_PollTimeMs_DrivesSeaPollingCadence` sets `polltime_ms=2000`, `wait_timeout=0`, `enable_direct_results=false`, drains a `SELECT 1`, and asserts wall-clock ≥ 1800ms.

**Before fix** (against unmodified main):

```
Expected polltime_ms=2000 to drive SEA polling cadence, but query completed in 1364ms (expected >= 1800ms).
```

SEA fell back to the 1000 ms default; `polltime_ms` was silently dropped.

**After fix:** test passes (~2 s wall-clock); the full `StatementExecutionDriverE2ETests` class passes against the live `pecotesting` warehouse.

## Files touched

| File | Change |
|---|---|
| `csharp/src/DatabricksParameters.cs` | Delete `PollingInterval` constant |
| `csharp/src/StatementExecution/StatementExecutionConnection.cs` | Read only `ApacheParameters.PollTimeMilliseconds` (SEA default 1000 ms) |
| `csharp/test/Unit/DatabricksParametersTests.cs` | Remove `PollingInterval`-existence and REST-prefix assertions |
| `csharp/test/E2E/StatementExecution/StatementExecutionDriverE2ETests.cs` | Keep + rename the polltime_ms-drives-SEA-cadence test; delete the precedence and standalone-canonical tests (no precedence to test anymore) |
| `csharp/README.md` | Restructure Core Spark / Databricks-Specific / CloudFetch tables with `Thrift Default` / `SEA Default` columns. Auth, TLS, Proxy, Tracing tables get an "applies to both" header note. REST API Configuration noted as SEA-only, polling row removed |
| `csharp/doc/statement-execution-api-design.md` | Update polling-interval references to the consolidated key |

## Manual verification

- [x] E2E test `ExecuteQuery_PollTimeMs_DrivesSeaPollingCadence` passes against `pecotesting`
- [x] Full `StatementExecutionDriverE2ETests` class passes
- [x] `dotnet build` clean on all TFMs (0 warnings, 0 errors)
- [x] `DatabricksParametersTests` passes
- [ ] pre-commit (sandbox blocks hook env install; will run in CI)

PECO-3064
