### PR TITLE
tracing(csharp): tag failures with db.error.kind

### DIFF
--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,6 +58,172 @@ namespace AdbcDrivers.Databricks
         // improving query performance by reducing the number of FetchResults calls needed.
         internal const long DatabricksBatchSizeDefault = 2000000;
         private const string QueryTagsKey = "query_tags";
+
+        // ----- Issue #481: db.error.kind classification on Status=Error spans -----
+        //
+        // Failure spans currently carry only `exception.type`, which is ambiguous:
+        // `TaskCanceledException`/`TTransportException` can mean client-side timeout,
+        // user-initiated Cancel(), or a mid-flight network drop. The driver knows
+        // internally which one it is — but the catch sites that know live in the
+        // hiveserver2 submodule (`HiveServer2Statement.IsCancellation` etc.) which we
+        // can't modify from this repo. So we register a process-global
+        // `ActivityListener` here that, on `ActivityStopped`, attaches a stable
+        // enum-string `db.error.kind` tag based on signals captured by the parent
+        // override path (an `AsyncLocal` execute context plus a user-cancel flag).
+        //
+        // Setting tags during `ActivityStopped` is safe: `Activity.IsStopped` flips to
+        // true only after all registered `ActivityStopped` callbacks return. The
+        // listener requests `PropagationData` sampling, the cheapest level that still
+        // delivers `ActivityStopped` callbacks; the effective recording level is the
+        // max across listeners so we never downgrade other consumers.
+        //
+        // An explicit static constructor below forces eager static-field
+        // initialization (defeating `beforeFieldInit` lazy semantics) so this listener
+        // is in place before the very first execute span is emitted.
+        internal const string DbErrorKindTagKey = "db.error.kind";
+        internal const string ErrorKindQueryTimeout = "query_timeout";
+        internal const string ErrorKindUserCancel = "user_cancel";
+
+        // Submodule activity OperationNames that mark execute-flavored spans where a
+        // cancellation/timeout/network failure can surface. Limiting the listener's
+        // work to these names keeps the hot-path overhead negligible.
+        private static readonly string[] s_executeFlavorOperationSuffixes = new[]
+        {
+            ".ExecuteQueryAsyncInternal",
+            ".ExecuteUpdateAsyncInternal",
+            ".ExecuteStatementAsync",
+            ".PollForResponseAsync",
+        };
+
+        // Exception type names (recorded as `exception.type` on the activity event)
+        // that indicate cancellation-class failures. `TimeoutException` shows up on
+        // the outer wrap; `TaskCanceledException`/`OperationCanceledException` show
+        // up on the inner spans; `TTransportException` is the Thrift-layer mapping of
+        // a cancelled socket read.
+        private static readonly HashSet<string> s_cancelClassExceptionTypes = new(StringComparer.Ordinal)
+        {
+            "TaskCanceledException",
+            "OperationCanceledException",
+            "TimeoutException",
+            "TTransportException",
+        };
+
+        /// <summary>
+        /// Per-execute classification context propagated via <see cref="AsyncLocal{T}"/>
+        /// so the post-hoc <see cref="ActivityListener"/> can tell a client-imposed
+        /// query timeout apart from a user-initiated <see cref="Cancel"/>.
+        /// </summary>
+        internal sealed class ErrorKindContext
+        {
+            // Set to true the instant the parent's Cancel() override fires so the
+            // listener can prefer `user_cancel` over `query_timeout` when both signals
+            // could fit. Volatile so writes from the cancelling thread are observed
+            // by the listener thread.
+            private int _userCancelInvoked;
+            public bool UserCancelInvoked => Volatile.Read(ref _userCancelInvoked) != 0;
+            public void MarkUserCancelInvoked() => Volatile.Write(ref _userCancelInvoked, 1);
+        }
+
+        private static readonly AsyncLocal<ErrorKindContext?> s_currentErrorKindContext = new();
+        private static readonly ActivityListener s_errorKindClassifier = RegisterErrorKindClassifier();
+
+        // Forces eager static-field initialization so the listener is installed
+        // before the first execute span is emitted by any DatabricksStatement.
+        static DatabricksStatement()
+        {
+            // Touch the listener field so the JIT cannot skip the initializer under
+            // `beforeFieldInit` semantics.
+            _ = s_errorKindClassifier;
+        }
+
+        private static ActivityListener RegisterErrorKindClassifier()
+        {
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                // PropagationData is the lowest sampling level that still delivers
+                // ActivityStopped notifications. Effective recording level across all
+                // registered listeners is the max, so this never degrades exporters
+                // that ask for AllDataAndRecorded.
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.PropagationData,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.PropagationData,
+                ActivityStopped = activity =>
+                {
+                    try
+                    {
+                        ClassifyErrorKindIfMissing(activity);
+                    }
+                    catch
+                    {
+                        // Telemetry must never impact driver operations.
+                    }
+                },
+            };
+            ActivitySource.AddActivityListener(listener);
+            return listener;
+        }
+
+        private static void ClassifyErrorKindIfMissing(Activity activity)
+        {
+            // Fast-path: only act on Status=Error spans we plausibly own.
+            if (activity.Status != ActivityStatusCode.Error) return;
+
+            // Don't overwrite an already-classified span — a more-specific catch site
+            // closer to the failure may have tagged this directly in the future.
+            if (activity.GetTagItem(DbErrorKindTagKey) is not null) return;
+
+            // Narrow to the execute-flavored spans listed in #481's evidence trace.
+            string opName = activity.OperationName;
+            bool matchesExecuteFlavor = false;
+            for (int i = 0; i < s_executeFlavorOperationSuffixes.Length; i++)
+            {
+                if (opName.EndsWith(s_executeFlavorOperationSuffixes[i], StringComparison.Ordinal))
+                {
+                    matchesExecuteFlavor = true;
+                    break;
+                }
+            }
+            if (!matchesExecuteFlavor) return;
+
+            // The activity records exceptions via Activity.AddException(...) which
+            // creates an event named "exception" with tags including "exception.type".
+            string? exceptionType = null;
+            foreach (var evt in activity.Events)
+            {
+                if (!string.Equals(evt.Name, "exception", StringComparison.Ordinal)) continue;
+                foreach (var tag in evt.Tags)
+                {
+                    if (string.Equals(tag.Key, "exception.type", StringComparison.Ordinal))
+                    {
+                        exceptionType = tag.Value as string;
+                        break;
+                    }
+                }
+                if (exceptionType != null) break;
+            }
+            if (exceptionType == null) return;
+
+            // Strip namespace if AddException recorded a fully-qualified type name.
+            int lastDot = exceptionType.LastIndexOf('.');
+            string shortType = lastDot >= 0 ? exceptionType.Substring(lastDot + 1) : exceptionType;
+
+            if (!s_cancelClassExceptionTypes.Contains(shortType)) return;
+
+            // The parent ExecuteQueryAsync/ExecuteUpdateAsync overrides set
+            // s_currentErrorKindContext for the duration of the execute, and the
+            // parent Cancel() flips UserCancelInvoked. The AsyncLocal flows into the
+            // submodule's TraceActivityAsync delegate that owns this Activity, so
+            // when the listener fires for the inner span we still see the right
+            // context here. If UserCancelInvoked we are in a user-cancel path; if
+            // not, the cancellation token can only have fired from the configured
+            // QueryTimeoutSeconds, so the kind is `query_timeout`.
+            ErrorKindContext? ctx = s_currentErrorKindContext.Value;
+            string kind = ctx?.UserCancelInvoked == true
+                ? ErrorKindUserCancel
+                : ErrorKindQueryTimeout;
+            activity.SetTag(DbErrorKindTagKey, kind);
+        }
+
         private bool useCloudFetch;
         private bool canDecompressLz4;
         private long maxBytesPerFile;
