### PR TITLE
fix(csharp): canonicalize identifier case in SEA get_primary_keys (PECO-3045) [SEA]

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1492,8 +1492,17 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
                 var keys = new List<(string, string, string, string, int, string)>();
                 int seq = 0;
+                // PECO-3045: prefer canonical identifiers from the SHOW KEYS server response over the
+                // (possibly non-canonical) user input. JDBC spec calls for canonical names in the
+                // result columns; Thrift returns them natively, so SEA must match.
+                string fallbackCatalog = _metadataCatalogName!.ToLowerInvariant();
+                string fallbackSchema = _metadataSchemaName!.ToLowerInvariant();
+                string fallbackTable = _metadataTableName!.ToLowerInvariant();
                 foreach (var batch in batches)
                 {
+                    var catalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                    var schemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                    var tableNameArray = TryGetColumn<StringArray>(batch, "tableName");
                     var colNameArray = TryGetColumn<StringArray>(batch, "col_name");
                     var keyNameArray = TryGetColumn<StringArray>(batch, "constraintName");
                     var keySeqArray = TryGetColumn<Int32Array>(batch, "keySeq");
@@ -1503,7 +1512,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
                         if (colNameArray.IsNull(i)) continue;
                         int keySeq = keySeqArray != null && !keySeqArray.IsNull(i) ? keySeqArray.GetValue(i)!.Value : ++seq;
                         string pkName = keyNameArray != null && !keyNameArray.IsNull(i) ? keyNameArray.GetString(i) : "";
-                        keys.Add((_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!,
+                        string catalog = catalogArray != null && !catalogArray.IsNull(i) ? catalogArray.GetString(i) : fallbackCatalog;
+                        string schemaName = schemaArray != null && !schemaArray.IsNull(i) ? schemaArray.GetString(i) : fallbackSchema;
+                        string tableName = tableNameArray != null && !tableNameArray.IsNull(i) ? tableNameArray.GetString(i) : fallbackTable;
+                        keys.Add((catalog, schemaName, tableName,
                             colNameArray.GetString(i), keySeq, pkName));
                     }
                 }

--- a/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
@@ -330,6 +330,31 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             Assert.Equal("c_int", rows[1]["COLUMN_NAME"]);
         }
 
+        // PECO-3045 — SEA echoed input case in result columns; JDBC spec says columns
+        // should be canonical (lowercase). Call get_primary_keys with uppercase
+        // catalog/schema/table and assert the returned TABLE_CAT / TABLE_SCHEM / TABLE_NAME
+        // columns are the canonical lowercase form.
+        [SkippableFact]
+        public async Task SEA_GetPrimaryKeys_ReturnsCanonicalCase_InResultColumns()
+        {
+            SkipIfNotConfigured();
+            using var conn = CreateSeaConnection();
+            // Pass non-canonical (uppercase) input — server-side identifiers are lowercase.
+            var rows = await ReadMetadata(
+                conn,
+                "GetPrimaryKeys",
+                TestCatalog.ToUpperInvariant(),
+                TestSchema.ToUpperInvariant(),
+                TestTable.ToUpperInvariant());
+            Assert.Equal(2, rows.Count);
+            foreach (var row in rows)
+            {
+                Assert.Equal(TestCatalog, row["TABLE_CAT"]);
+                Assert.Equal(TestSchema, row["TABLE_SCHEM"]);
+                Assert.Equal(TestTable, row["TABLE_NAME"]);
+            }
+        }
+
         // --- GetTableSchema ---
 
         [SkippableFact]


### PR DESCRIPTION
## What's Changed

The SEA path of `GetPrimaryKeysAsync` used the user-provided input names
(`_metadataCatalogName` / `_metadataSchemaName` / `_metadataTableName`)
verbatim when building result rows. When callers pass non-canonical case
(e.g. `catalog=\"MAIN\"` for a server-lowercase catalog `main`) the
`TABLE_CAT` / `TABLE_SCHEM` / `TABLE_NAME` result columns echo back the
input case instead of the canonical lowercase form. The Thrift path
returns canonical names from the server, and JDBC's SDK path reads
`catalogName` / `namespace` / `tableName` from the SHOW KEYS response —
so SEA was the outlier.

This change makes SEA read those three columns from each SHOW KEYS
record batch and use them when populating result rows, with a defensive
fallback to a lowercased copy of the user input if the columns are
missing or null. It mirrors how `FetchCrossReferenceAsync` already
reads `parentCatalogName` / `parentNamespace` / `parentTableName` from
SHOW FOREIGN KEYS in the same file.

## Why

PECO-3045 — D17: SEA echoes input case in `get_primary_keys` result
columns; Thrift returns canonical names. JDBC spec says results should
be canonical.

## Red → Green proof

**Before fix** (`SEA_GetPrimaryKeys_ReturnsCanonicalCase_InResultColumns`):

```
[xUnit.net 00:00:01.43]     ...SEA_GetPrimaryKeys_ReturnsCanonicalCase_InResultColumns [FAIL]
  Error Message:
   Assert.Equal() Failure: Strings differ
           ↓ (pos 0)
Expected: \"main\"
Actual:   \"MAIN\"
           ↑ (pos 0)
Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1
```

**After fix:**

```
Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 1 s
```

Full `SeaMetadataE2ETests` class — 19/19 pass post-fix.

## Files touched

- `csharp/src/StatementExecution/StatementExecutionStatement.cs` — read canonical names from SHOW KEYS columns; lowercase fallback.
- `csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs` — added `SEA_GetPrimaryKeys_ReturnsCanonicalCase_InResultColumns`.

## Manual verification

- [x] E2E test red → green against `pecotesting` warehouse
- [x] Full `SeaMetadataE2ETests` class passes (19/19)
- [x] `dotnet build` clean on `netstandard2.0`, `net472`, `net8.0`
- [ ] pre-commit — environment could not install pip deps (no network from sandbox); pre-existing CI hooks will run on PR