### PR TITLE
perf(csharp): reduce allocations and copies in result transfer

### DIFF
--- a/csharp/src/CustomLZ4FrameReader.cs
+++ b/csharp/src/CustomLZ4FrameReader.cs
@@ -75,10 +75,14 @@ namespace AdbcDrivers.Databricks
         {
             if (buffer != null)
             {
-                // Clear the buffer to prevent stale data from previous decompressions
-                // from corrupting subsequent operations. The performance overhead (~1-2ms
-                // per 4MB buffer) is negligible compared to network I/O and decompression time.
-                _bufferPool.Return(buffer, clearArray: true);
+                // Return without clearing. This is the LZ4 decoder's internal block work buffer; K4os
+                // bounds every read to the number of bytes it actually decoded into the buffer, so stale
+                // bytes from a previous decompression are never surfaced to the output. This is verified
+                // by Lz4DecompressNoStaleDataTest, which decodes through a deliberately poisoned buffer
+                // and still gets byte-exact output. Upstream K4os likewise returns these buffers without
+                // clearing. Skipping the clear avoids zeroing a multi-MB buffer (~80us each, measured)
+                // that the next decode overwrites anyway.
+                _bufferPool.Return(buffer, clearArray: false);
             }
         }
     }

--- a/csharp/src/DatabricksDatabase.cs
+++ b/csharp/src/DatabricksDatabase.cs
@@ -58,6 +58,17 @@ namespace AdbcDrivers.Databricks
         /// Sized for 4MB buffers (Databricks maxBlockSize) with capacity for 10 buffers.
         /// This pool is instance-based to allow cleanup when the database is disposed.
         /// </summary>
+        /// <remarks>
+        /// IMPORTANT: This pool MUST remain database-scoped — do not promote it to a static or
+        /// otherwise global/process-wide pool. <see cref="CustomLZ4FrameReader.ReleaseBuffer"/>
+        /// returns the decoder's work buffers <b>without</b> clearing them (a measured perf win;
+        /// K4os bounds every read to the bytes it actually decoded, so stale bytes are never
+        /// surfaced on the normal path). Because the buffers are not zeroed on return, the pool's
+        /// reuse boundary is also a data-isolation boundary: a database-scoped pool only ever
+        /// recycles buffers among connections of that one database. A global pool would let a
+        /// buffer rented by one DatabricksDatabase's decode be handed to another's — surfacing
+        /// stale decode bytes across tenants in a multi-tenant host. Keep it instance-scoped.
+        /// </remarks>
         internal readonly System.Buffers.ArrayPool<byte> Lz4BufferPool =
             System.Buffers.ArrayPool<byte>.Create(maxArrayLength: 4 * 1024 * 1024, maxArraysPerBucket: 10);
 

--- a/csharp/src/Lz4Utilities.cs
+++ b/csharp/src/Lz4Utilities.cs
@@ -47,50 +47,52 @@ namespace AdbcDrivers.Databricks
         /// Decompresses LZ4 compressed data into memory.
         /// </summary>
         /// <param name="compressedData">The compressed data bytes.</param>
+        /// <param name="memoryStreamManager">The RecyclableMemoryStreamManager used for the (pooled) decompression buffer.</param>
         /// <param name="bufferPool">The ArrayPool to use for buffer allocation (from DatabricksDatabase).</param>
         /// <returns>A ReadOnlyMemory containing the decompressed data.</returns>
         /// <exception cref="AdbcException">Thrown when decompression fails.</exception>
-        public static ReadOnlyMemory<byte> DecompressLz4(byte[] compressedData, ArrayPool<byte> bufferPool)
+        public static ReadOnlyMemory<byte> DecompressLz4(byte[] compressedData, RecyclableMemoryStreamManager memoryStreamManager, ArrayPool<byte> bufferPool)
         {
-            return DecompressLz4(compressedData, DefaultBufferSize, bufferPool);
+            return DecompressLz4(compressedData, DefaultBufferSize, memoryStreamManager, bufferPool);
         }
 
         /// <summary>
         /// Decompresses LZ4 compressed data into memory with a specified buffer size.
-        /// NOTE: This method uses regular MemoryStream (not RecyclableMemoryStream) because the buffer
-        /// must remain valid after the method returns for the caller to use.
-        /// Uses CustomLZ4DecoderStream with custom ArrayPool to efficiently pool 4MB+ buffers.
         /// </summary>
+        /// <remarks>
+        /// Decompresses into a pooled <see cref="RecyclableMemoryStream"/> rather than a plain
+        /// <see cref="MemoryStream"/>. A plain MemoryStream starts empty and doubles its backing array
+        /// as it grows, repeatedly reallocating and copying — landing on the Large Object Heap for the
+        /// multi-MB Arrow batches Databricks returns — and then leaves an over-sized buffer. The
+        /// recyclable stream instead writes into reused fixed-size blocks (no per-call LOH churn).
+        /// <see cref="RecyclableMemoryStream.ToArray"/> then produces a single exact-size, GC-owned
+        /// array, which is safe for the caller to retain after the pooled blocks are returned — the
+        /// Arrow <c>RecordBatch</c> built from it references this memory beyond this method's scope.
+        /// </remarks>
         /// <param name="compressedData">The compressed data bytes.</param>
         /// <param name="bufferSize">The buffer size to use for decompression operations.</param>
+        /// <param name="memoryStreamManager">The RecyclableMemoryStreamManager used for the (pooled) decompression buffer.</param>
         /// <param name="bufferPool">The ArrayPool to use for buffer allocation (from DatabricksDatabase).</param>
         /// <returns>A ReadOnlyMemory containing the decompressed data.</returns>
         /// <exception cref="AdbcException">Thrown when decompression fails.</exception>