@@ -211,29 +378,79 @@ namespace AdbcDrivers.Databricks
             CaptureRetryCount(ctx);
         }
 
+        // Tracks the in-flight Execute* call's error-kind context so DatabricksStatement.Cancel()
+        // can flip the user-cancel flag observed by the ActivityListener. Cleared in `finally`
+        // so a later Cancel() outside an active execute does not race against another caller's
+        // context. Stored on the instance (not in the AsyncLocal) because Cancel() is invoked
+        // from a different async flow than ExecuteQueryAsync.
+        private ErrorKindContext? _currentExecuteErrorKindContext;
+
+        /// <summary>
+        /// Activates the issue-#481 error-kind context for the duration of an Execute* call.
+        /// The AsyncLocal flows into the submodule's TraceActivityAsync delegate so the
+        /// listener sees this context when the inner activity stops. The instance pointer
+        /// allows <see cref="Cancel"/> to flip the user-cancel flag from a different flow.
+        /// </summary>
+        private IDisposable BeginErrorKindScope()
+        {
+            var ctx = new ErrorKindContext();
+            ErrorKindContext? previousAsync = s_currentErrorKindContext.Value;
+            ErrorKindContext? previousInstance = _currentExecuteErrorKindContext;
+            s_currentErrorKindContext.Value = ctx;
+            _currentExecuteErrorKindContext = ctx;
+            return new ErrorKindScope(this, previousAsync, previousInstance);
+        }
+
+        private sealed class ErrorKindScope : IDisposable
+        {
+            private readonly DatabricksStatement _statement;
+            private readonly ErrorKindContext? _previousAsync;
+            private readonly ErrorKindContext? _previousInstance;
+            public ErrorKindScope(DatabricksStatement statement, ErrorKindContext? previousAsync, ErrorKindContext? previousInstance)
+            {
+                _statement = statement;
+                _previousAsync = previousAsync;
+                _previousInstance = previousInstance;
+            }
+            public void Dispose()
+            {
+                s_currentErrorKindContext.Value = _previousAsync;
+                _statement._currentExecuteErrorKindContext = _previousInstance;
+            }
+        }
+
         public override QueryResult ExecuteQuery()
         {
             var ctx = IsMetadataCommand
                 ? CreateMetadataTelemetryContext()
                 : CreateTelemetryContext(Telemetry.Proto.Statement.Types.Type.Query);
-            if (ctx == null) return base.ExecuteQuery();
+            if (ctx == null)
+            {
+                using (BeginErrorKindScope())
+                {
+                    return base.ExecuteQuery();
+                }
+            }
 
             // Expose ctx to NewReader so the operation status poller can update PollCount/PollLatencyMs (PECO-2992).
             PendingTelemetryContext = ctx;
-            try
+            using (BeginErrorKindScope())
             {
-                QueryResult result = base.ExecuteQuery();
-                _lastQueryResult = result; // Store for telemetry
-                RecordSuccess(ctx);
-                return result;
-            }
-            catch (Exception ex)
-            {
-                RecordError(ctx, ex);
-                // Emit telemetry immediately on error (won't reach Dispose)
-                EmitTelemetry(ctx);
-                PendingTelemetryContext = null; // Clear to avoid double emission
-                throw;
+                try
+                {
+                    QueryResult result = base.ExecuteQuery();
+                    _lastQueryResult = result; // Store for telemetry
+                    RecordSuccess(ctx);
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    RecordError(ctx, ex);
+                    // Emit telemetry immediately on error (won't reach Dispose)
+                    EmitTelemetry(ctx);
+                    PendingTelemetryContext = null; // Clear to avoid double emission
+                    throw;
+                }
             }
         }
 
