### PR TITLE
refactor(csharp): unify user-agent on UserAgentHelper with capital-ADBC prefix

### DIFF
--- a/csharp/src/Http/UserAgentHelper.cs
+++ b/csharp/src/Http/UserAgentHelper.cs
@@ -24,19 +24,28 @@ namespace AdbcDrivers.Databricks.Http
     internal static class UserAgentHelper
     {
         /// <summary>
-        /// Builds the User-Agent string for ADBC driver HTTP requests (e.g., feature flag fetching).
-        /// Format: AdbcDatabricksDriver/{version} [user_agent_entry]
+        /// Builds the User-Agent string used by every Databricks driver HTTP request — feature-flag
+        /// fetches, and (via delegation) the SEA statement-execution path.
+        /// Format: {DriverName}/{version} [product] [user_agent_entry],
+        /// e.g. <c>ADBCDatabricksDriver/1.2.3 REST custom-entry</c>.
         /// </summary>
         /// <param name="assemblyVersion">The driver version.</param>
         /// <param name="properties">Connection properties (optional, for user_agent_entry).</param>
+        /// <param name="product">Optional product/component token inserted after the version
+        /// (e.g. "REST" for the SEA path). Thrift adds its own "Thrift/{v}" token in the base class.</param>
         /// <returns>The User-Agent string.</returns>
         /// <remarks>
-        /// This is used for internal driver HTTP requests like feature flag fetching.
-        /// Statement execution uses ADBCDatabricksDriver as the User-Agent.
+        /// The prefix is derived from <see cref="DatabricksConnection.DatabricksDriverName"/> so it
+        /// stays consistent with the Thrift transport user agent (which uses the same driver name).
         /// </remarks>
-        public static string GetUserAgent(string assemblyVersion, IReadOnlyDictionary<string, string>? properties = null)
+        public static string GetUserAgent(string assemblyVersion, IReadOnlyDictionary<string, string>? properties = null, string? product = null)
         {
-            string baseUserAgent = $"AdbcDatabricksDriver/{assemblyVersion}";
+            string baseUserAgent = $"{DatabricksConnection.DatabricksDriverName.Replace(" ", "")}/{assemblyVersion}";
+
+            if (!string.IsNullOrEmpty(product))
+            {
+                baseUserAgent += $" {product}";
+            }
 
             if (properties != null)
             {

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -417,21 +417,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         /// <summary>
         /// Builds the user agent string for HTTP requests.
-        /// Format: ADBCDatabricksDriver/{version} REST
+        /// Format: ADBCDatabricksDriver/{version} REST [user_agent_entry] — delegated to
+        /// <see cref="UserAgentHelper"/> so the prefix/entry handling stays shared with the
+        /// feature-flag path. "REST" marks the SEA transport (Thrift uses a "Thrift/{v}" token).
         /// </summary>
         private string GetUserAgent(IReadOnlyDictionary<string, string> properties)
-        {
-            string baseUserAgent = $"{DatabricksConnection.DatabricksDriverName.Replace(" ", "")}/{DatabricksConnection.DriverVersion} REST";
-
-            // Check if a client has provided a user-agent entry
-            string userAgentEntry = PropertyHelper.GetStringProperty(properties, "adbc.spark.user_agent_entry", string.Empty);
-            if (!string.IsNullOrWhiteSpace(userAgentEntry))
-            {
-                return $"{baseUserAgent} {userAgentEntry}";
-            }
-
-            return baseUserAgent;
-        }
+            => UserAgentHelper.GetUserAgent(DatabricksConnection.DriverVersion, properties, product: "REST");
 
         /// <summary>
         /// Opens the connection and creates a session.

--- a/csharp/src/Telemetry/Models/TelemetryClientContext.cs
+++ b/csharp/src/Telemetry/Models/TelemetryClientContext.cs
@@ -26,7 +26,7 @@ namespace AdbcDrivers.Databricks.Telemetry.Models
     {
         /// <summary>
         /// User agent string identifying the driver.
-        /// Example: "AdbcDatabricksDriver/1.0.0 (.NET 8.0; Windows 10)"
+        /// Example: "ADBCDatabricksDriver/1.0.0 (.NET 8.0; Windows 10)"
         /// </summary>
         [JsonPropertyName("user_agent")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/csharp/test/Unit/Http/UserAgentHelperTests.cs
+++ b/csharp/test/Unit/Http/UserAgentHelperTests.cs
@@ -1,0 +1,75 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using AdbcDrivers.Databricks.Http;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Http
+{
+    /// <summary>
+    /// Pins the User-Agent contract: capital-ADBC prefix (shared with the Thrift transport,
+    /// derived from DatabricksConnection.DatabricksDriverName), an optional product token, and
+    /// the adbc.spark.user_agent_entry suffix.
+    /// </summary>
+    public class UserAgentHelperTests
+    {
+        private const string UserAgentEntryKey = "adbc.spark.user_agent_entry";
+
+        [Fact]
+        public void GetUserAgent_NoProductNoEntry_UsesCapitalAdbcPrefix()
+        {
+            Assert.Equal("ADBCDatabricksDriver/1.2.3", UserAgentHelper.GetUserAgent("1.2.3"));
+        }
+
+        [Fact]
+        public void GetUserAgent_WithProduct_InsertsTokenAfterVersion()
+        {
+            // The SEA path passes product: "REST".
+            Assert.Equal("ADBCDatabricksDriver/1.2.3 REST", UserAgentHelper.GetUserAgent("1.2.3", null, product: "REST"));
+        }
+
+        [Fact]
+        public void GetUserAgent_WithProductAndEntry_AppendsEntryLast()
+        {
+            var props = new Dictionary<string, string> { [UserAgentEntryKey] = "custom-entry" };
+            Assert.Equal("ADBCDatabricksDriver/1.2.3 REST custom-entry",
+                UserAgentHelper.GetUserAgent("1.2.3", props, product: "REST"));
+        }
+
+        [Fact]
+        public void GetUserAgent_EntryNoProduct_AppendsEntry()
+        {
+            var props = new Dictionary<string, string> { [UserAgentEntryKey] = "custom-entry" };
+            Assert.Equal("ADBCDatabricksDriver/1.2.3 custom-entry", UserAgentHelper.GetUserAgent("1.2.3", props));
+        }
+
+        [Fact]
+        public void GetUserAgent_BlankEntry_Ignored()
+        {
+            var props = new Dictionary<string, string> { [UserAgentEntryKey] = "   " };
+            Assert.Equal("ADBCDatabricksDriver/1.2.3", UserAgentHelper.GetUserAgent("1.2.3", props));
+        }
+
+        [Fact]
+        public void GetUserAgent_PrefixMatchesDriverNameConstant()
+        {
+            // Single source of truth: the prefix is the driver name with spaces removed.
+            string expectedPrefix = DatabricksConnection.DatabricksDriverName.Replace(" ", "");
+            Assert.StartsWith(expectedPrefix + "/", UserAgentHelper.GetUserAgent("9.9.9"));
+        }
+    }
+}

--- a/csharp/test/Unit/Http/UserAgentHelperTests.cs
+++ b/csharp/test/Unit/Http/UserAgentHelperTests.cs
@@ -15,6 +15,7 @@
 */
 
 using System.Collections.Generic;
+using AdbcDrivers.Databricks;
 using AdbcDrivers.Databricks.Http;
 using Xunit;
 


### PR DESCRIPTION
## What's changed

Unifies all of the driver's HTTP user-agent strings on a single capital-`ADBC` prefix, sourced from one constant.

- **`UserAgentHelper.GetUserAgent`** now derives its prefix from `DatabricksConnection.DatabricksDriverName` (`"ADBC Databricks Driver"` → `ADBCDatabricksDriver`) instead of the hardcoded literal `AdbcDatabricksDriver`, and gains an optional `product` token inserted after the version.
- **SEA** (`StatementExecutionConnection.GetUserAgent`) now delegates to `UserAgentHelper.GetUserAgent(DriverVersion, properties, product: "REST")`. Its output is unchanged: `ADBCDatabricksDriver/{version} REST [entry]`.
- **Internal / feature-flag** requests now emit `ADBCDatabricksDriver/{version}` (was `AdbcDatabricksDriver`) — the only wire-visible change, and the intended alignment.
- Fixed a stale `Adbc…` example in `TelemetryClientContext` XML docs.

**Thrift** (`SparkHttpConnection`, hiveserver2 submodule) already emits `ADBCDatabricksDriver/{version} Thrift/{tv}` via `DriverName` and can't reference this helper (dependency direction), so it is unchanged. All three builders now resolve to the same `ADBCDatabricksDriver` prefix from the single `DatabricksDriverName` constant.

## Why

Before this change the prefixes were inconsistent: the query transports (Thrift + SEA) emitted `ADBCDatabricksDriver` while internal feature-flag requests emitted `AdbcDatabricksDriver`. This makes them uniform.

## Tests

- New `UserAgentHelperTests` (6 cases): prefix, `product` token placement, `user_agent_entry` append order, blank-entry handling, and that the prefix matches the driver-name constant.
- Driver builds clean on `netstandard2.0` / `net472` / `net8.0`.

Supersedes #317.