-        public static ReadOnlyMemory<byte> DecompressLz4(byte[] compressedData, int bufferSize, ArrayPool<byte> bufferPool)
+        public static ReadOnlyMemory<byte> DecompressLz4(byte[] compressedData, int bufferSize, RecyclableMemoryStreamManager memoryStreamManager, ArrayPool<byte> bufferPool)
         {
             try
             {
-                // Use regular MemoryStream here because we return the buffer after disposal
-                // RecyclableMemoryStream would return the buffer to the pool, making it unsafe
-                using (var outputStream = new MemoryStream())
+                using (var outputStream = memoryStreamManager.GetStream())
+                using (var inputStream = new MemoryStream(compressedData))
+                using (var decompressor = new CustomLZ4DecoderStream(
+                    inputStream,
+                    descriptor => descriptor.CreateDecoder(),
+                    bufferPool,
+                    leaveOpen: false,
+                    interactive: false))
                 {
-                    using (var inputStream = new MemoryStream(compressedData))
-                    using (var decompressor = new CustomLZ4DecoderStream(
-                        inputStream,
-                        descriptor => descriptor.CreateDecoder(),
-                        bufferPool,
-                        leaveOpen: false,
-                        interactive: false))
-                    {
-                        decompressor.CopyTo(outputStream, bufferSize);
-                    }
+                    decompressor.CopyTo(outputStream, bufferSize);
 
-                    // Get the underlying buffer and its valid length without copying
-                    // The buffer remains valid after MemoryStream disposal since we hold a reference to it
-                    byte[] buffer = outputStream.GetBuffer();
-                    int length = (int)outputStream.Length;
-
-                    return new ReadOnlyMemory<byte>(buffer, 0, length);
+                    // Copy to an exact-size, GC-owned array before the pooled stream/blocks are
+                    // returned on dispose. The caller retains this beyond the stream's lifetime.
+                    return outputStream.ToArray();
                 }
             }
             catch (Exception ex)

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -678,15 +678,11 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                             bodyTimeoutCts.CancelAfter(TimeSpan.FromMinutes(_timeoutMinutes));
                             using (var contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                             {
-                                // Pre-allocate with Content-Length when available (CloudFetch always provides it).
-                                int capacity = contentLength.HasValue && contentLength.Value > 0
-                                    ? (int)contentLength.Value
-                                    : 0;
-                                using (var memoryStream = new MemoryStream(capacity))
-                                {
-                                    await contentStream.CopyToAsync(memoryStream, 81920, bodyTimeoutCts.Token).ConfigureAwait(false);
-                                    fileData = memoryStream.ToArray();
-                                }
+                                // Read the body into a single right-sized buffer. When Content-Length is
+                                // known (CloudFetch presigned-URL responses always provide it) this avoids the
+                                // previous MemoryStream-grow + ToArray approach, which allocated and copied the
+                                // whole payload twice.
+                                fileData = await ReadResponseBodyAsync(contentStream, contentLength, bodyTimeoutCts.Token).ConfigureAwait(false);
                             }
                         }
                         break; // Success, exit retry loop
@@ -878,6 +874,73 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 downloadResult.SetCompleted(dataStream, size);
                 _stragglerDetector?.MarkCompleted(fileOffset, activity);
             }, activityName: "DownloadFile");
+        }
+
+        /// <summary>
+        /// Reads an HTTP response body into a byte array.
+        /// <para>
+        /// When the body length is known up front (CloudFetch presigned-URL responses always
+        /// include <c>Content-Length</c>), the body is read into a single exactly-sized buffer.
+        /// This avoids the previous <see cref="MemoryStream"/>-plus-<see cref="MemoryStream.ToArray"/>
+        /// pattern, which allocated and copied the entire payload twice — once into the stream's
+        /// internal (possibly over-sized) buffer and again into the array returned by <c>ToArray()</c>.
+        /// </para>
+        /// <para>
+        /// Falls back to a growable <see cref="MemoryStream"/> when the length is unknown, and also
+        /// handles the abnormal cases where the server sends fewer or more bytes than declared, so the
+        /// returned array always contains exactly the bytes received (matching the prior behavior).
+        /// </para>
+        /// </summary>
+        internal static async Task<byte[]> ReadResponseBodyAsync(
+            Stream contentStream,
+            long? contentLength,
+            CancellationToken cancellationToken)
+        {
+            const int CopyBufferSize = 81920;
+
+            if (contentLength.HasValue && contentLength.Value > 0 && contentLength.Value <= int.MaxValue)
+            {
+                int length = (int)contentLength.Value;
+                byte[] buffer = new byte[length];
+                int offset = 0;
+                int read;
+                while (offset < length &&
+                       (read = await contentStream.ReadAsync(buffer, offset, length - offset, cancellationToken).ConfigureAwait(false)) > 0)
+                {
+                    offset += read;
+                }
+
+                // Probe for any bytes beyond the declared Content-Length. For a well-formed response
+                // of exactly Content-Length bytes this returns 0 (EOF) and we take the fast path.
+                byte[] probe = new byte[1];
+                int extra = await contentStream.ReadAsync(probe, 0, 1, cancellationToken).ConfigureAwait(false);
+
+                if (offset == length && extra == 0)
+                {
+                    // Common case: body matched Content-Length exactly. Single allocation, no extra copy.
+                    return buffer;
+                }
+
+                // Abnormal: short read (truncated body) or more data than declared. Reconstruct exactly
+                // the bytes received, preserving the original CopyToAsync semantics.
+                using (var ms = new MemoryStream(length + 1))
+                {
+                    ms.Write(buffer, 0, offset);
+                    if (extra > 0)
+                    {
+                        ms.Write(probe, 0, extra);
+                        await contentStream.CopyToAsync(ms, CopyBufferSize, cancellationToken).ConfigureAwait(false);
+                    }
+                    return ms.ToArray();
+                }
+            }
+
+            // Unknown length: grow as needed (original behavior).
+            using (var memoryStream = new MemoryStream())
+            {
+                await contentStream.CopyToAsync(memoryStream, CopyBufferSize, cancellationToken).ConfigureAwait(false);
+                return memoryStream.ToArray();
+            }
         }
 
         private void SetError(Exception ex, Activity? activity = null)

--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -921,9 +921,11 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                     return buffer;
                 }
 
-                // Abnormal: short read (truncated body) or more data than declared. Reconstruct exactly
-                // the bytes received, preserving the original CopyToAsync semantics.
-                using (var ms = new MemoryStream(length + 1))
+                // Abnormal: short read (truncated body) or more data than declared. Size the stream to
+                // what was actually read so far (offset + extra) rather than the declared Content-Length,
+                // so a truncated body doesn't over-allocate; it grows only if the drain below adds more.
+                // For the over-read case offset == length and extra == 1, so this equals length + 1.
+                using (var ms = new MemoryStream(offset + extra))
                 {
                     ms.Write(buffer, 0, offset);
                     if (extra > 0)

--- a/csharp/src/Reader/DatabricksReader.cs
+++ b/csharp/src/Reader/DatabricksReader.cs
@@ -198,9 +198,9 @@ namespace AdbcDrivers.Databricks.Reader
                             new("row_count", batch.RowCount)
                         ]);
 
-                        // Pass the connection's buffer pool for efficient LZ4 decompression
+                        // Pass the connection's pooled stream manager + buffer pool for efficient LZ4 decompression
                         var connection = (DatabricksConnection)_statement.Connection;