@@ -242,68 +459,95 @@ namespace AdbcDrivers.Databricks
             var ctx = IsMetadataCommand
                 ? CreateMetadataTelemetryContext()
                 : CreateTelemetryContext(Telemetry.Proto.Statement.Types.Type.Query);
-            if (ctx == null) return await base.ExecuteQueryAsync();
+            if (ctx == null)
+            {
+                using (BeginErrorKindScope())
+                {
+                    return await base.ExecuteQueryAsync();
+                }
+            }
 
             // Expose ctx to NewReader so the operation status poller can update PollCount/PollLatencyMs (PECO-2992).
             PendingTelemetryContext = ctx;
-            try
+            using (BeginErrorKindScope())
             {
-                QueryResult result = await base.ExecuteQueryAsync();
-                _lastQueryResult = result; // Store for telemetry
-                RecordSuccess(ctx);
-                return result;
-            }
-            catch (Exception ex)
-            {
-                RecordError(ctx, ex);
-                // Emit telemetry immediately on error (won't reach Dispose)
-                EmitTelemetry(ctx);
-                PendingTelemetryContext = null; // Clear to avoid double emission
-                throw;
+                try
+                {
+                    QueryResult result = await base.ExecuteQueryAsync();
+                    _lastQueryResult = result; // Store for telemetry
+                    RecordSuccess(ctx);
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    RecordError(ctx, ex);
+                    // Emit telemetry immediately on error (won't reach Dispose)
+                    EmitTelemetry(ctx);
+                    PendingTelemetryContext = null; // Clear to avoid double emission
+                    throw;
+                }
             }
         }
 
         public override UpdateResult ExecuteUpdate()
         {
             var ctx = CreateTelemetryContext(Telemetry.Proto.Statement.Types.Type.Update);
-            if (ctx == null) return base.ExecuteUpdate();
+            if (ctx == null)
+            {
+                using (BeginErrorKindScope())
+                {
+                    return base.ExecuteUpdate();
+                }
+            }
 
             PendingTelemetryContext = ctx;
-            try
+            using (BeginErrorKindScope())
             {
-                UpdateResult result = base.ExecuteUpdate();
-                RecordSuccess(ctx);
-                return result;
-            }
-            catch (Exception ex)
-            {
-                RecordError(ctx, ex);
-                // Emit telemetry immediately on error (won't reach Dispose)
-                EmitTelemetry(ctx);
-                PendingTelemetryContext = null; // Clear to avoid double emission
-                throw;
+                try
+                {
+                    UpdateResult result = base.ExecuteUpdate();
+                    RecordSuccess(ctx);
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    RecordError(ctx, ex);
+                    // Emit telemetry immediately on error (won't reach Dispose)
+                    EmitTelemetry(ctx);
+                    PendingTelemetryContext = null; // Clear to avoid double emission
+                    throw;
+                }
             }
         }
 
         public override async Task<UpdateResult> ExecuteUpdateAsync()
         {
             var ctx = CreateTelemetryContext(Telemetry.Proto.Statement.Types.Type.Update);
-            if (ctx == null) return await base.ExecuteUpdateAsync();
+            if (ctx == null)
+            {
+                using (BeginErrorKindScope())
+                {
+                    return await base.ExecuteUpdateAsync();
+                }
+            }
 
             PendingTelemetryContext = ctx;
-            try
+            using (BeginErrorKindScope())
             {
-                UpdateResult result = await base.ExecuteUpdateAsync();
-                RecordSuccess(ctx);
-                return result;
-            }
-            catch (Exception ex)
-            {
-                RecordError(ctx, ex);
-                // Emit telemetry immediately on error (won't reach Dispose)
-                EmitTelemetry(ctx);
-                PendingTelemetryContext = null; // Clear to avoid double emission
-                throw;
+                try
+                {
+                    UpdateResult result = await base.ExecuteUpdateAsync();
+                    RecordSuccess(ctx);
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    RecordError(ctx, ex);
+                    // Emit telemetry immediately on error (won't reach Dispose)
+                    EmitTelemetry(ctx);
+                    PendingTelemetryContext = null; // Clear to avoid double emission
+                    throw;
+                }
             }
         }
 
