### PR TITLE
fix(csharp): bracket close_operation event for measurable latency

### DIFF
--- a/csharp/src/Reader/DatabricksCompositeReader.cs
+++ b/csharp/src/Reader/DatabricksCompositeReader.cs
@@ -252,7 +252,18 @@ namespace AdbcDrivers.Databricks.Reader
                             // Always close the operation here at the composite level.
                             // CloudFetchReader is protocol-agnostic and does not send CloseOperation,
                             // so we must not rely on the contained reader to do it.
-                            activity?.AddEvent("composite_reader.close_operation");
+                            //
+                            // Issue #489: bracket the Thrift TCloseOperationReq RPC with a pair
+                            // of events ("...started" before, "...completed" after) so the
+                            // timestamp delta between them captures the RPC's wall-clock
+                            // latency in the trace. Previously a single
+                            // "composite_reader.close_operation" event was emitted before the
+                            // call, which made its timestamp identical to the surrounding
+                            // "composite_reader.disposing" event and hid the RPC's cost.
+                            // Mirrors the cancel_operation event-pair pattern used in
+                            // HiveServer2Statement.CancelOperationAsync ("...starting" /
+                            // "...completed").
+                            activity?.AddEvent("composite_reader.close_operation.started");
                             // Time the TCloseOperationReq RPC so CLOSE_STATEMENT telemetry
                             // emitted later from DatabricksStatement.Dispose can report the
                             // actual server-side close latency (PECO-2991).
@@ -276,6 +287,13 @@ namespace AdbcDrivers.Databricks.Reader
                                     dbxStatement.CloseStatementRpcLatencyMs = closeStopwatch.ElapsedMilliseconds;
                                     dbxStatement.CloseStatementRpcError = closeError;
                                 }
+                                // Emit the matching "completed" event regardless of whether
+                                // the RPC threw so the trace always records when the close
+                                // call returned. Tag with error=true on failure so consumers
+                                // can distinguish a clean close from a thrown one.
+                                activity?.AddEvent(
+                                    "composite_reader.close_operation.completed",
+                                    [new("error", closeError != null)]);
                             }
                             if (_activeReader != null)
                             {

--- a/csharp/src/Reader/DatabricksCompositeReader.cs
+++ b/csharp/src/Reader/DatabricksCompositeReader.cs
@@ -290,10 +290,12 @@ namespace AdbcDrivers.Databricks.Reader
                                 }
                                 // Emit the matching "completed" event regardless of whether
                                 // the RPC threw so the trace always records when the close
-                                // call returned. Error details, if any, are surfaced via
-                                // AddException above (matches the convention used in
-                                // HiveServer2Statement.CancelOperationAsync).
-                                activity?.AddEvent("composite_reader.close_operation.completed");
+                                // call returned. Error details are also surfaced via
+                                // AddException above; the tag here lets consumers filter
+                                // clean vs. failed closes without parsing the exception.
+                                activity?.AddEvent("composite_reader.close_operation.completed", [
+                                    new("error", closeError != null)
+                                ]);
                             }
                             if (_activeReader != null)
                             {

--- a/csharp/src/Reader/DatabricksCompositeReader.cs
+++ b/csharp/src/Reader/DatabricksCompositeReader.cs
@@ -277,6 +277,7 @@ namespace AdbcDrivers.Databricks.Reader
                             catch (Exception ex)
                             {
                                 closeError = ex;
+                                activity?.AddException(ex);
                                 throw;
                             }
                             finally
@@ -289,11 +290,10 @@ namespace AdbcDrivers.Databricks.Reader
                                 }
                                 // Emit the matching "completed" event regardless of whether
                                 // the RPC threw so the trace always records when the close