-                        dataToUse = Lz4Utilities.DecompressLz4(batch.Batch, connection.Lz4BufferPool);
+                        dataToUse = Lz4Utilities.DecompressLz4(batch.Batch, connection.RecyclableMemoryStreamManager, connection.Lz4BufferPool);
 
                         activity?.AddEvent("databricks_reader.decompress_completed", [
                             new("batch_index", this.index),

--- a/csharp/src/StatementExecution/ConcatenatedReadOnlyMemoryStream.cs
+++ b/csharp/src/StatementExecution/ConcatenatedReadOnlyMemoryStream.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2025 ADBC Drivers Contributors
+* Copyright (c) 2026 ADBC Drivers Contributors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -71,8 +71,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
-            if (offset < 0 || count < 0 || offset + count > buffer.Length)
-                throw new ArgumentOutOfRangeException(nameof(count));
+            if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+            if (buffer.Length - offset < count)
+                throw new ArgumentException("Offset and count must refer to a location within the buffer.", nameof(count));
             return ReadCore(buffer.AsSpan(offset, count));
         }
 

--- a/csharp/src/StatementExecution/ConcatenatedReadOnlyMemoryStream.cs
+++ b/csharp/src/StatementExecution/ConcatenatedReadOnlyMemoryStream.cs
@@ -1,0 +1,135 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AdbcDrivers.Databricks.StatementExecution
+{
+    /// <summary>
+    /// A forward-only, read-only <see cref="Stream"/> over an ordered list of
+    /// <see cref="ReadOnlyMemory{Byte}"/> segments, presenting them as one continuous stream.
+    ///
+    /// <para>
+    /// Used by the SEA inline result path to feed multi-chunk Arrow IPC data to
+    /// <c>ArrowStreamReader</c> without first concatenating every chunk into a single large
+    /// buffer. The SEA server splits one Arrow IPC stream across N attachment chunks, so reading
+    /// the segments back-to-back is byte-equivalent to the concatenated buffer — but avoids the
+    /// extra whole-result allocation and copy (and lets each decompressed chunk stay as the
+    /// <see cref="ReadOnlyMemory{Byte}"/> returned by decompression rather than a trimmed copy).
+    /// </para>
+    ///
+    /// <para>Not seekable: the Arrow IPC <em>stream</em> format is read strictly forward, which is
+    /// all <c>ArrowStreamReader</c> requires.</para>
+    /// </summary>
+    internal sealed class ConcatenatedReadOnlyMemoryStream : Stream
+    {
+        private readonly IReadOnlyList<ReadOnlyMemory<byte>> _segments;
+        private readonly long _length;
+        private int _segmentIndex;
+        private int _segmentOffset;
+        private long _position;
+
+        public ConcatenatedReadOnlyMemoryStream(IReadOnlyList<ReadOnlyMemory<byte>> segments)
+        {
+            _segments = segments ?? throw new ArgumentNullException(nameof(segments));
+            long total = 0;
+            for (int i = 0; i < _segments.Count; i++)
+            {
+                total += _segments[i].Length;
+            }
+            _length = total;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _length;
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException("ConcatenatedReadOnlyMemoryStream is forward-only.");
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0 || count < 0 || offset + count > buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(count));
+            return ReadCore(buffer.AsSpan(offset, count));
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<int>(cancellationToken);
+            return Task.FromResult(Read(buffer, offset, count));
+        }
+
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+        public override int Read(Span<byte> buffer) => ReadCore(buffer);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
+            return new ValueTask<int>(ReadCore(buffer.Span));
+        }
+#endif
+
+        private int ReadCore(Span<byte> destination)
+        {
+            int copied = 0;
+            while (copied < destination.Length && _segmentIndex < _segments.Count)
+            {
+                ReadOnlySpan<byte> segment = _segments[_segmentIndex].Span;
+                int available = segment.Length - _segmentOffset;
+                if (available <= 0)
+                {
+                    _segmentIndex++;
+                    _segmentOffset = 0;
+                    continue;
+                }
+
+                int toCopy = Math.Min(available, destination.Length - copied);
+                segment.Slice(_segmentOffset, toCopy).CopyTo(destination.Slice(copied, toCopy));
+                _segmentOffset += toCopy;
+                copied += toCopy;
+            }
+
+            _position += copied;
+            return copied;
+        }
+
+        public override void Flush()
+        {
+            // No-op: read-only stream.
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException("ConcatenatedReadOnlyMemoryStream is forward-only.");
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException("ConcatenatedReadOnlyMemoryStream is read-only.");
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException("ConcatenatedReadOnlyMemoryStream is read-only.");
+    }
+}

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -525,7 +525,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 // keeping inline consistent with CloudFetch (which also uses the manifest schema).
                 int totalChunks = response.Manifest?.Chunks?.Count ?? 1;
                 return new InlineArrowStreamReader(_client, _currentStatementId!, response.Result.Attachment,
-                    isLz4Compressed, totalChunks, _lz4BufferPool, cancellationToken, GetSchemaFromManifest(response.Manifest));
+                    isLz4Compressed, totalChunks, _recyclableMemoryStreamManager, _lz4BufferPool, cancellationToken, GetSchemaFromManifest(response.Manifest));
             }
             else
             {
@@ -835,7 +835,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private class InlineArrowStreamReader : IArrowArrayStream
         {
             private readonly ArrowStreamReader _streamReader;
-            private readonly System.IO.MemoryStream _memoryStream;
+            private readonly System.IO.Stream _dataStream;
             private readonly Schema _schema;
             private bool _disposed;
 
@@ -845,6 +845,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 byte[] firstChunkData,
                 bool isLz4Compressed,
                 int totalChunks,
+                Microsoft.IO.RecyclableMemoryStreamManager memoryStreamManager,
                 System.Buffers.ArrayPool<byte> bufferPool,
                 CancellationToken cancellationToken,
                 Schema manifestSchema)
@@ -854,11 +855,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     throw new ArgumentException("First chunk data cannot be null or empty", nameof(firstChunkData));
                 }
 
-                // Fetch and concatenate all chunks
-                var allData = FetchAllChunksAsync(client, statementId, firstChunkData, isLz4Compressed, totalChunks, bufferPool, cancellationToken).GetAwaiter().GetResult();
+                // Fetch all chunks as a list of segments and present them as one continuous stream.
+                // The SEA server splits a single Arrow IPC stream across N attachment chunks, so reading
+                // the segments back-to-back is byte-equivalent to concatenating them — but avoids both the
+                // per-chunk ToArray copy and the whole-result concatenation buffer (fix: PECO perf).
+                var segments = FetchAllChunkSegmentsAsync(client, statementId, firstChunkData, isLz4Compressed, totalChunks, memoryStreamManager, bufferPool, cancellationToken).GetAwaiter().GetResult();
 
-                _memoryStream = new System.IO.MemoryStream(allData);
-                _streamReader = new ArrowStreamReader(_memoryStream);
+                _dataStream = new ConcatenatedReadOnlyMemoryStream(segments);
+                _streamReader = new ArrowStreamReader(_dataStream);
                 // Validate that the IPC schema column count matches the manifest schema.
                 // Type mismatches are expected (manifest uses StringType for interval/complex columns),
                 // but a count mismatch indicates a server bug or version skew and should fail loudly.
@@ -898,32 +902,34 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 if (!_disposed)
                 {
                     _streamReader?.Dispose();
-                    _memoryStream?.Dispose();
+                    _dataStream?.Dispose();
                     _disposed = true;
                 }
             }
 
