### PR TITLE
tracing(csharp): tag Execute spans with query_timeout_s

### DIFF
--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -466,6 +466,12 @@ namespace AdbcDrivers.Databricks
             Activity.Current?.SetTag("statement.property.complex_types_as_arrow", statement.UseArrowNativeTypes.ComplexTypesAsArrow);
             Activity.Current?.SetTag("statement.property.interval_types_as_arrow", statement.UseArrowNativeTypes.IntervalTypesAsArrow);
 
+            // Issue #478: propagate the configured query timeout onto the Execute
+            // span so timeout-related failures self-explain in traces. Previously the
+            // tag only appeared on CreateSessionRequest of a different trace, forcing
+            // operators to do duration math to infer the threshold.
+            Activity.Current?.SetTag(ApacheParameters.QueryTimeoutSeconds, QueryTimeoutSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
             // Log CloudFetch configuration
             Activity.Current?.SetTag("statement.cloudfetch.enabled", useCloudFetch);
             Activity.Current?.SetTag("statement.cloudfetch.can_decompress_lz4", canDecompressLz4);

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -22,7 +22,9 @@
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -157,6 +159,80 @@ namespace AdbcDrivers.Databricks.Tests
                 Add(new(null, LongRunningQuery, typeof(TimeoutException)));
                 Add(new(0, LongRunningQuery, null));
             }
+        }
+
+        /// <summary>
+        /// Regression test for issue #478: when a query times out, the failing
+        /// HiveServer2Statement.ExecuteStatementAsync / ExecuteQueryAsyncInternal
+        /// spans must carry the configured "adbc.apache.statement.query_timeout_s"
+        /// tag so an operator reading just the failing span can see the threshold
+        /// without doing duration math from CreateSessionRequest of a different trace.
+        /// </summary>
+        [SkippableFact]
+        public void StatementTimeout_TagsExecuteSpanWithQueryTimeoutSeconds_Issue478()
+        {
+            // Arrange: short timeout against a query guaranteed to exceed it.
+            const int queryTimeoutSeconds = 5;
+            const string expectedTagKey = ApacheParameters.QueryTimeoutSeconds; // "adbc.apache.statement.query_timeout_s"
+
+            var stoppedActivities = new ConcurrentBag<Activity>();
+            var activitySourceNames = new HashSet<string>
+            {
+                "AdbcDrivers.Databricks",
+                "AdbcDrivers.Databricks.StatementExecution",
+                "AdbcDrivers.HiveServer2",
+            };
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => activitySourceNames.Contains(source.Name),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => stoppedActivities.Add(activity),
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var testConfiguration = (DatabricksTestConfiguration)TestConfiguration.Clone();
+            testConfiguration.QueryTimeoutSeconds = queryTimeoutSeconds.ToString();
+            testConfiguration.Query = LongRunningStatementTimeoutTestData.LongRunningQuery;
+
+            // Act + Assert (timeout)
+            Assert.Throws<TimeoutException>(() =>
+            {
+                using AdbcConnection connection = NewConnection(testConfiguration);
+                using AdbcStatement statement = connection.CreateStatement();
+                statement.SqlQuery = testConfiguration.Query;
+                statement.ExecuteQuery();
+            });
+
+            // Assert (tag is propagated): find the failing Execute span and confirm
+            // it carries the configured query_timeout_s threshold.
+            string[] candidateOperationNameSuffixes = new[]
+            {
+                ".ExecuteStatementAsync",
+                ".ExecuteQueryAsyncInternal",
+            };
+
+            var executeSpans = stoppedActivities
+                .Where(a => candidateOperationNameSuffixes.Any(sfx => a.OperationName.EndsWith(sfx, StringComparison.Ordinal)))
+                .ToList();
+
+            Assert.True(executeSpans.Count > 0,
+                $"Expected at least one Execute span among captured activities (got {stoppedActivities.Count}); " +
+                $"operation names: [{string.Join(", ", stoppedActivities.Select(a => a.OperationName).Distinct())}]");
+
+            // The fix is: at least one Execute span must carry the configured timeout
+            // value as a tag. We accept either the canonical ApacheParameters key
+            // ("adbc.apache.statement.query_timeout_s") on the span tags.
+            var taggedSpan = executeSpans.FirstOrDefault(a =>
+                a.Tags.Any(t => string.Equals(t.Key, expectedTagKey, StringComparison.Ordinal) &&
+                                string.Equals(t.Value, queryTimeoutSeconds.ToString(), StringComparison.Ordinal)));
+
+            Assert.True(taggedSpan != null,
+                $"Expected an Execute span tagged with '{expectedTagKey}={queryTimeoutSeconds}'. " +
+                $"Inspected {executeSpans.Count} Execute span(s); their tags: [" +
+                string.Join(" | ", executeSpans.Select(a =>
+                    a.OperationName + ": " + string.Join(",", a.Tags.Select(t => $"{t.Key}={t.Value}")))) +
+                "]");
         }
 
         protected override void CreateNewTableName(out string tableName, out string fullTableName)


### PR DESCRIPTION
## Motivation

When a query times out (e.g. `QueryTimeoutSeconds=5` against a long
count-over-join), the trace correctly records `Status=Error` on
`HiveServer2Statement.ExecuteQueryAsyncInternal` /
`ExecuteStatementAsync` with `exception.type=TTransportException` and
the cancel-operation event chain. But the configured timeout value
(`adbc.apache.statement.query_timeout_s`) only lived on the
`CreateSessionRequest` of a *different* trace. The timing-out span
carried no threshold tag, so an operator reading just the failing span
had to do duration math ("Duration=5.30s -> probably a 5s timeout") to
recover the configured threshold. See issue #478.

## What changed

- `csharp/src/DatabricksStatement.cs` — in the
  `SetStatementProperties(TExecuteStatementReq)` override (which runs
  inside the `HiveServer2Statement.ExecuteStatementAsync` activity),
  emit `Activity.Current?.SetTag(ApacheParameters.QueryTimeoutSeconds,
  QueryTimeoutSeconds.ToString(InvariantCulture))`. Matches the
  existing tag-naming convention exactly
  (`adbc.apache.statement.query_timeout_s`) so debugger/log queries
  keyed on this name work uniformly across CreateSession and Execute
  spans.

## Test added

`StatementTimeout_TagsExecuteSpanWithQueryTimeoutSeconds_Issue478` in
`csharp/test/E2E/StatementTests.cs`. Wires an `ActivityListener`
against the Databricks/HiveServer2 activity sources, configures
`QueryTimeoutSeconds=5`, runs the existing
`LongRunningStatementTimeoutTestData.LongRunningQuery`, asserts
`Assert.Throws<TimeoutException>(...)`, and then asserts that at
least one captured Execute span carries
`adbc.apache.statement.query_timeout_s=5`. Before the fix this test
fails with the expected diagnostic ("Inspected 2 Execute span(s);
their tags: [...] -- no `query_timeout_s` tag"); after the fix it
passes.

The test was committed first as RED (failing), then the production
fix was applied to turn it GREEN — see commits on this branch.

## Regression check

`StatementTests` class: 95 passed / 3 skipped / 0 failed against
`sf10-pat`.

Closes #478

This pull request and its description were written by Isaac.