### PR TITLE
tracing(csharp): omit db.response.returned_rows tag when -1 sentinel

### DIFF
--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,6 +58,70 @@ namespace AdbcDrivers.Databricks
         // improving query performance by reducing the number of FetchResults calls needed.
         internal const long DatabricksBatchSizeDefault = 2000000;
         private const string QueryTagsKey = "query_tags";
+
+        // Issue #484: HiveServer2Statement.ExecuteUpdateAsyncInternal (in the
+        // submodule) unconditionally tags every UPDATE-flavored span with
+        // `db.response.returned_rows = -1` when Thrift returns no num_affected_rows
+        // column (CREATE / DDL paths). The -1 sentinel clutters APM dashboards by
+        // sorting alongside legitimate row counts. We can't modify the submodule, so
+        // we register a one-time process-global ActivityListener that strips the
+        // tag during ActivityStopped notification. The listener is registered before
+        // any FileActivityListener (which is created per-connection in Open()), so
+        // file exporters never see the -1 either.
+        //
+        // The static constructor below forces eager initialization of this field
+        // (defeating beforeFieldInit) so the listener is in place before the first
+        // ExecuteUpdate span is emitted.
+        private const string ReturnedRowsTagKey = "db.response.returned_rows";
+        private static readonly ActivityListener s_returnedRowsSentinelStripper = RegisterReturnedRowsSentinelStripper();
+
+        private static ActivityListener RegisterReturnedRowsSentinelStripper()
+        {
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                // PropagationData is the lowest sampling level that still delivers
+                // ActivityStopped notifications. The effective recording level is
+                // the max across all registered listeners, so this does NOT degrade
+                // recording for other listeners that ask for AllDataAndRecorded.
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.PropagationData,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.PropagationData,
+                ActivityStopped = activity =>
+                {
+                    try
+                    {
+                        // Cheap pre-check: only inspect tags if the operation name matches
+                        // the offending submodule method.
+                        if (!activity.OperationName.EndsWith(".ExecuteUpdateAsyncInternal", StringComparison.Ordinal))
+                        {
+                            return;
+                        }
+                        foreach (var tag in activity.TagObjects)
+                        {
+                            if (!string.Equals(tag.Key, ReturnedRowsTagKey, StringComparison.Ordinal)) continue;
+                            // Match either boxed long/int -1 or string "-1".
+                            if ((tag.Value is long l && l == -1L)
+                                || (tag.Value is int i && i == -1)
+                                || (tag.Value != null && string.Equals(tag.Value.ToString(), "-1", StringComparison.Ordinal)))
+                            {
+                                // SetTag(key, null) removes the tag. Valid while the
+                                // activity is mid-Stop notification: IsStopped flips to
+                                // true only after all ActivityStopped listeners return.
+                                activity.SetTag(ReturnedRowsTagKey, null);
+                            }
+                            break;
+                        }
+                    }
+                    catch
+                    {
+                        // Telemetry must never impact driver operations.
+                    }
+                },
+            };
+            ActivitySource.AddActivityListener(listener);
+            return listener;
+        }
+
         private bool useCloudFetch;
         private bool canDecompressLz4;
         private long maxBytesPerFile;
@@ -96,6 +161,14 @@ namespace AdbcDrivers.Databricks
         internal Exception? CloseStatementRpcError { get; set; }
 
         public override long BatchSize { get; protected set; } = DatabricksBatchSizeDefault;
+
+        // Explicit static constructor forces eager static initialization (instead of
+        // beforeFieldInit lazy semantics), guaranteeing s_returnedRowsSentinelStripper
+        // is registered before the first ExecuteUpdate span is emitted.
+        static DatabricksStatement()
+        {
+            _ = s_returnedRowsSentinelStripper;
+        }
 
         public DatabricksStatement(DatabricksConnection connection)
             : base(connection)

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -22,7 +22,9 @@
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -157,6 +159,80 @@ namespace AdbcDrivers.Databricks.Tests
                 Add(new(null, LongRunningQuery, typeof(TimeoutException)));
                 Add(new(0, LongRunningQuery, null));
             }