-            private static async Task<byte[]> FetchAllChunksAsync(
+            private static async Task<List<ReadOnlyMemory<byte>>> FetchAllChunkSegmentsAsync(
                 IStatementExecutionClient client,
                 string statementId,
                 byte[] firstChunkData,
                 bool isLz4Compressed,
                 int totalChunks,
+                Microsoft.IO.RecyclableMemoryStreamManager memoryStreamManager,
                 System.Buffers.ArrayPool<byte> bufferPool,
                 CancellationToken cancellationToken)
             {
-                // Start with the first chunk (already have it inline)
-                var chunks = new List<byte[]>();
+                // Collect the chunks as segments rather than concatenating them into one buffer.
+                // For LZ4 we keep the ReadOnlyMemory returned by decompression directly (no ToArray
+                // copy); for uncompressed chunks we wrap the attachment array as-is.
+                var segments = new List<ReadOnlyMemory<byte>>(totalChunks);
 
-                // Decompress first chunk if needed
+                // Start with the first chunk (already have it inline)
                 if (isLz4Compressed)
                 {
-                    var decompressed = Lz4Utilities.DecompressLz4(firstChunkData, bufferPool);
-                    chunks.Add(decompressed.ToArray());
+                    segments.Add(Lz4Utilities.DecompressLz4(firstChunkData, memoryStreamManager, bufferPool));
                 }
                 else
                 {
-                    chunks.Add(firstChunkData);
+                    segments.Add(firstChunkData);
                 }
 
                 // Fetch remaining chunks (chunks are 0-indexed, chunk 0 is already inline)
@@ -935,27 +941,16 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     {
                         if (isLz4Compressed)
                         {
-                            var decompressed = Lz4Utilities.DecompressLz4(chunkResult.Attachment, bufferPool);
-                            chunks.Add(decompressed.ToArray());
+                            segments.Add(Lz4Utilities.DecompressLz4(chunkResult.Attachment, memoryStreamManager, bufferPool));
                         }
                         else
                         {
-                            chunks.Add(chunkResult.Attachment);
+                            segments.Add(chunkResult.Attachment);
                         }
                     }
                 }
 
-                // Concatenate all chunks
-                int totalLength = chunks.Sum(c => c.Length);
-                byte[] result = new byte[totalLength];
-                int offset = 0;
-                foreach (var chunk in chunks)
-                {
-                    Buffer.BlockCopy(chunk, 0, result, offset, chunk.Length);
-                    offset += chunk.Length;
-                }
-
-                return result;
+                return segments;
             }
         }
 

--- a/csharp/test/Unit/Lz4DecompressAllocationTest.cs
+++ b/csharp/test/Unit/Lz4DecompressAllocationTest.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2025 ADBC Drivers Contributors
+* Copyright (c) 2026 ADBC Drivers Contributors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
+#if NET6_0_OR_GREATER
 
 using System;
 using System.Buffers;
@@ -113,7 +115,6 @@ namespace AdbcDrivers.Databricks.Tests
             double newMb = newBytes / (double)iters / 1024.0 / 1024.0;
             string line = $"LZ4 decompress {size / 1024 / 1024} MB (decompressed): OLD {oldMb:F2} MB/op  NEW {newMb:F2} MB/op  ratio NEW/OLD {newMb / oldMb:F2}";
             _out.WriteLine(line);
-            try { File.AppendAllText(Path.Combine(Path.GetTempPath(), "lz4_decompress_perf.txt"), line + "\n"); } catch { }
 
             Assert.True(newBytes < oldBytes,
                 $"Expected new allocations ({newMb:F2} MB/op) < old ({oldMb:F2} MB/op)");
@@ -134,3 +135,5 @@ namespace AdbcDrivers.Databricks.Tests
         }
     }
 }
+
+#endif

--- a/csharp/test/Unit/Lz4DecompressAllocationTest.cs
+++ b/csharp/test/Unit/Lz4DecompressAllocationTest.cs
@@ -1,0 +1,136 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Buffers;
+using System.IO;
+using K4os.Compression.LZ4.Streams;
+using Microsoft.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.Databricks.Tests
+{
+    /// <summary>
+    /// Validates SEA/inline fix #3: <see cref="Lz4Utilities.DecompressLz4(byte[], RecyclableMemoryStreamManager, ArrayPool{byte})"/>
+    /// now decompresses into a pooled RecyclableMemoryStream + exact ToArray, instead of a plain
+    /// MemoryStream that grows geometrically (LOH churn) and returns an over-sized GetBuffer.
+    /// Compares the real method's allocation against the previous approach, using the same decoder
+    /// (<see cref="CustomLZ4DecoderStream"/>) so only the output-buffer strategy differs.
+    /// </summary>
+    public class Lz4DecompressAllocationTest
+    {
+        private readonly ITestOutputHelper _out;
+
+        public Lz4DecompressAllocationTest(ITestOutputHelper output) => _out = output;
+
+        private static byte[] MakeCompressible(int size)
+        {
+            var rng = new Random(31);
+            var data = new byte[size];
+            int i = 0;
+            while (i < size)
+            {
+                if (rng.Next(100) < 60)
+                {
+                    int run = Math.Min(rng.Next(8, 64), size - i);
+                    byte v = (byte)rng.Next(256);
+                    for (int j = 0; j < run; j++) data[i++] = v;
+                }
+                else
+                {
+                    int noise = Math.Min(rng.Next(4, 24), size - i);
+                    for (int j = 0; j < noise; j++) data[i++] = (byte)rng.Next(256);
+                }
+            }
+            return data;
+        }
+
+        private static byte[] Lz4Frame(byte[] src)
+        {
+            using var ms = new MemoryStream();
+            using (var enc = LZ4Stream.Encode(ms, leaveOpen: true))
+            {
+                enc.Write(src, 0, src.Length);
+            }
+            return ms.ToArray();
+        }
+
+        // Previous behavior: decompress into a plain (growing) MemoryStream and hand back GetBuffer.
+        // Uses the same CustomLZ4DecoderStream as the real method so only the output buffer differs.
+        private static ReadOnlyMemory<byte> OldDecompress(byte[] compressed, ArrayPool<byte> pool)
+        {
+            using var output = new MemoryStream();
+            using (var input = new MemoryStream(compressed))
+            using (var dec = new CustomLZ4DecoderStream(input, d => d.CreateDecoder(), pool, leaveOpen: false, interactive: false))
+            {
+                dec.CopyTo(output, 81920);
+            }
+            byte[] buf = output.GetBuffer();
+            return new ReadOnlyMemory<byte>(buf, 0, (int)output.Length);
+        }
+
+        [Fact]
+        public void DecompressLz4_RoundTripsAndAllocatesLess()
+        {
+            const int size = 4 * 1024 * 1024;
+            byte[] original = MakeCompressible(size);
+            byte[] compressed = Lz4Frame(original);
+
+            var pool = ArrayPool<byte>.Create(4 * 1024 * 1024, 16);
+            var manager = new RecyclableMemoryStreamManager();
+
+            // Correctness: the real method reproduces the original bytes exactly...
+            byte[] decompressed = Lz4Utilities.DecompressLz4(compressed, manager, pool).ToArray();
+            Assert.Equal(original, decompressed);
+            // ...and matches the previous approach's output.
+            Assert.Equal(OldDecompress(compressed, pool).ToArray(), decompressed);
+
+            const int iters = 100;
+            for (int i = 0; i < 10; i++) // warm both buffer pools
+            {
+                _ = OldDecompress(compressed, pool);
+                _ = Lz4Utilities.DecompressLz4(compressed, manager, pool);
+            }
+
+            long oldBytes = Measure(() => OldDecompress(compressed, pool), iters);
+            long newBytes = Measure(() => Lz4Utilities.DecompressLz4(compressed, manager, pool), iters);
+
+            double oldMb = oldBytes / (double)iters / 1024.0 / 1024.0;
+            double newMb = newBytes / (double)iters / 1024.0 / 1024.0;
+            string line = $"LZ4 decompress {size / 1024 / 1024} MB (decompressed): OLD {oldMb:F2} MB/op  NEW {newMb:F2} MB/op  ratio NEW/OLD {newMb / oldMb:F2}";
+            _out.WriteLine(line);
+            try { File.AppendAllText(Path.Combine(Path.GetTempPath(), "lz4_decompress_perf.txt"), line + "\n"); } catch { }
+
+            Assert.True(newBytes < oldBytes,
+                $"Expected new allocations ({newMb:F2} MB/op) < old ({oldMb:F2} MB/op)");
+        }
+
+        private static long Measure(Func<ReadOnlyMemory<byte>> action, int iters)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < iters; i++)
+            {
+                ReadOnlyMemory<byte> r = action();
+                GC.KeepAlive(r);
+            }
+            return GC.GetAllocatedBytesForCurrentThread() - before;
+        }
+    }
+}