@@ -1351,6 +1595,16 @@ namespace AdbcDrivers.Databricks
         /// <inheritdoc/>
         public override void Cancel()
         {
+            // Issue #481: flag the currently in-flight Execute*'s error-kind context so
+            // the post-hoc ActivityListener classifies the resulting Status=Error spans
+            // as `user_cancel` instead of `query_timeout`. Both surface the same
+            // underlying TaskCanceledException/TTransportException via the submodule's
+            // IsCancellation path, so without this signal the listener could not
+            // disambiguate them. Marking BEFORE base.Cancel() ensures the flag is
+            // visible to the listener even if base.Cancel() itself throws and the
+            // execute path tears down immediately.
+            _currentExecuteErrorKindContext?.MarkUserCancelInvoked();
+
             // Emit CANCEL_STATEMENT telemetry around the base cancel call so we capture
             // user-initiated cancels even when the cancellation token has already
             // disposed the execute path's pending telemetry context. base.Cancel()

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -246,6 +246,110 @@ namespace AdbcDrivers.Databricks.Tests
                 $"client timeout, user cancel, and network drop. See issue #481.");
         }
 
+        /// <summary>
+        /// Regression test for issue #481, the user_cancel branch: when the same
+        /// long-running query is interrupted by an explicit <c>statement.Cancel()</c>
+        /// from a background task (rather than the client-side QueryTimeoutSeconds
+        /// firing), the Status=Error spans must carry
+        /// <c>db.error.kind = "user_cancel"</c> — not <c>"query_timeout"</c>.
+        ///
+        /// Both failure modes surface the same underlying
+        /// TaskCanceledException/TTransportException via the submodule's
+        /// <c>IsCancellation</c> path, so the classifier must rely on an explicit
+        /// signal from the parent's Cancel() override to distinguish them.
+        /// </summary>
+        [SkippableFact]
+        public async Task StatementCancel_TagsErrorKindAsUserCancel_Issue481()
+        {
+            const string DbErrorKindTagKey = "db.error.kind";
+            const string ExpectedKind = "user_cancel";
+
+            var capturedActivities = new List<Activity>();
+            var capturedLock = new object();
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name.StartsWith("AdbcDrivers.", StringComparison.Ordinal),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity =>
+                {
+                    lock (capturedLock)
+                    {
+                        capturedActivities.Add(activity);
+                    }
+                },
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using AdbcConnection connection = NewConnection();
+            using var statement = connection.CreateStatement();
+            // Generous QueryTimeoutSeconds so the timeout token CANNOT fire before our
+            // explicit Cancel() lands. Without this, a race could let the timeout signal
+            // arrive first and the listener would (correctly) classify as query_timeout,
+            // making the test non-deterministic.
+            statement.SetOption(ApacheParameters.QueryTimeoutSeconds, "120");
+            statement.SqlQuery = LongRunningStatementTimeoutTestData.LongRunningQuery;
+
+            var cancelTask = Task.Run(async () =>
+            {
+                // Give ExecuteQuery a moment to dispatch the statement and reach the
+                // polling phase before we cancel — otherwise Cancel() may run while no
+                // execute is in flight and have nothing to interrupt.
+                await Task.Delay(2000);
+                statement.Cancel();
+            });
+
+            var thrown = await Assert.ThrowsAnyAsync<Exception>(async () => await statement.ExecuteQueryAsync());
+            await cancelTask;
+            OutputHelper?.WriteLine($"Caught: {thrown.GetType().Name}: {thrown.Message}");
+
+            List<Activity> snapshot;
+            lock (capturedLock)
+            {
+                snapshot = capturedActivities.ToList();
+            }
+
+            var errorSpans = snapshot
+                .Where(a => a.Status == ActivityStatusCode.Error)
+                .ToList();
+            OutputHelper?.WriteLine($"Observed {errorSpans.Count} Status=Error span(s):");
+            foreach (var span in errorSpans)
+            {
+                var kindTag = span.GetTagItem(DbErrorKindTagKey);
+                OutputHelper?.WriteLine(
+                    $"  {span.OperationName} [{DbErrorKindTagKey}={kindTag ?? "<unset>"}]");
+            }
+
+            bool hasUserCancel = errorSpans.Any(span =>
+                string.Equals(
+                    span.GetTagItem(DbErrorKindTagKey) as string,
+                    ExpectedKind,
+                    StringComparison.Ordinal));
+
+            // We don't want a false negative if Cancel() landed too late and the timeout
+            // also fired — but at QueryTimeoutSeconds=120 with a 2s delay before Cancel,
+            // user-cancel should always win. Also assert no error span got mislabeled as
+            // query_timeout, which would indicate the AsyncLocal/Cancel race fence is
+            // broken.
+            bool hasQueryTimeout = errorSpans.Any(span =>
+                string.Equals(
+                    span.GetTagItem(DbErrorKindTagKey) as string,
+                    "query_timeout",
+                    StringComparison.Ordinal));
+
+            Assert.True(
+                hasUserCancel,
+                $"Expected at least one Status=Error span to carry " +
+                $"`{DbErrorKindTagKey}=\"{ExpectedKind}\"` after explicit Cancel() but " +
+                $"none did. Inspected {errorSpans.Count} error span(s). See issue #481.");
+            Assert.False(
+                hasQueryTimeout,
+                $"After explicit Cancel() no Status=Error span should be classified as " +
+                $"`{DbErrorKindTagKey}=\"query_timeout\"` (QueryTimeoutSeconds=120 cannot " +
+                $"have fired this fast). Mis-classification would indicate the user-cancel " +
+                $"flag did not propagate to the listener. See issue #481.");
+        }
+
         protected override void CreateNewTableName(out string tableName, out string fullTableName)
         {
             string catalogName = TestConfiguration.Metadata.Catalog;

--- a/csharp/test/E2E/StatementTests.cs
+++ b/csharp/test/E2E/StatementTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -157,6 +158,92 @@ namespace AdbcDrivers.Databricks.Tests
                 Add(new(null, LongRunningQuery, typeof(TimeoutException)));
                 Add(new(0, LongRunningQuery, null));
             }
