### PR TITLE
chore(csharp): sync hiveserver2 submodule to latest main (a8ad1e4)

### DIFF
--- a/csharp/src/AdbcDrivers.Databricks.csproj
+++ b/csharp/src/AdbcDrivers.Databricks.csproj
@@ -27,6 +27,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\hiveserver2\csharp\src\AdbcDrivers.HiveServer2.csproj" />
+    <ProjectReference Include="..\hiveserver2\csharp\src\AdbcDrivers.HiveServer2\AdbcDrivers.HiveServer2.csproj" />
   </ItemGroup>
 </Project>

--- a/csharp/test/AdbcDrivers.Databricks.Tests.csproj
+++ b/csharp/test/AdbcDrivers.Databricks.Tests.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\hiveserver2\csharp\arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj" />
-    <ProjectReference Include="..\hiveserver2\csharp\test\AdbcDrivers.Tests.HiveServer2.csproj" />
+    <ProjectReference Include="..\hiveserver2\csharp\test\AdbcDrivers.Tests.HiveServer2\AdbcDrivers.Tests.HiveServer2.csproj" />
     <ProjectReference Include="..\src\AdbcDrivers.Databricks.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Advances `csharp/hiveserver2` from `7db3d85` → `a8ad1e4` (15 commits)
- Key additions picked up:
  - `feat(csharp)`: NativeAOT packaging for the HiveServer2 driver
  - `perf(csharp)`: SIMD-accelerated Thrift column decoding with fewer copies
  - `fix(csharp)`: emit `db.error.kind` span tag on `Status=Error` spans
  - `fix(csharp)`: `proxy_ignore_list` bypass for any-host patterns (PECO-3069)
  - `fix(csharp)`: omit `db.response.returned_rows` when affected count is unknown
  - `test(csharp)`: mock-fixture coverage push 56% → 85.9% across multiple PRs

## Test Plan

- [x] Submodule pinned to `a8ad1e4` (tip of `hiveserver2` `main`)
- [x] CI will build with the updated submodule

Closes #439

---
_This PR was created with [GitHub MCP](http://go/mcps)._