+        }
+
+        /// <summary>
+        /// Regression test for issue #484: HiveServer2Statement.ExecuteUpdateAsyncInternal
+        /// emits `db.response.returned_rows = -1` on every UPDATE-flavored statement
+        /// (CREATE/INSERT/UPDATE/DELETE) because Thrift doesn't return an affected-row
+        /// count via this pathway. The misleading sentinel clutters APM dashboards.
+        ///
+        /// The fix should ensure that when the value is -1, the tag is omitted entirely
+        /// (backends naturally interpret absent-tag as "unknown"). When the server does
+        /// return an affected-row count (>= 0), the tag should still be present.
+        /// </summary>
+        [SkippableFact]
+        public async Task ExecuteUpdate_DoesNotEmitMinusOneReturnedRows_Issue484()
+        {
+            const string returnedRowsTagKey = "db.response.returned_rows";
+
+            var stoppedActivities = new ConcurrentBag<Activity>();
+            var activitySourceNames = new HashSet<string>
+            {
+                "AdbcDrivers.Databricks",
+                "AdbcDrivers.Databricks.StatementExecution",
+                "AdbcDrivers.HiveServer2",
+            };
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => activitySourceNames.Contains(source.Name),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => stoppedActivities.Add(activity),
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            // Use a transient table so we never collide with seeded state.
+            CreateNewTableName(out _, out string fullTableName);
+
+            using AdbcStatement createStmt = Connection.CreateStatement();
+            createStmt.SqlQuery = $"CREATE TABLE IF NOT EXISTS {fullTableName} (id INT, name STRING)";
+            await createStmt.ExecuteUpdateAsync();
+
+            try
+            {
+                using AdbcStatement insertStmt = Connection.CreateStatement();
+                insertStmt.SqlQuery = $"INSERT INTO {fullTableName} VALUES (1, 'a'), (2, 'b'), (3, 'c')";
+                await insertStmt.ExecuteUpdateAsync();
+
+                using AdbcStatement updateStmt = Connection.CreateStatement();
+                updateStmt.SqlQuery = $"UPDATE {fullTableName} SET name = 'updated' WHERE id = 1";
+                await updateStmt.ExecuteUpdateAsync();
+            }
+            finally
+            {
+                using AdbcStatement dropStmt = Connection.CreateStatement();
+                dropStmt.SqlQuery = $"DROP TABLE IF EXISTS {fullTableName}";
+                await dropStmt.ExecuteUpdateAsync();
+            }
+
+            // Inspect every captured activity (UPDATE-flavored statements run through
+            // HiveServer2Statement.ExecuteUpdateAsyncInternal — the offending span).
+            // No span should carry the -1 sentinel.
+            var spansWithMinusOne = stoppedActivities
+                .Where(a => a.TagObjects.Any(t =>
+                    string.Equals(t.Key, returnedRowsTagKey, StringComparison.Ordinal) &&
+                    t.Value is { } v &&
+                    string.Equals(v.ToString(), "-1", StringComparison.Ordinal)))
+                .ToList();
+
+            Assert.True(spansWithMinusOne.Count == 0,
+                $"Expected no captured spans to emit '{returnedRowsTagKey}=-1', but {spansWithMinusOne.Count} did. " +
+                $"Offending operation names: [{string.Join(", ", spansWithMinusOne.Select(a => a.OperationName).Distinct())}]. " +
+                $"Tags on offending spans: [" +
+                string.Join(" | ", spansWithMinusOne.Select(a =>
+                    a.OperationName + ": " + string.Join(",", a.TagObjects.Select(t => $"{t.Key}={t.Value}")))) +
+                "]");
         }
 
         protected override void CreateNewTableName(out string tableName, out string fullTableName)


### PR DESCRIPTION
## Motivation

`HiveServer2Statement.ExecuteUpdateAsyncInternal` (in the
hiveserver2 submodule) always tags UPDATE-flavored spans
(CREATE/INSERT/UPDATE/DELETE/DROP) with
`db.response.returned_rows = -1` when the Thrift response carries no
`num_affected_rows` column — i.e., for DDL paths where the server
genuinely doesn't return an affected-row count. The `-1` is a sentinel
masquerading as a row count: in APM dashboards it sorts alongside
legitimate counts, and consumers naturally misread it as "we measured
zero" or "we don't know". See issue #484.

## What changed

- `csharp/src/DatabricksStatement.cs` — adds a one-time process-global
  `ActivityListener` registered in an eager static initializer. The
  listener inspects every `*.ExecuteUpdateAsyncInternal` span on
  `ActivityStopped` and, when `db.response.returned_rows` carries the
  `-1` sentinel, removes the tag entirely via `SetTag(key, null)`. Tag
  removal during `ActivityStopped` is safe: `Activity.IsStopped` flips
  to `true` only after all `ActivityStopped` callbacks return.
- The listener's `Sample` callback returns `PropagationData` (the
  minimum sampling level that still delivers `ActivityStopped`
  notifications). Effective recording level across listeners is the
  max, so this does NOT degrade other listeners that ask for
  `AllDataAndRecorded`.
- An explicit `static DatabricksStatement()` constructor forces eager
  static-field initialization (defeating `beforeFieldInit` lazy
  semantics), guaranteeing the listener is registered before any
  per-connection `FileActivityListener` subscribes — so file exporters
  also never see the `-1` value.
- When the Thrift response does carry a real `num_affected_rows` (>= 0),
  the existing submodule code path tags the span with that value
  unchanged.

The submodule is read-only from this repo (same constraint as
PR #490 / issue #478), so the listener-based scrub is the least
invasive in-driver fix.

## Test added

`ExecuteUpdate_DoesNotEmitMinusOneReturnedRows_Issue484` in
`csharp/test/E2E/StatementTests.cs`. Wires an `ActivityListener`
over the Databricks/HiveServer2 activity sources, runs
CREATE/INSERT/UPDATE/DROP through `ExecuteUpdateAsyncInternal` against
a transient table, then asserts that no captured Execute span carries
`db.response.returned_rows = -1`. Without the fix the test fails with
two offending CREATE/DROP spans carrying the sentinel (INSERT/UPDATE
have positive affected_rows so they're naturally unaffected). With the
fix the test passes.

The test was committed first as RED (failing), then the production
fix turned it GREEN — see commits on this branch.

## Regression check

- `StatementTests` class: 95 passed / 3 skipped / 0 failed against
  the configured Thrift workspace.
- `DriverTests` class: 35 passed / 0 failed.

Closes #484

This pull request and its description were written by Isaac.