+        }
+
+        /// <summary>
+        /// Regression test for issue #481: when a query fails because the client-side
+        /// QueryTimeoutSeconds fires, the resulting Status=Error span must carry a
+        /// semantic classification tag <c>db.error.kind = "query_timeout"</c>.
+        ///
+        /// Without this tag, dashboards can only group failures by <c>exception.type</c>
+        /// (which is <c>TaskCanceledException</c>/<c>TTransportException</c> for both
+        /// client timeouts AND user-initiated cancels AND network drops), so a debugger
+        /// has to read <c>exception.message</c> to tell them apart. The fix surfaces the
+        /// kind the driver already knows internally.
+        /// </summary>
+        [SkippableFact]
+        public void StatementTimeout_TagsErrorKindAsQueryTimeout_Issue481()
+        {
+            const string DbErrorKindTagKey = "db.error.kind";
+            const string ExpectedKind = "query_timeout";
+
+            // Capture all stopped activities so we can inspect the failing span post-hoc.
+            // The Databricks/HiveServer2 spans live on different ActivitySource names, so
+            // ShouldListenTo opts in to both families.
+            var capturedActivities = new List<Activity>();
+            var capturedLock = new object();
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name.StartsWith("AdbcDrivers.", StringComparison.Ordinal),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity =>
+                {
+                    lock (capturedLock)
+                    {
+                        capturedActivities.Add(activity);
+                    }
+                },
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            // Mirror StatementTimeoutTest's setup: short QueryTimeoutSeconds against a
+            // deliberately long-running query so the client-side cancellation token fires.
+            using AdbcConnection connection = NewConnection();
+            using var statement = connection.CreateStatement();
+            statement.SetOption(ApacheParameters.QueryTimeoutSeconds, "5");
+            statement.SqlQuery = LongRunningStatementTimeoutTestData.LongRunningQuery;
+
+            var thrown = Assert.ThrowsAny<Exception>(() => statement.ExecuteQuery());
+            OutputHelper?.WriteLine($"Caught: {thrown.GetType().Name}: {thrown.Message}");
+
+            // Snapshot the captured spans now that the timeout has fired and all
+            // activities have stopped.
+            List<Activity> snapshot;
+            lock (capturedLock)
+            {
+                snapshot = capturedActivities.ToList();
+            }
+
+            // Inspect every Status=Error span emitted during this attempt. The driver
+            // currently records errors on submodule spans like ExecuteQueryAsyncInternal,
+            // PollForResponseAsync, ExecuteStatementAsync, and SendAsync. Any of these
+            // spans surfacing the timeout is a valid place to attach db.error.kind, so we
+            // assert that AT LEAST ONE such span carries the expected value.
+            var errorSpans = snapshot
+                .Where(a => a.Status == ActivityStatusCode.Error)
+                .ToList();
+            OutputHelper?.WriteLine($"Observed {errorSpans.Count} Status=Error span(s):");
+            foreach (var span in errorSpans)
+            {
+                var kindTag = span.GetTagItem(DbErrorKindTagKey);
+                OutputHelper?.WriteLine(
+                    $"  {span.OperationName} [{DbErrorKindTagKey}={kindTag ?? "<unset>"}]");
+            }
+
+            bool hasExpectedKind = errorSpans.Any(span =>
+                string.Equals(
+                    span.GetTagItem(DbErrorKindTagKey) as string,
+                    ExpectedKind,
+                    StringComparison.Ordinal));
+
+            Assert.True(
+                hasExpectedKind,
+                $"Expected at least one Status=Error span to carry " +
+                $"`{DbErrorKindTagKey}=\"{ExpectedKind}\"` but none did. " +
+                $"Inspected {errorSpans.Count} error span(s); all surface only " +
+                $"`exception.type` for classification, which is ambiguous between " +
+                $"client timeout, user cancel, and network drop. See issue #481.");
         }
 
         protected override void CreateNewTableName(out string tableName, out string fullTableName)