--- a/csharp/test/Unit/Lz4DecompressNoStaleDataTest.cs
+++ b/csharp/test/Unit/Lz4DecompressNoStaleDataTest.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2025 ADBC Drivers Contributors
+* Copyright (c) 2026 ADBC Drivers Contributors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/csharp/test/Unit/Lz4DecompressNoStaleDataTest.cs
+++ b/csharp/test/Unit/Lz4DecompressNoStaleDataTest.cs
@@ -1,0 +1,96 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Buffers;
+using System.IO;
+using K4os.Compression.LZ4.Streams;
+using Microsoft.IO;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests
+{
+    /// <summary>
+    /// Safety proof for fix #4: <see cref="CustomLZ4FrameReader.ReleaseBuffer"/> now returns the LZ4
+    /// decoder's work buffer to the pool WITHOUT clearing it. This is only safe if the decoder never
+    /// surfaces bytes it did not decode into the buffer. These tests force exactly the worst case —
+    /// a pooled buffer pre-filled with poison (0xFF) on every rent — and assert decompression output
+    /// is still byte-exact, demonstrating the clear was unnecessary for correctness.
+    /// </summary>
+    public class Lz4DecompressNoStaleDataTest
+    {
+        /// <summary>
+        /// ArrayPool that hands back a single retained buffer, re-poisoned with 0xFF on every rent,
+        /// simulating a pooled work buffer that still holds bytes from a prior (unrelated) decompression.
+        /// </summary>
+        private sealed class PoisonPool : ArrayPool<byte>
+        {
+            private byte[]? _buffer;
+
+            public override byte[] Rent(int minimumLength)
+            {
+                if (_buffer == null || _buffer.Length < minimumLength)
+                {
+                    _buffer = new byte[minimumLength];
+                }
+                _buffer.AsSpan().Fill(0xFF); // worst-case stale data
+                return _buffer;
+            }
+
+            public override void Return(byte[] array, bool clearArray = false)
+            {
+                if (clearArray)
+                {
+                    Array.Clear(array, 0, array.Length);
+                }
+                // Retain the (already-stored) buffer so the next Rent reuses it.
+            }
+        }
+
+        private static byte[] Lz4Frame(byte[] src)
+        {
+            using var ms = new MemoryStream();
+            using (var enc = LZ4Stream.Encode(ms, leaveOpen: true))
+            {
+                enc.Write(src, 0, src.Length);
+            }
+            return ms.ToArray();
+        }
+
+        [Theory]
+        [InlineData(100)]            // tiny
+        [InlineData(64 * 1024)]      // ~one default block
+        [InlineData(1024 * 1024)]    // multi-block
+        public void Decompress_OverPoisonedReusedBuffer_ReturnsExactBytes(int size)
+        {
+            var payload = new byte[size];
+            new Random(99).NextBytes(payload);
+            byte[] compressed = Lz4Frame(payload);
+
+            var manager = new RecyclableMemoryStreamManager();
+            var poison = new PoisonPool();
+
+            // Decompress twice through the same never-cleared, re-poisoned work buffer.
+            byte[] first = Lz4Utilities.DecompressLz4(compressed, manager, poison).ToArray();
+            byte[] second = Lz4Utilities.DecompressLz4(compressed, manager, poison).ToArray();
+
+            // Exact equality proves no poison bytes leaked into the output and the length is exact:
+            // the decoder exposed only the bytes it decoded, so clearing on return is unnecessary.
+            Assert.Equal(payload, first);
+            Assert.Equal(payload, second);
+        }
+    }
+}

--- a/csharp/test/Unit/Lz4UtilitiesTests.cs
+++ b/csharp/test/Unit/Lz4UtilitiesTests.cs
@@ -45,7 +45,7 @@ namespace AdbcDrivers.Databricks.Tests
         public void DecompressLz4_ValidData_Success()
         {
             var compressed = Compress("test data");
-            var result = Lz4Utilities.DecompressLz4(compressed, _bufferPool);
+            var result = Lz4Utilities.DecompressLz4(compressed, _memoryManager, _bufferPool);
             Assert.Equal("test data", Encoding.UTF8.GetString(result.ToArray()));
         }
 
@@ -53,7 +53,7 @@ namespace AdbcDrivers.Databricks.Tests
         public void DecompressLz4_InvalidData_ThrowsAdbcException()
         {
             var invalid = new byte[] { 0x00, 0x01, 0x02 };
-            var ex = Assert.Throws<AdbcException>(() => Lz4Utilities.DecompressLz4(invalid, _bufferPool));
+            var ex = Assert.Throws<AdbcException>(() => Lz4Utilities.DecompressLz4(invalid, _memoryManager, _bufferPool));
             Assert.Contains("Failed to decompress LZ4 data", ex.Message);
         }
 

--- a/csharp/test/Unit/Reader/CloudFetch/CloudFetchBodyReadPerfTest.cs
+++ b/csharp/test/Unit/Reader/CloudFetch/CloudFetchBodyReadPerfTest.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2025 ADBC Drivers Contributors
+* Copyright (c) 2026 ADBC Drivers Contributors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
+#if NET6_0_OR_GREATER
+
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -100,13 +101,6 @@ namespace AdbcDrivers.Databricks.Tests.CloudFetch
             string l3 = $"  NEW (ReadResponseBodyAsync)  : {newMb,6:F2} MB/op   {neo.ms / iters,7:F3} ms/op";
             string l4 = $"  alloc ratio NEW/OLD = {(double)neo.bytes / old.bytes:F2}   time ratio NEW/OLD = {neo.ms / old.ms:F2}";
             _out.WriteLine(l1); _out.WriteLine(l2); _out.WriteLine(l3); _out.WriteLine(l4);
-            // Also persist to a file so results are captured regardless of test-logger verbosity.
-            try
-            {
-                string path = Path.Combine(Path.GetTempPath(), "bodyread_perf.txt");
-                File.AppendAllText(path, l1 + "\n" + l2 + "\n" + l3 + "\n" + l4 + "\n\n");
-            }
-            catch { /* best effort */ }
 
             // The fix should not allocate more than the old pattern; in practice it roughly halves it.
             Assert.True(neo.bytes <= old.bytes,
@@ -131,3 +125,5 @@ namespace AdbcDrivers.Databricks.Tests.CloudFetch
         }
     }
 }
+
+#endif