-                                // call returned. Tag with error=true on failure so consumers
-                                // can distinguish a clean close from a thrown one.
-                                activity?.AddEvent(
-                                    "composite_reader.close_operation.completed",
-                                    [new("error", closeError != null)]);
+                                // call returned. Error details, if any, are surfaced via
+                                // AddException above (matches the convention used in
+                                // HiveServer2Statement.CancelOperationAsync).
+                                activity?.AddEvent("composite_reader.close_operation.completed");
                             }
                             if (_activeReader != null)
                             {

--- a/csharp/test/E2E/CloseOperationE2ETest.cs
+++ b/csharp/test/E2E/CloseOperationE2ETest.cs
@@ -47,6 +47,7 @@ namespace AdbcDrivers.Databricks.Tests
     public class CloseOperationE2ETest : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>, IDisposable
     {
         private readonly List<(string ActivityName, string EventName)> _capturedEvents = new();
+        private readonly List<(string ActivityName, ActivityEvent Event)> _capturedFullEvents = new();
         private readonly object _capturedEventsLock = new();
         private readonly ActivityListener _activityListener;
         private bool _disposed;
@@ -67,6 +68,7 @@ namespace AdbcDrivers.Databricks.Tests
                         foreach (var evt in activity.Events)
                         {
                             _capturedEvents.Add((activity.OperationName, evt.Name));
+                            _capturedFullEvents.Add((activity.OperationName, evt));
                         }
                     }
                 }
@@ -181,6 +183,112 @@ namespace AdbcDrivers.Databricks.Tests
                     $"[{description}] composite_reader.close_operation event not found in " +
                     $"DatabricksCompositeReader.Dispose. Without the fix, server operations are " +
                     $"orphaned until SQL Gateway closes them with CommandInactivityTimeout (~1 hour).");