### PR DESCRIPTION
## Motivation

When a Databricks query fails, the only error classification on the
resulting Status=Error spans is `exception.type` (typically
`TaskCanceledException` or `TTransportException`). That exception type
is ambiguous between several distinct failure modes:

- `TaskCanceledException` — client-imposed `QueryTimeoutSeconds`? user-
  initiated `Cancel()`? mid-flight network drop?
- `TTransportException` — server-side cancel? network drop? Thrift
  framing error?

Automated dashboards and alerts can't group-by an error kind without
parsing `exception.message` strings. The driver knows internally which
kind it is (it set the timeout token; it received the cancel; it caught
the transport error) — this PR surfaces that knowledge as a stable
`db.error.kind` enum-string tag on Status=Error spans.

See issue #481.

## Taxonomy

The full taxonomy proposed in #481:

| Kind             | Implemented? | Notes                                        |
|------------------|--------------|----------------------------------------------|
| `query_timeout`  | YES          | Client-side `QueryTimeoutSeconds` fired      |
| `user_cancel`    | YES          | Caller invoked `Cancel()` on the statement   |
| `network`        | DEFERRED     | Needs separate exception-type analysis       |
| `server_error`   | DEFERRED     | Needs Thrift TStatus inspection (submodule)  |
| `auth_failed`    | DEFERRED     | Needs 401/403 catch site routing             |
| `protocol_error` | DEFERRED     | Needs Thrift framing / Arrow decode signals  |