--- a/csharp/test/Unit/Reader/CloudFetch/CloudFetchBodyReadPerfTest.cs
+++ b/csharp/test/Unit/Reader/CloudFetch/CloudFetchBodyReadPerfTest.cs
@@ -1,0 +1,133 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.Reader.CloudFetch;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.Databricks.Tests.CloudFetch
+{
+    /// <summary>
+    /// Measures the effect of fix #1 (eliminating the redundant ToArray copy in the CloudFetch
+    /// body read) against the REAL <see cref="CloudFetchDownloader.ReadResponseBodyAsync"/> method.
+    /// The body is read from a genuine HttpContent response stream (the same type the production
+    /// path consumes via response.Content.ReadAsStreamAsync()).
+    /// </summary>
+    public class CloudFetchBodyReadPerfTest
+    {
+        private readonly ITestOutputHelper _out;
+
+        public CloudFetchBodyReadPerfTest(ITestOutputHelper output) => _out = output;
+
+        private static byte[] MakePayload(int size)
+        {
+            var data = new byte[size];
+            new Random(7).NextBytes(data);
+            return data;
+        }
+
+        /// <summary>A fresh HttpContent body stream of the given bytes, with Content-Length set.</summary>
+        private static async Task<Stream> BodyStreamAsync(byte[] payload)
+        {
+            var content = new ByteArrayContent(payload);
+            content.Headers.ContentLength = payload.Length;
+            return await content.ReadAsStreamAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>Replica of the pre-fix body read (CloudFetchDownloader before fix #1).</summary>
+        private static async Task<byte[]> OldPattern(Stream contentStream, long? contentLength, CancellationToken ct)
+        {
+            int capacity = contentLength.HasValue && contentLength.Value > 0 ? (int)contentLength.Value : 0;
+            using var ms = new MemoryStream(capacity);
+            await contentStream.CopyToAsync(ms, 81920, ct).ConfigureAwait(false);
+            return ms.ToArray();
+        }
+
+        [Theory]
+        [InlineData(1 * 1024 * 1024)]
+        [InlineData(8 * 1024 * 1024)]
+        public async Task BodyRead_RealMethod_AllocationsAndTime(int size)
+        {
+            byte[] payload = MakePayload(size);
+            const int iters = 200;
+            long len = payload.Length;
+
+            // --- Correctness: the real method returns exactly the same bytes as the old pattern. ---
+            byte[] oldBytes = await OldPattern(await BodyStreamAsync(payload), len, CancellationToken.None);
+            byte[] newBytes = await CloudFetchDownloader.ReadResponseBodyAsync(await BodyStreamAsync(payload), len, CancellationToken.None);
+            Assert.Equal(payload.Length, newBytes.Length);
+            Assert.Equal(payload, newBytes);
+            Assert.Equal(oldBytes, newBytes);
+
+            // Also exercise the unknown-length fallback path for correctness.
+            byte[] unknownLen = await CloudFetchDownloader.ReadResponseBodyAsync(await BodyStreamAsync(payload), null, CancellationToken.None);
+            Assert.Equal(payload, unknownLen);
+
+            // --- Warm up both arms. ---
+            for (int i = 0; i < 20; i++)
+            {
+                _ = await OldPattern(await BodyStreamAsync(payload), len, CancellationToken.None);
+                _ = await CloudFetchDownloader.ReadResponseBodyAsync(await BodyStreamAsync(payload), len, CancellationToken.None);
+            }
+
+            var old = await Measure(async () => await OldPattern(await BodyStreamAsync(payload), len, CancellationToken.None), iters);
+            var neo = await Measure(async () => await CloudFetchDownloader.ReadResponseBodyAsync(await BodyStreamAsync(payload), len, CancellationToken.None), iters);
+
+            double oldMb = old.bytes / (double)iters / 1024.0 / 1024.0;
+            double newMb = neo.bytes / (double)iters / 1024.0 / 1024.0;
+            string l1 = $"payload = {size / 1024 / 1024} MB ({Environment.Version}), iterations = {iters}";
+            string l2 = $"  OLD (MemoryStream + ToArray) : {oldMb,6:F2} MB/op   {old.ms / iters,7:F3} ms/op";
+            string l3 = $"  NEW (ReadResponseBodyAsync)  : {newMb,6:F2} MB/op   {neo.ms / iters,7:F3} ms/op";
+            string l4 = $"  alloc ratio NEW/OLD = {(double)neo.bytes / old.bytes:F2}   time ratio NEW/OLD = {neo.ms / old.ms:F2}";
+            _out.WriteLine(l1); _out.WriteLine(l2); _out.WriteLine(l3); _out.WriteLine(l4);
+            // Also persist to a file so results are captured regardless of test-logger verbosity.
+            try
+            {
+                string path = Path.Combine(Path.GetTempPath(), "bodyread_perf.txt");
+                File.AppendAllText(path, l1 + "\n" + l2 + "\n" + l3 + "\n" + l4 + "\n\n");
+            }
+            catch { /* best effort */ }
+
+            // The fix should not allocate more than the old pattern; in practice it roughly halves it.
+            Assert.True(neo.bytes <= old.bytes,
+                $"Expected new allocations ({newMb:F2} MB/op) <= old ({oldMb:F2} MB/op)");
+        }
+
+        private static async Task<(long bytes, double ms)> Measure(Func<Task<byte[]>> action, int iters)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < iters; i++)
+            {
+                byte[] r = await action().ConfigureAwait(false);
+                GC.KeepAlive(r);
+            }
+            sw.Stop();
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            return (after - before, sw.Elapsed.TotalMilliseconds);
+        }
+    }
+}