+            }
+            finally
+            {
+                connection.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Regression test for issue #489: the trace events bracketing the Thrift
+        /// CloseOperation RPC must allow operators to measure the RPC's latency.
+        ///
+        /// Previously DatabricksCompositeReader.Dispose emitted a single
+        /// "composite_reader.close_operation" event before invoking the RPC, so its
+        /// timestamp was identical to the surrounding "composite_reader.disposing"
+        /// event and the RPC's wall-clock cost was invisible in traces.
+        ///
+        /// The fix mirrors the cancel_operation event-pair pattern used in
+        /// HiveServer2Statement.CancelOperationAsync ("db.operation.cancel_operation.starting"
+        /// + ".completed"): emit "composite_reader.close_operation.started" BEFORE the
+        /// RPC and "composite_reader.close_operation.completed" AFTER it, so the
+        /// timestamp delta between them captures the RPC's latency.
+        /// </summary>
+        [SkippableFact]
+        public async Task DisposeCloseOperation_EmitsStartedAndCompletedWithDistinctTimestamps_Issue489()
+        {
+            lock (_capturedEventsLock)
+            {
+                _capturedEvents.Clear();
+                _capturedFullEvents.Clear();
+            }
+
+            var parameters = new Dictionary<string, string>
+            {
+                [DatabricksParameters.Protocol] = "thrift",
+                [DatabricksParameters.UseCloudFetch] = "false",
+                [DatabricksParameters.EnableDirectResults] = "false",
+            };
+
+            // Use a query that requires a real (non-inline) CloseOperation RPC so the
+            // event pair brackets a network round-trip with measurable latency.
+            const string query = "SELECT * FROM range(1, 100)";
+
+            var connection = NewConnection(TestConfiguration, parameters);
+            try
+            {
+                var statement = connection.CreateStatement();
+                statement.SqlQuery = query;
+                var result = await statement.ExecuteQueryAsync();
+
+                using (var reader = result.Stream!)
+                {
+                    RecordBatch? batch;
+                    while ((batch = await reader.ReadNextRecordBatchAsync()) != null)
+                    {
+                    }
+                }
+                // Reader.Dispose() above triggers DatabricksCompositeReader.Dispose,
+                // which is where the close_operation events are emitted.
+                statement.Dispose();
+
+                // Pull the events emitted by DatabricksCompositeReader.Dispose.
+                List<ActivityEvent> disposeEvents;
+                lock (_capturedEventsLock)
+                {
+                    disposeEvents = _capturedFullEvents
+                        .Where(e => e.ActivityName == "DatabricksCompositeReader.Dispose")
+                        .Select(e => e.Event)
+                        .ToList();
+                }
+
+                OutputHelper?.WriteLine(
+                    "Dispose events (name @ timestamp): [" +
+                    string.Join(", ", disposeEvents.Select(e => $"{e.Name} @ {e.Timestamp:HH:mm:ss.ffffff}")) +
+                    "]");
+
+                var startedEvent = disposeEvents
+                    .Where(e => e.Name == "composite_reader.close_operation.started")
+                    .Cast<ActivityEvent?>()
+                    .FirstOrDefault();
+                var completedEvent = disposeEvents
+                    .Where(e => e.Name == "composite_reader.close_operation.completed")
+                    .Cast<ActivityEvent?>()
+                    .FirstOrDefault();
+
+                Assert.True(startedEvent != null,
+                    "Expected 'composite_reader.close_operation.started' event in " +
+                    "DatabricksCompositeReader.Dispose. Without the fix the bare " +
+                    "'composite_reader.close_operation' event is emitted before the RPC " +
+                    "with the same timestamp as 'composite_reader.disposing', making the " +
+                    "RPC's latency unmeasurable. Got events: [" +
+                    string.Join(", ", disposeEvents.Select(e => e.Name)) + "]");
+                Assert.True(completedEvent != null,
+                    "Expected 'composite_reader.close_operation.completed' event in " +
+                    "DatabricksCompositeReader.Dispose. Without the fix only a single " +
+                    "pre-RPC event is emitted, so the RPC duration cannot be derived from " +
+                    "the trace. Got events: [" +
+                    string.Join(", ", disposeEvents.Select(e => e.Name)) + "]");
+
+                var startedAt = startedEvent!.Value.Timestamp;
+                var completedAt = completedEvent!.Value.Timestamp;
+                Assert.True(completedAt > startedAt,
+                    $"Expected 'composite_reader.close_operation.completed' timestamp " +
+                    $"({completedAt:HH:mm:ss.ffffff}) to be strictly later than " +
+                    $"'composite_reader.close_operation.started' ({startedAt:HH:mm:ss.ffffff}). " +
+                    "If they are equal, the RPC's latency is still invisible in the trace " +
+                    "(issue #489).");
             }
             finally
             {

--- a/csharp/test/E2E/CloseOperationE2ETest.cs
+++ b/csharp/test/E2E/CloseOperationE2ETest.cs
@@ -177,12 +177,17 @@ namespace AdbcDrivers.Databricks.Tests
 
                 OutputHelper?.WriteLine($"[{description}] Dispose events: [{string.Join(", ", disposeEvents)}]");
 
-                // The composite_reader.close_operation event is only present after the fix.
-                // Without it, the CloudFetch path silently skips CloseOperation entirely.
-                Assert.True(disposeEvents.Contains("composite_reader.close_operation"),
-                    $"[{description}] composite_reader.close_operation event not found in " +
-                    $"DatabricksCompositeReader.Dispose. Without the fix, server operations are " +
-                    $"orphaned until SQL Gateway closes them with CommandInactivityTimeout (~1 hour).");
+                // The composite_reader.close_operation.started event is only present after
+                // the original CloseOperation fix (it was renamed from the bare
+                // "composite_reader.close_operation" by issue #489 to mark when the RPC
+                // begins). Without that fix, the CloudFetch path silently skips
+                // CloseOperation entirely and neither event is emitted.
+                Assert.True(disposeEvents.Contains("composite_reader.close_operation.started"),
+                    $"[{description}] composite_reader.close_operation.started event not found in " +
+                    $"DatabricksCompositeReader.Dispose. Without the close-operation fix, server " +
+                    $"operations are orphaned until SQL Gateway closes them with " +
+                    $"CommandInactivityTimeout (~1 hour). Got events: [" +
+                    string.Join(", ", disposeEvents) + "]");
             }
             finally
             {

--- a/csharp/test/E2E/CloseOperationE2ETest.cs
+++ b/csharp/test/E2E/CloseOperationE2ETest.cs
@@ -265,11 +265,11 @@ namespace AdbcDrivers.Databricks.Tests
 
                 var startedEvent = disposeEvents
                     .Where(e => e.Name == "composite_reader.close_operation.started")
-                    .Cast<ActivityEvent?>()
+                    .Select(e => (ActivityEvent?)e)
                     .FirstOrDefault();
                 var completedEvent = disposeEvents
                     .Where(e => e.Name == "composite_reader.close_operation.completed")
-                    .Cast<ActivityEvent?>()
+                    .Select(e => (ActivityEvent?)e)
                     .FirstOrDefault();
 
                 Assert.True(startedEvent != null,


### PR DESCRIPTION
## Motivation

`DatabricksCompositeReader.Dispose` previously emitted a single
`composite_reader.close_operation` event immediately before invoking
the Thrift `TCloseOperationReq` RPC. Because the event fired before
the call, its timestamp was effectively identical to the surrounding
`composite_reader.disposing` event (sample observed in issue #489:
both at `t=21:31:29.768505`). The RPC's wall-clock cost was therefore
invisible in the trace — defeating the whole purpose of having a
dedicated event for the close call. A repro on `sf10/pecotesting`
showed the next event (`composite_reader.disposing_active_reader`)
firing ~142ms later, so the latency is non-trivial and worth
capturing.

## What changed

- `csharp/src/Reader/DatabricksCompositeReader.cs` — in
  `Dispose(bool)`, replace the single
  `composite_reader.close_operation` event with a pair:
  - `composite_reader.close_operation.started` BEFORE the RPC
  - `composite_reader.close_operation.completed` AFTER the RPC
    (emitted in the `finally` block so it always fires; tagged
    `error=true/false` so consumers can distinguish a clean close
    from a thrown one).

  This mirrors the existing event-pair convention used in
  `HiveServer2Statement.CancelOperationAsync`
  (`db.operation.cancel_operation.starting` / `.completed`). The
  delta between the two timestamps now captures the RPC's latency
  directly in the trace.

- `csharp/test/E2E/CloseOperationE2ETest.cs` — the existing
  `DisposeEmitsCloseOperationEvent` theory was asserting on the bare
  `composite_reader.close_operation` name; updated it to assert on
  the new `.started` event name since the bare event no longer
  exists.

## Test added

`DisposeCloseOperation_EmitsStartedAndCompletedWithDistinctTimestamps_Issue489`
in `csharp/test/E2E/CloseOperationE2ETest.cs`. Wires the same
`ActivityListener` the existing test uses but additionally captures
full `ActivityEvent` objects (with timestamps), runs a query that
triggers a non-inline close RPC, disposes the reader and statement,
and asserts:

1. `composite_reader.close_operation.started` is present
2. `composite_reader.close_operation.completed` is present
3. `completed.Timestamp > started.Timestamp` (strict — any positive
   delta means the RPC is now measurable)

The test was committed RED first; against the unpatched driver it
fails with the diagnostic `Got events: [composite_reader.disposing,
composite_reader.close_operation, composite_reader.disposing_active_reader,
composite_reader.disposed]` (sample timestamps:
`disposing @ 06:54:05.501959`, `close_operation @ 06:54:05.501960` —
1µs apart, then `disposing_active_reader @ 06:54:05.643804` — 142ms
later, i.e. the RPC took ~142ms but the old single-event design
showed 0). After the fix the pair brackets the RPC cleanly and the
test passes.

## Regression check

- `CloseOperationE2ETest` (4 tests, including the new one): all pass.
- `DriverTests`: 35/35 pass.
- `StatementTests`: 94 passed / 3 skipped / 0 failed.

All against `sf10/pecotesting`, Thrift protocol.

Closes #489

This pull request and its description were written by Isaac.