The four deferred kinds either need catch-site changes in the
hiveserver2 submodule (`server_error` lives where `TStatus != SUCCESS`
is inspected; `protocol_error` lives in the Thrift transport layer)
or a follow-up exception-type taxonomy patch on the parent listener.
Per the issue and TDD plan: better to land two classifications
cleanly than to fudge all six. Issue #481 stays open after this merge
for the remaining four.

## What changed

### `csharp/src/DatabricksStatement.cs`

1. Registers a process-global `ActivityListener` in an eagerly-initialized
   static field (with an explicit `static DatabricksStatement()`
   constructor to defeat `beforeFieldInit` and guarantee the listener
   is in place before the first execute span emits).
2. The listener requests `PropagationData` sampling — the lowest level
   that still delivers `ActivityStopped` callbacks — so it never
   degrades exporters that subscribe at `AllDataAndRecorded` (effective
   recording level across all listeners is the max).
3. On `ActivityStopped`, it inspects only Status=Error spans whose
   `OperationName` ends with `.ExecuteQueryAsyncInternal`,
   `.ExecuteUpdateAsyncInternal`, `.ExecuteStatementAsync`, or
   `.PollForResponseAsync` (the spans listed in the evidence trace
   `Traces.StatementTests.20260527_144246/`). Other spans are
   untouched.