--- a/csharp/test/Unit/Reader/CloudFetch/CloudFetchBodyReadTest.cs
+++ b/csharp/test/Unit/Reader/CloudFetch/CloudFetchBodyReadTest.cs
@@ -1,0 +1,101 @@
+/*
+* Copyright (c) 2026 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.Reader.CloudFetch;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.CloudFetch
+{
+    /// <summary>
+    /// Correctness tests for <see cref="CloudFetchDownloader.ReadResponseBodyAsync"/>, focused on the
+    /// paths where the stream's actual length disagrees with the declared Content-Length. The method
+    /// must always return exactly the bytes the stream produced, regardless of the declared length.
+    /// These run on all target frameworks (unlike the NET6+-only allocation benchmark in
+    /// CloudFetchBodyReadPerfTest), and exercise the abnormal branch that the (offset + extra) sizing
+    /// optimizes — a truncated body must not over-allocate, an over-read must still drain fully.
+    /// </summary>
+    public class CloudFetchBodyReadTest
+    {
+        private static byte[] MakePayload(int size)
+        {
+            var data = new byte[size];
+            new Random(13).NextBytes(data);
+            return data;
+        }
+
+        [Fact]
+        public async Task ExactContentLength_ReturnsAllBytes()
+        {
+            byte[] payload = MakePayload(64 * 1024);
+            byte[] result = await CloudFetchDownloader.ReadResponseBodyAsync(
+                new MemoryStream(payload, writable: false), payload.Length, CancellationToken.None);
+            Assert.Equal(payload, result);
+        }
+
+        [Fact]
+        public async Task UnknownContentLength_ReturnsAllBytes()
+        {
+            byte[] payload = MakePayload(64 * 1024);
+            byte[] result = await CloudFetchDownloader.ReadResponseBodyAsync(
+                new MemoryStream(payload, writable: false), contentLength: null, CancellationToken.None);
+            Assert.Equal(payload, result);
+        }
+
+        [Fact]
+        public async Task ZeroContentLength_WithData_ReturnsAllBytes()
+        {
+            // Content-Length 0 falls through to the unknown-length (growable) branch.
+            byte[] payload = MakePayload(4096);
+            byte[] result = await CloudFetchDownloader.ReadResponseBodyAsync(
+                new MemoryStream(payload, writable: false), contentLength: 0, CancellationToken.None);
+            Assert.Equal(payload, result);
+        }
+
+        [Fact]
+        public async Task TruncatedBody_DeclaredLargerThanActual_ReturnsBytesReceived()
+        {
+            byte[] payload = MakePayload(500_000);
+            // Declare far more than the stream actually contains: the abnormal branch must return
+            // only what was received (and, with offset + extra sizing, not over-allocate to 4 MB).
+            byte[] result = await CloudFetchDownloader.ReadResponseBodyAsync(
+                new MemoryStream(payload, writable: false), contentLength: 4 * 1024 * 1024, CancellationToken.None);
+            Assert.Equal(payload, result);
+        }
+
+        [Fact]
+        public async Task MoreThanDeclared_DeclaredSmallerThanActual_ReturnsAllBytes()
+        {
+            byte[] payload = MakePayload(1_000_000);
+            // Declare fewer bytes than the stream actually contains: the over-read probe + drain must
+            // recover every byte.
+            byte[] result = await CloudFetchDownloader.ReadResponseBodyAsync(
+                new MemoryStream(payload, writable: false), contentLength: 500_000, CancellationToken.None);
+            Assert.Equal(payload, result);
+        }
+
+        [Fact]
+        public async Task EmptyBodyWithDeclaredLength_ReturnsEmpty()
+        {
+            byte[] result = await CloudFetchDownloader.ReadResponseBodyAsync(
+                new MemoryStream(Array.Empty<byte>()), contentLength: 1024, CancellationToken.None);
+            Assert.Empty(result);
+        }
+    }
+}

--- a/csharp/test/Unit/StatementExecution/ConcatenatedReadOnlyMemoryStreamTest.cs
+++ b/csharp/test/Unit/StatementExecution/ConcatenatedReadOnlyMemoryStreamTest.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2025 ADBC Drivers Contributors
+* Copyright (c) 2026 ADBC Drivers Contributors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,9 +16,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using AdbcDrivers.Databricks.StatementExecution;
 using Apache.Arrow;
@@ -158,6 +156,7 @@ namespace AdbcDrivers.Databricks.Tests.StatementExecution
             Assert.Equal(5, stream.Position);
         }
 
+#if NET6_0_OR_GREATER
         [Fact]
         public void ConcatenatedStream_AvoidsWholeResultAllocation()
         {
@@ -184,7 +183,6 @@ namespace AdbcDrivers.Databricks.Tests.StatementExecution
             double newKb = newBytes / (double)iters / 1024.0;
             string line = $"concat {size / 1024 / 1024} MB across {parts} segments: OLD {oldMb:F2} MB/op  NEW {newKb:F3} KB/op";
             _out.WriteLine(line);
-            try { File.AppendAllText(Path.Combine(Path.GetTempPath(), "concat_perf.txt"), line + "\n"); } catch { }
 
             // The new path should allocate essentially nothing per op (no whole-result copy).
             Assert.True(newBytes * 100 < oldBytes,
@@ -204,5 +202,6 @@ namespace AdbcDrivers.Databricks.Tests.StatementExecution
             }
             return GC.GetAllocatedBytesForCurrentThread() - before;
         }
+#endif
     }
 }

--- a/csharp/test/Unit/StatementExecution/ConcatenatedReadOnlyMemoryStreamTest.cs
+++ b/csharp/test/Unit/StatementExecution/ConcatenatedReadOnlyMemoryStreamTest.cs
@@ -1,0 +1,208 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.StatementExecution;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.Databricks.Tests.StatementExecution
+{
+    /// <summary>
+    /// Validates <see cref="ConcatenatedReadOnlyMemoryStream"/> (the core of SEA fix #2): reading an
+    /// Arrow IPC stream split across multiple segments must be byte-equivalent to the old approach of
+    /// concatenating every chunk into one buffer, and must avoid that whole-result allocation.
+    /// </summary>
+    public class ConcatenatedReadOnlyMemoryStreamTest
+    {
+        private readonly ITestOutputHelper _out;
+
+        public ConcatenatedReadOnlyMemoryStreamTest(ITestOutputHelper output) => _out = output;
+
+        private static byte[] BuildArrowIpc(int rows)
+        {
+            var schema = new Schema(
+                new[]
+                {
+                    new Field("id", Int32Type.Default, nullable: false),
+                    new Field("name", StringType.Default, nullable: true),
+                },
+                metadata: null);
+
+            var idBuilder = new Int32Array.Builder();
+            var nameBuilder = new StringArray.Builder();
+            for (int i = 0; i < rows; i++)
+            {
+                idBuilder.Append(i);
+                if (i % 7 == 0) nameBuilder.AppendNull();
+                else nameBuilder.Append($"row-{i}-some-padding-text-to-grow-the-buffer");
+            }
+
+            var batch = new RecordBatch(schema, new IArrowArray[] { idBuilder.Build(), nameBuilder.Build() }, rows);
+
+            using var ms = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(ms, schema))
+            {
+                writer.WriteRecordBatch(batch);
+                writer.WriteEnd();
+            }
+            return ms.ToArray();
+        }
+
+        /// <summary>Split a byte[] into <paramref name="parts"/> segments of nearly-equal size.</summary>
+        private static List<ReadOnlyMemory<byte>> SplitEqual(byte[] data, int parts)
+        {
+            var segments = new List<ReadOnlyMemory<byte>>(parts);
+            int chunk = Math.Max(1, data.Length / parts);
+            int offset = 0;
+            while (offset < data.Length)
+            {
+                int len = Math.Min(chunk, data.Length - offset);
+                segments.Add(new ReadOnlyMemory<byte>(data, offset, len));
+                offset += len;
+            }
+            return segments;
+        }
+
+        private static async Task<(int batches, long rows, int firstId, string? lastName)> ReadAllAsync(Stream stream)
+        {
+            using var reader = new ArrowStreamReader(stream);
+            int batches = 0;
+            long rows = 0;
+            int firstId = -1;
+            string? lastName = null;
+            RecordBatch? batch;
+            while ((batch = await reader.ReadNextRecordBatchAsync()) != null)
+            {
+                using (batch)
+                {
+                    batches++;
+                    rows += batch.Length;
+                    var ids = (Int32Array)batch.Column(0);
+                    var names = (StringArray)batch.Column(1);
+                    if (firstId == -1 && batch.Length > 0) firstId = ids.GetValue(0)!.Value;
+                    if (batch.Length > 0) lastName = names.GetString(batch.Length - 1);
+                }
+            }
+            return (batches, rows, firstId, lastName);
+        }
+
+        [Theory]
+        [InlineData(1)]     // single segment
+        [InlineData(2)]
+        [InlineData(5)]     // forces reads across message boundaries
+        [InlineData(1000)]  // many tiny segments: stress cross-segment partial reads
+        public async Task ConcatenatedStream_MatchesContiguousBuffer(int parts)
+        {
+            const int rows = 5000;
+            byte[] ipc = BuildArrowIpc(rows);
+            var segments = SplitEqual(ipc, parts);
+
+            // Baseline: old approach — concatenate segments into one buffer, wrap in MemoryStream.
+            byte[] concatenated = new byte[ipc.Length];
+            int off = 0;
+            foreach (var s in segments) { s.Span.CopyTo(concatenated.AsSpan(off)); off += s.Length; }
+            Assert.Equal(ipc, concatenated); // sanity: split+concat round-trips
+
+            var expected = await ReadAllAsync(new MemoryStream(concatenated));
+            var actual = await ReadAllAsync(new ConcatenatedReadOnlyMemoryStream(segments));
+
+            Assert.Equal(expected.batches, actual.batches);
+            Assert.Equal(rows, actual.rows);
+            Assert.Equal(expected.rows, actual.rows);
+            Assert.Equal(expected.firstId, actual.firstId);
+            Assert.Equal(expected.lastName, actual.lastName);
+        }
+
+        [Fact]
+        public void ConcatenatedStream_ReportsLengthAndIsForwardOnly()
+        {
+            var segments = new List<ReadOnlyMemory<byte>>
+            {
+                new byte[] { 1, 2, 3 },
+                ReadOnlyMemory<byte>.Empty,   // empty segment must be skipped
+                new byte[] { 4, 5 },
+            };
+            using var stream = new ConcatenatedReadOnlyMemoryStream(segments);
+            Assert.Equal(5, stream.Length);
+            Assert.False(stream.CanSeek);
+            Assert.True(stream.CanRead);
+
+            // Reading 1 byte at a time crosses every segment boundary (incl. the empty one).
+            var collected = new List<byte>();
+            var one = new byte[1];
+            int n;
+            while ((n = stream.Read(one, 0, 1)) > 0) collected.Add(one[0]);
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, collected.ToArray());
+            Assert.Equal(5, stream.Position);
+        }
+
+        [Fact]
+        public void ConcatenatedStream_AvoidsWholeResultAllocation()
+        {
+            const int parts = 8;
+            const int size = 8 * 1024 * 1024;
+            var data = new byte[size];
+            new Random(11).NextBytes(data);
+            var segments = SplitEqual(data, parts);
+            const int iters = 200;
+
+            // OLD: concatenate all segments into one buffer (as FetchAllChunksAsync did) + wrap.
+            long oldBytes = Measure(() =>
+            {
+                byte[] result = new byte[size];
+                int off = 0;
+                foreach (var s in segments) { s.Span.CopyTo(result.AsSpan(off)); off += s.Length; }
+                return new MemoryStream(result);
+            }, iters);
+
+            // NEW: present segments as a stream — no whole-result buffer.
+            long newBytes = Measure(() => new ConcatenatedReadOnlyMemoryStream(segments), iters);
+
+            double oldMb = oldBytes / (double)iters / 1024.0 / 1024.0;
+            double newKb = newBytes / (double)iters / 1024.0;
+            string line = $"concat {size / 1024 / 1024} MB across {parts} segments: OLD {oldMb:F2} MB/op  NEW {newKb:F3} KB/op";
+            _out.WriteLine(line);
+            try { File.AppendAllText(Path.Combine(Path.GetTempPath(), "concat_perf.txt"), line + "\n"); } catch { }
+
+            // The new path should allocate essentially nothing per op (no whole-result copy).
+            Assert.True(newBytes * 100 < oldBytes,
+                $"Expected new allocations ({newKb:F3} KB/op) to be far below old ({oldMb:F2} MB/op)");
+        }
+
+        private static long Measure(Func<Stream> action, int iters)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < iters; i++)
+            {
+                Stream s = action();
+                GC.KeepAlive(s);
+            }
+            return GC.GetAllocatedBytesForCurrentThread() - before;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Four independent reductions in CPU/memory overhead on the result-transfer path. Each is small, localized, and covered by tests. Allocation figures below are from microbenchmarks (BenchmarkDotNet / `GC.GetAllocatedBytesForCurrentThread`).

| # | Area | Change | Effect |
|---|------|--------|--------|
| 1 | CloudFetch download (`CloudFetchDownloader`) | Read the HTTP body into one right-sized buffer instead of `MemoryStream` + `ToArray` | Removes a second full-size copy/alloc per chunk — ~2× faster, ½ allocation (8 MB: 16 → 8 MB/op) |
| 2 | SEA inline results (`StatementExecutionStatement`) | Feed chunks to `ArrowStreamReader` via a new forward-only `ConcatenatedReadOnlyMemoryStream` instead of `ToArray`-ing each chunk and concatenating into one buffer | Eliminates the whole-result allocation (8 MB/op → 0.055 KB/op) and the per-chunk copies |
| 3 | LZ4 decompression (`Lz4Utilities`) | Decompress into a pooled `RecyclableMemoryStream` + exact `ToArray` instead of a geometrically growing `MemoryStream` | Removes LOH growth churn and the over-sized result buffer (4 MB batch: 7.88 → 4.01 MB/op). Helps the inline Thrift reader **and** the SEA path |
| 4 | LZ4 work buffer (`CustomLZ4FrameReader`) | Return the decoder's work buffer without clearing it | ~83 µs/4 MB buffer saved; the decode overwrites it anyway |

Fixes #2 and #3 share `Lz4Utilities.DecompressLz4`; #3 threads the connection's existing `RecyclableMemoryStreamManager` to both the inline and SEA call sites.

## Why each is safe

- **2** — the SEA server splits a single Arrow IPC stream across N attachment chunks, so reading the segments back-to-back is byte-equivalent to the old concatenated buffer. `ConcatenatedReadOnlyMemoryStreamTest` verifies `ArrowStreamReader` returns identical batches/rows/values when the IPC bytes are split into 1 / 2 / 5 / 1000 segments (the 1000-segment case stresses cross-boundary reads).
- **3** — the returned array is an exact-size, GC-owned copy, so it stays valid for the `RecordBatch`'s lifetime after the pooled blocks are returned. Round-trip + equivalence asserted in `Lz4DecompressAllocationTest`.
- **4** — K4os bounds reads to the number of bytes it decoded, so stale buffer bytes are never surfaced. `Lz4DecompressNoStaleDataTest` proves this by decoding through a deliberately `0xFF`-poisoned, reused, never-cleared work buffer and still getting byte-exact output.

## Tests

New: `ConcatenatedReadOnlyMemoryStreamTest`, `Lz4DecompressNoStaleDataTest` (correctness), `CloudFetchBodyReadPerfTest`, `Lz4DecompressAllocationTest` (allocation characterization, loose ratio asserts). Updated `Lz4UtilitiesTests` for the new `DecompressLz4` signature. All pass locally on net8.0; the existing `CloudFetchDownloaderTest` / SEA `StatementExecution` suites stay green.

## Notes for reviewers

- The two allocation-characterization tests assert relative allocation (e.g. new ≤ old). If you'd prefer they not run in CI, I can gate them behind a trait or `SkippableFact`.
- **4 trade-off:** the previous `clearArray: true` could be read as memory-hygiene defense-in-depth. It was inconsistent anyway — the decompressed result also passes through `RecyclableMemoryStream` output blocks that are returned without clearing — so this is not a regression in end-to-end hygiene. If deliberate zeroing of sensitive data is wanted, that's a separate, end-to-end decision. Happy to drop #4 alone.
- The standalone `perf-analysis/` microbenchmark project used during analysis is intentionally **not** included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
