### PR TITLE
fix(csharp): extract spog org id from cluster path

### DIFF
--- a/csharp/src/PropertyHelper.cs
+++ b/csharp/src/PropertyHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text.RegularExpressions;
 using AdbcDrivers.HiveServer2.Spark;
 using Apache.Arrow.Adbc;
 
@@ -220,10 +221,29 @@ namespace AdbcDrivers.Databricks
             return null;
         }
 
+        // Matches the workspace ID inside an all-purpose-compute HiveServer2 path of the form
+        // [/]sql/protocolv1/o/<workspace-id>/<cluster-id>[/...]. Workspace IDs are decimal
+        // integers; the regex rejects anything else so a stray segment can't be shipped as an org ID.
+        private static readonly Regex s_clusterPathOrgIdPattern = new(
+            @"(?:^|/)sql/protocolv1/o/(\d+)/[^/?]+",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         /// <summary>
-        /// Extracts the org ID from connection properties by inspecting the http path and URI query strings.
-        /// Checks <see cref="SparkParameters.Path"/> first, then falls back to <see cref="AdbcOptions.Uri"/>.
+        /// Extracts the org ID from connection properties by inspecting the http path and URI.
         /// </summary>
+        /// <remarks>
+        /// Two sources are checked, in priority order, for both
+        /// <see cref="SparkParameters.Path"/> and <see cref="AdbcOptions.Uri"/>:
+        /// <list type="number">
+        ///   <item><c>?o=&lt;workspace-id&gt;</c> query parameter (warehouse paths on SPOG
+        ///         typically encode the workspace this way).</item>
+        ///   <item><c>/sql/protocolv1/o/&lt;workspace-id&gt;/&lt;cluster-id&gt;</c> path segment
+        ///         (all-purpose-compute paths embed the workspace in the path itself).</item>
+        /// </list>
+        /// Without the path-segment fallback, non-Thrift requests (telemetry, feature flags)
+        /// on SPOG (custom-URL) hosts lack workspace context and PoPP redirects them to
+        /// <c>/login</c>, silently dropping telemetry.
+        /// </remarks>
         /// <param name="properties">Connection properties.</param>
         /// <returns>The org ID value, or null if not present.</returns>
         public static string? ParseOrgIdFromProperties(IReadOnlyDictionary<string, string>? properties)
@@ -232,22 +252,40 @@ namespace AdbcDrivers.Databricks
 
             if (properties.TryGetValue(SparkParameters.Path, out string? path) && !string.IsNullOrEmpty(path))
             {
-                int q = path.IndexOf('?');
-                if (q >= 0)
-                {
-                    string? orgId = ParseOrgIdFromQueryString(path.Substring(q + 1));
-                    if (orgId != null) return orgId;
-                }
+                string? orgId = ParseOrgIdFromPathOrUriQuery(path);
+                if (orgId != null) return orgId;
             }
 
             if (properties.TryGetValue(AdbcOptions.Uri, out string? uri) && !string.IsNullOrEmpty(uri)
-                && Uri.TryCreate(uri, UriKind.Absolute, out Uri? parsedUri)
-                && !string.IsNullOrEmpty(parsedUri.Query))
+                && Uri.TryCreate(uri, UriKind.Absolute, out Uri? parsedUri))
             {
-                return ParseOrgIdFromQueryString(parsedUri.Query.TrimStart('?'));
+                if (!string.IsNullOrEmpty(parsedUri.Query))
+                {
+                    string? orgId = ParseOrgIdFromQueryString(parsedUri.Query.TrimStart('?'));
+                    if (orgId != null) return orgId;
+                }
+
+                // Fall back to /sql/protocolv1/o/<wsid>/<cluster> in the URI path.
+                Match uriPathMatch = s_clusterPathOrgIdPattern.Match(parsedUri.AbsolutePath);
+                if (uriPathMatch.Success) return uriPathMatch.Groups[1].Value;
             }
 
             return null;
+        }
+
+        // ?o= in the query string wins; otherwise look for the cluster path segment.
+        private static string? ParseOrgIdFromPathOrUriQuery(string path)
+        {
+            int q = path.IndexOf('?');
+            if (q >= 0)
+            {
+                string? orgId = ParseOrgIdFromQueryString(path.Substring(q + 1));
+                if (orgId != null) return orgId;
+            }
+
+            string pathOnly = q >= 0 ? path.Substring(0, q) : path;
+            Match match = s_clusterPathOrgIdPattern.Match(pathOnly);
+            return match.Success ? match.Groups[1].Value : null;
         }
     }
 }