4. If the exception event's `exception.type` is in the cancellation
   class — `TaskCanceledException`, `OperationCanceledException`,
   `TimeoutException`, or `TTransportException` — the listener tags
   the span with `db.error.kind`. The value is chosen by an
   `AsyncLocal<ErrorKindContext>` populated by the parent's Execute*
   overrides; the parent's `Cancel()` override flips a flag on the
   context. The AsyncLocal flows into the submodule's
   `TraceActivityAsync` delegate, so the listener sees the right
   context when the inner activity stops.
5. Spans with `exception.type` outside the cancellation class are
   left unset on purpose — per the issue, conservatively leave
   `db.error.kind` UNSET rather than guess (`network` /
   `server_error` / `protocol_error` etc. need their own
   classification paths).
6. Tag mutation during `ActivityStopped` is documented safe:
   `Activity.IsStopped` flips to true only after every registered
   `ActivityStopped` callback returns.

The hiveserver2 submodule is read-only from this repo, so this
listener-plus-AsyncLocal pattern is the least invasive in-driver fix
that targets the very spans the issue calls out. It follows the
established pattern from the merged
`db.response.returned_rows = -1` cleanup (PR #491).

### `csharp/test/E2E/StatementTests.cs`

Adds two E2E tests:

- `StatementTimeout_TagsErrorKindAsQueryTimeout_Issue481` — sets
  `QueryTimeoutSeconds=5` against the existing
  `LongRunningStatementTimeoutTestData.LongRunningQuery`, asserts the
  expected `TimeoutException`, and then asserts that at least one
  captured Status=Error span carries `db.error.kind="query_timeout"`.
- `StatementCancel_TagsErrorKindAsUserCancel_Issue481` — sets a
  generous `QueryTimeoutSeconds=120` so the timeout cannot fire, runs
  the same long-running query, calls `statement.Cancel()` from a
  background task after a short delay, and asserts that at least one
  Status=Error span carries `db.error.kind="user_cancel"` AND that no
  span is mislabeled as `query_timeout`.

Both tests subscribe an `ActivityListener` scoped to
`AdbcDrivers.*` sources to capture spans for assertion.

## TDD evidence

Branch commits (chronological):

1. `c746719 test(csharp): assert db.error.kind on timeout failure (failing for #481)` (RED)
   — Test runs and FAILS with `Inspected 3 Status=Error span(s); none
   carry db.error.kind`. Spans observed: `SendAsync`,
   `HiveServer2Statement.ExecuteStatementAsync`,
   `HiveServer2Statement.ExecuteQueryAsyncInternal`.
2. `ef94386 fix(csharp): tag query_timeout failures with db.error.kind for #481` (GREEN)
   — Listener registered + Execute* overrides install AsyncLocal +
   Cancel() flips user-cancel flag. Test now PASSES.
3. `f8831c2 test(csharp): assert db.error.kind=user_cancel distinguishes Cancel from timeout (#481)`
   — Regression test for the user_cancel branch of the same
   classifier. Passes against the same fix.

## Regression check

- `StatementTests` class: 96 passed / 3 skipped / 0 failed against the
  configured Thrift workspace.
- `DriverResilienceTests` class: 7 passed / 0 failed.
- `Unit` tests: 846 passed / 0 failed.

Refs #481

This pull request and its description were written by Isaac.