--- a/csharp/test/Unit/PropertyHelperTests.cs
+++ b/csharp/test/Unit/PropertyHelperTests.cs
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 ADBC Drivers Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using AdbcDrivers.HiveServer2.Spark;
+using Apache.Arrow.Adbc;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit
+{
+    /// <summary>
+    /// Tests for the SPOG cluster-path fallback in <see cref="PropertyHelper.ParseOrgIdFromProperties"/>.
+    /// Existing <c>?o=</c> extraction is covered indirectly through
+    /// <see cref="StatementExecution.StatementExecutionConnectionOrgIdTests"/>.
+    /// </summary>
+    public class PropertyHelperTests
+    {
+        [Fact]
+        public void ParseOrgIdFromProperties_ClusterPathWithoutQueryParam_ExtractsOrgIdFromPathSegment()
+        {
+            var props = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt" },
+            };
+
+            Assert.Equal("6051921418418893", PropertyHelper.ParseOrgIdFromProperties(props));
+        }
+
+        [Fact]
+        public void ParseOrgIdFromProperties_ClusterPathWithLeadingSlash_ExtractsOrgIdFromPathSegment()
+        {
+            var props = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt" },
+            };
+
+            Assert.Equal("6051921418418893", PropertyHelper.ParseOrgIdFromProperties(props));
+        }
+
+        [Fact]
+        public void ParseOrgIdFromProperties_ClusterPathWithQueryParam_QueryParamWins()
+        {
+            // ?o= takes precedence over the path segment when both are present.
+            var props = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "sql/protocolv1/o/111/0528-220959-uzmcn1qt?o=222" },
+            };
+
+            Assert.Equal("222", PropertyHelper.ParseOrgIdFromProperties(props));
+        }
+
+        [Fact]
+        public void ParseOrgIdFromProperties_WarehousePathWithoutQueryParam_ReturnsNull()
+        {
+            // Regression guard: the cluster-path fallback must not match warehouse paths
+            // (they never embed the workspace ID).
+            var props = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123" },
+            };
+
+            Assert.Null(PropertyHelper.ParseOrgIdFromProperties(props));
+        }
+
+        [Fact]
+        public void ParseOrgIdFromProperties_UriWithClusterPath_ExtractsOrgIdFromPathSegment()
+        {
+            // When the path is supplied via AdbcOptions.Uri instead of SparkParameters.Path,
+            // the cluster-segment fallback still applies.
+            var props = new Dictionary<string, string>
+            {
+                {
+                    AdbcOptions.Uri,
+                    "https://host.databricks.com/sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt"
+                },
+            };
+
+            Assert.Equal("6051921418418893", PropertyHelper.ParseOrgIdFromProperties(props));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes silent workspace-context loss on SPOG/custom-URL hosts when the C# Databricks driver connects with an all-purpose-compute HiveServer2 path like `sql/protocolv1/o/<workspace-id>/<cluster-id>`.
- `PropertyHelper.ParseOrgIdFromProperties` now extracts the workspace ID from the `/o/<wsid>/` path segment as a fallback when `?o=<wsid>` is not present.
- Priority order matches the JDBC/Python/Go fixes: `?o=` query parameter wins, then `/sql/protocolv1/o/<wsid>/<cluster-id>` path segment.

## Why

For all-purpose cluster Thrift paths on SPOG, PoPP can route the Thrift request from the `/o/<workspace-id>/` path segment. Other HTTP requests built from the same connection, including SEA/telemetry-style requests, do not naturally carry that path context. Without the `x-databricks-org-id` header they can be routed without workspace context and redirected to `/login`.

## What changes

- Adds a compiled cluster-path regex matching `(?:^|/)sql/protocolv1/o/(\d+)/[^/?]+`.
- Applies the fallback to both `SparkParameters.Path` and `AdbcOptions.Uri` inputs.
- Adds unit coverage for cluster path extraction, leading slash, `?o=` precedence, warehouse-path non-match, and URI path extraction.

## Test plan

- [x] `dotnet test csharp/test/AdbcDrivers.Databricks.Tests.csproj --filter FullyQualifiedName~PropertyHelperTests`
- [x] `dotnet build csharp/src/AdbcDrivers.Databricks.csproj`
- [x] Same SPOG cluster behavior has been live-tested on sibling JDBC/Python/Go fixes against `peco.azuredatabricks.net` all-purpose cluster path.

This pull request and its description were written with assistance from Claude Code.