### PR TITLE
test(csharp): stop hardcoding protocol in CloudFetch/CloseOperation E2E tests

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -760,29 +760,37 @@ namespace AdbcDrivers.Databricks.StatementExecution
         {
             if (_currentStatementId != null)
             {
-                try
+                // Start a dedicated span instead of annotating Activity.Current: Dispose is
+                // typically called outside any ambient activity (e.g. connection pooling),
+                // so Activity.Current is usually null here and the event would be dropped.
+                // Mirrors DatabricksCompositeReader.Dispose on the Thrift path, which owns
+                // its own span so the close is always traced regardless of caller context.
+                this.TraceActivity(activity =>
                 {
-                    // Close statement synchronously during dispose
-                    Activity.Current?.AddEvent(new ActivityEvent("statement.dispose",
-                        tags: new ActivityTagsCollection
-                        {
-                            { "statement_id", _currentStatementId }
-                        }));
-                    _client.CloseStatementAsync(_currentStatementId, CancellationToken.None).GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    // Best effort - ignore errors during dispose
-                    Activity.Current?.AddEvent(new ActivityEvent("statement.dispose.error",
-                        tags: new ActivityTagsCollection
-                        {
-                            { "error", ex.Message }
-                        }));
-                }
-                finally
-                {
-                    _currentStatementId = null;
-                }
+                    try
+                    {
+                        // Close statement synchronously during dispose
+                        activity?.AddEvent(new ActivityEvent("statement.dispose",
+                            tags: new ActivityTagsCollection
+                            {
+                                { "statement_id", _currentStatementId }
+                            }));
+                        _client.CloseStatementAsync(_currentStatementId, CancellationToken.None).GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        // Best effort - ignore errors during dispose
+                        activity?.AddEvent(new ActivityEvent("statement.dispose.error",
+                            tags: new ActivityTagsCollection
+                            {
+                                { "error", ex.Message }
+                            }));
+                    }
+                    finally
+                    {
+                        _currentStatementId = null;
+                    }
+                }, activityName: nameof(StatementExecutionStatement) + "." + nameof(Dispose));
             }
         }
 

--- a/csharp/test/E2E/CloseOperationE2ETest.cs
+++ b/csharp/test/E2E/CloseOperationE2ETest.cs
@@ -136,7 +136,9 @@ namespace AdbcDrivers.Databricks.Tests
 
             var parameters = new Dictionary<string, string>
             {
-                [DatabricksParameters.Protocol] = "thrift",
+                // Protocol intentionally omitted — the CloseOperation code path is
+                // protocol-agnostic (see class docstring), so the test runs under
+                // whatever protocol the CI matrix / connection config selects.
                 [DatabricksParameters.UseCloudFetch] = useCloudFetch.ToString(),
                 [DatabricksParameters.EnableDirectResults] = enableDirectResults.ToString(),
             };
@@ -221,7 +223,7 @@ namespace AdbcDrivers.Databricks.Tests
 
             var parameters = new Dictionary<string, string>
             {
-                [DatabricksParameters.Protocol] = "thrift",
+                // Protocol intentionally omitted — inherits the configured protocol.
                 [DatabricksParameters.UseCloudFetch] = "false",
                 [DatabricksParameters.EnableDirectResults] = "false",
             };

--- a/csharp/test/E2E/CloseOperationE2ETest.cs
+++ b/csharp/test/E2E/CloseOperationE2ETest.cs
@@ -114,16 +114,17 @@ namespace AdbcDrivers.Databricks.Tests
         ];
 
         /// <summary>
-        /// Validates that DatabricksCompositeReader.Dispose emits the composite_reader.close_operation
-        /// trace event for all result delivery modes when the reader is disposed without closing
-        /// the underlying connection (simulating connection pooling).
+        /// Validates that disposing a statement releases the server-side operation across all
+        /// result delivery modes when the connection is not closed (simulating connection pooling).
+        /// The protocol is inherited from config / the CI matrix, and the assertion branches:
         ///
-        /// The composite_reader.close_operation event is only present in the code path introduced
-        /// by the fix. Without the fix:
-        /// - Inline (DirectResults or not): event missing because _activeReader != null caused
-        ///   the old code to delegate to _activeReader.Dispose() instead.
-        /// - CloudFetch: same delegation, but CloseOperation is never sent at all, orphaning
-        ///   the server operation for ~1 hour.
+        /// - Thrift: DatabricksCompositeReader.Dispose must emit composite_reader.close_operation.
+        ///   Without the fix this event is missing — Inline (DirectResults or not) because the old
+        ///   code delegated to _activeReader.Dispose(); CloudFetch because CloseOperation was never
+        ///   sent at all, orphaning the server operation for ~1 hour.
+        /// - REST/SEA: there is no composite reader; StatementExecutionStatement.Dispose must emit
+        ///   statement.dispose, which brackets the CloseStatementAsync (HTTP DELETE) that releases
+        ///   the server statement.
         ///
         /// For Thrift wire-level assertions, see proxy-based tests in databricks-driver-test:
         /// CLOUDFETCH-013 through CLOUDFETCH-016.
@@ -134,15 +135,14 @@ namespace AdbcDrivers.Databricks.Tests
         {
             lock (_capturedEventsLock) { _capturedEvents.Clear(); }
 
+            // Inherit the protocol from config / CI matrix rather than hardcoding it.
+            // The two protocols release the server-side operation through different
+            // code paths, so the assertion below branches on the effective protocol.
+            string protocol = string.IsNullOrEmpty(TestConfiguration.Protocol)
+                ? "thrift" : TestConfiguration.Protocol.ToLowerInvariant();
+
             var parameters = new Dictionary<string, string>
             {
-                // Thrift-specific by design: the assertion targets the
-                // composite_reader.close_operation event emitted by
-                // DatabricksCompositeReader.Dispose, which only exists on the Thrift
-                // path. The REST path (StatementExecutionConnection) has no composite
-                // reader, so this test pins Thrift rather than inheriting the matrix
-                // protocol. (Skipping it on REST-only warehouses is tracked separately.)
-                [DatabricksParameters.Protocol] = "thrift",
                 [DatabricksParameters.UseCloudFetch] = useCloudFetch.ToString(),
                 [DatabricksParameters.EnableDirectResults] = enableDirectResults.ToString(),
             };
@@ -171,29 +171,54 @@ namespace AdbcDrivers.Databricks.Tests
 
                 OutputHelper?.WriteLine($"[{description}] Read {totalRows} rows, reader disposed.");
 
-                // Collect the events emitted by DatabricksCompositeReader.Dispose.
-                List<string> disposeEvents;
-                lock (_capturedEventsLock)
+                if (protocol == "rest")
                 {
-                    disposeEvents = _capturedEvents
-                        .Where(e => e.ActivityName == "DatabricksCompositeReader.Dispose")
-                        .Select(e => e.EventName)
-                        .ToList();
+                    // SEA path: there is no composite reader. The server statement is
+                    // released by StatementExecutionStatement.Dispose via CloseStatementAsync
+                    // (HTTP DELETE), traced as the statement.dispose event under that span.
+                    List<string> seaDisposeEvents;
+                    lock (_capturedEventsLock)
+                    {
+                        seaDisposeEvents = _capturedEvents
+                            .Where(e => e.ActivityName == "StatementExecutionStatement.Dispose")
+                            .Select(e => e.EventName)
+                            .ToList();
+                    }
+
+                    OutputHelper?.WriteLine($"[{description}] SEA dispose events: [{string.Join(", ", seaDisposeEvents)}]");
+
+                    Assert.True(seaDisposeEvents.Contains("statement.dispose"),
+                        $"[{description}] statement.dispose event not found in " +
+                        $"StatementExecutionStatement.Dispose. The SEA path must release the " +
+                        $"server statement via CloseStatementAsync (HTTP DELETE) on dispose. " +
+                        $"Got events: [" + string.Join(", ", seaDisposeEvents) + "]");
                 }
+                else
+                {
+                    // Thrift path: the operation is closed by DatabricksCompositeReader.Dispose.
+                    List<string> disposeEvents;
+                    lock (_capturedEventsLock)
+                    {
+                        disposeEvents = _capturedEvents
+                            .Where(e => e.ActivityName == "DatabricksCompositeReader.Dispose")
+                            .Select(e => e.EventName)
+                            .ToList();
+                    }
 
-                OutputHelper?.WriteLine($"[{description}] Dispose events: [{string.Join(", ", disposeEvents)}]");
+                    OutputHelper?.WriteLine($"[{description}] Dispose events: [{string.Join(", ", disposeEvents)}]");
 
-                // The composite_reader.close_operation.started event is only present after
-                // the original CloseOperation fix (it was renamed from the bare
-                // "composite_reader.close_operation" by issue #489 to mark when the RPC
-                // begins). Without that fix, the CloudFetch path silently skips
-                // CloseOperation entirely and neither event is emitted.
-                Assert.True(disposeEvents.Contains("composite_reader.close_operation.started"),
-                    $"[{description}] composite_reader.close_operation.started event not found in " +
-                    $"DatabricksCompositeReader.Dispose. Without the close-operation fix, server " +
-                    $"operations are orphaned until SQL Gateway closes them with " +
-                    $"CommandInactivityTimeout (~1 hour). Got events: [" +
-                    string.Join(", ", disposeEvents) + "]");
+                    // The composite_reader.close_operation.started event is only present after
+                    // the original CloseOperation fix (it was renamed from the bare
+                    // "composite_reader.close_operation" by issue #489 to mark when the RPC
+                    // begins). Without that fix, the CloudFetch path silently skips
+                    // CloseOperation entirely and neither event is emitted.
+                    Assert.True(disposeEvents.Contains("composite_reader.close_operation.started"),
+                        $"[{description}] composite_reader.close_operation.started event not found in " +
+                        $"DatabricksCompositeReader.Dispose. Without the close-operation fix, server " +
+                        $"operations are orphaned until SQL Gateway closes them with " +
+                        $"CommandInactivityTimeout (~1 hour). Got events: [" +
+                        string.Join(", ", disposeEvents) + "]");
+                }
             }
             finally
             {
@@ -227,7 +252,10 @@ namespace AdbcDrivers.Databricks.Tests
 
             var parameters = new Dictionary<string, string>
             {
-                // Thrift-specific by design — see DisposeEmitsCloseOperationEvent.
+                // Thrift-pinned by design: this test measures the latency of the Thrift
+                // TCloseOperationReq RPC via the started/completed event pair, which only
+                // exists on the composite-reader (Thrift) path. The REST/SEA close is a
+                // single HTTP DELETE with no equivalent latency-bracketing pair.
                 [DatabricksParameters.Protocol] = "thrift",
                 [DatabricksParameters.UseCloudFetch] = "false",
                 [DatabricksParameters.EnableDirectResults] = "false",

--- a/csharp/test/E2E/CloseOperationE2ETest.cs
+++ b/csharp/test/E2E/CloseOperationE2ETest.cs
@@ -136,9 +136,13 @@ namespace AdbcDrivers.Databricks.Tests
 
             var parameters = new Dictionary<string, string>
             {
-                // Protocol intentionally omitted — the CloseOperation code path is
-                // protocol-agnostic (see class docstring), so the test runs under
-                // whatever protocol the CI matrix / connection config selects.
+                // Thrift-specific by design: the assertion targets the
+                // composite_reader.close_operation event emitted by
+                // DatabricksCompositeReader.Dispose, which only exists on the Thrift
+                // path. The REST path (StatementExecutionConnection) has no composite
+                // reader, so this test pins Thrift rather than inheriting the matrix
+                // protocol. (Skipping it on REST-only warehouses is tracked separately.)
+                [DatabricksParameters.Protocol] = "thrift",
                 [DatabricksParameters.UseCloudFetch] = useCloudFetch.ToString(),
                 [DatabricksParameters.EnableDirectResults] = enableDirectResults.ToString(),
             };
@@ -223,7 +227,8 @@ namespace AdbcDrivers.Databricks.Tests
 
             var parameters = new Dictionary<string, string>
             {
-                // Protocol intentionally omitted — inherits the configured protocol.
+                // Thrift-specific by design — see DisposeEmitsCloseOperationEvent.
+                [DatabricksParameters.Protocol] = "thrift",
                 [DatabricksParameters.UseCloudFetch] = "false",
                 [DatabricksParameters.EnableDirectResults] = "false",
             };

--- a/csharp/test/E2E/CloudFetchE2ETest.cs
+++ b/csharp/test/E2E/CloudFetchE2ETest.cs
@@ -37,7 +37,8 @@ namespace AdbcDrivers.Databricks.Tests
 {
     /// <summary>
     /// End-to-end tests for the CloudFetch feature in the Databricks ADBC driver.
-    /// Tests both Thrift and Statement Execution REST API protocols.
+    /// Runs under the protocol selected by the connection config / CI matrix
+    /// (the suite is exercised against both Thrift and REST as separate jobs).
     /// </summary>
     public class CloudFetchE2ETest : TestBase<DatabricksTestConfiguration, DatabricksTestEnvironment>, IDisposable
     {
@@ -111,48 +112,51 @@ namespace AdbcDrivers.Databricks.Tests
         }
 
         /// <summary>
-        /// Test cases for CloudFetch with protocol dimension.
-        /// Format: (query, expected row count, use cloud fetch, enable direct results, protocol)
+        /// Test cases for CloudFetch.
+        /// Format: (query, expected row count, use cloud fetch, enable direct results)
+        ///
+        /// The protocol is NOT a test-case dimension: each case runs under the protocol
+        /// selected by the connection config / CI matrix (separate rest and thrift jobs),
+        /// so it isn't duplicated or hardcoded here.
         /// </summary>
         public static IEnumerable<object[]> TestCases()
         {
-            string[] protocols = { "thrift", "rest" };
-
             string zeroQuery = "SELECT * FROM range(1000) LIMIT 0";
             string smallQuery = "SELECT * FROM range(1000)";
             string largeQuery = "SELECT * FROM main.tpcds_sf100_delta.store_sales LIMIT 1000000";
 
-            foreach (var protocol in protocols)
-            {
-                // LIMIT 0 test cases - edge case for empty result set (PECO-2524)
-                yield return new object[] { zeroQuery, 0, true, true, protocol };
-                yield return new object[] { zeroQuery, 0, false, true, protocol };
+            // LIMIT 0 test cases - edge case for empty result set (PECO-2524)
+            yield return new object[] { zeroQuery, 0, true, true };
+            yield return new object[] { zeroQuery, 0, false, true };
 
-                // Small query test cases
-                yield return new object[] { smallQuery, 1000, true, true, protocol };
-                yield return new object[] { smallQuery, 1000, false, true, protocol };
-                yield return new object[] { smallQuery, 1000, true, false, protocol };
-                yield return new object[] { smallQuery, 1000, false, false, protocol };
+            // Small query test cases
+            yield return new object[] { smallQuery, 1000, true, true };
+            yield return new object[] { smallQuery, 1000, false, true };
+            yield return new object[] { smallQuery, 1000, true, false };
+            yield return new object[] { smallQuery, 1000, false, false };
 
-                // Large query test cases
-                yield return new object[] { largeQuery, 1000000, true, true, protocol };
-                yield return new object[] { largeQuery, 1000000, false, true, protocol };
-                yield return new object[] { largeQuery, 1000000, true, false, protocol };
-                yield return new object[] { largeQuery, 1000000, false, false, protocol };
-            }
+            // Large query test cases
+            yield return new object[] { largeQuery, 1000000, true, true };
+            yield return new object[] { largeQuery, 1000000, false, true };
+            yield return new object[] { largeQuery, 1000000, true, false };
+            yield return new object[] { largeQuery, 1000000, false, false };
         }
 
         /// <summary>
         /// Integration test for running queries against a real Databricks cluster with different CloudFetch settings.
-        /// Tests both Thrift and Statement Execution REST API protocols.
+        /// Runs under the protocol selected by the connection config / CI matrix (rest or thrift).
         /// </summary>
         [Theory]
         [MemberData(nameof(TestCases))]
-        public async Task TestCloudFetch(string query, int rowCount, bool useCloudFetch, bool enableDirectResults, string protocol)
+        public async Task TestCloudFetch(string query, int rowCount, bool useCloudFetch, bool enableDirectResults)
         {
+            // Effective protocol comes from config (mirrors DatabricksDatabase's default),
+            // not from the test — so the rest-only setup below tracks the configured protocol.
+            string protocol = string.IsNullOrEmpty(TestConfiguration.Protocol)
+                ? "thrift" : TestConfiguration.Protocol.ToLowerInvariant();
+
             var parameters = new Dictionary<string, string>
             {
-                [DatabricksParameters.Protocol] = protocol,
                 [DatabricksParameters.UseCloudFetch] = useCloudFetch.ToString(),
                 [DatabricksParameters.EnableDirectResults] = enableDirectResults.ToString(),
                 [DatabricksParameters.CanDecompressLz4] = "true",


### PR DESCRIPTION
## What & why

Several E2E tests hardcoded the connection protocol in the test body. Because Connect-level options take precedence over the Open-level config protocol (`DatabricksDatabase.cs:91-95`), a `protocol: rest` matrix job still opened **Thrift** sessions for those tests — which fail with `ENDPOINT_NOT_FOUND … (HTTP 404)` against a REST-only warehouse (e.g. the Reyden nightly). This PR removes the incidental hardcoding so tests follow the matrix/config protocol, and makes the genuinely protocol-specific test branch on protocol instead of pinning.

## Changes

### `CloudFetchE2ETest` — de-hardcoded
Removed the in-test `protocols = { "thrift", "rest" }` dimension. The CI matrix already runs `rest` and `thrift` as separate jobs, so the dimension both duplicated coverage and forced Thrift inside the rest job. Each case now runs once under the configured protocol; the REST-only result-disposition setup keys off `TestConfiguration.Protocol`. **20 cases → 10.**

### `CloseOperationE2ETest` — protocol-aware
`DisposeEmitsCloseOperationEvent` no longer pins Thrift. It inherits the configured protocol and branches the assertion to match how each protocol releases the server-side operation:
- **Thrift**: `composite_reader.close_operation` emitted by `DatabricksCompositeReader.Dispose`.
- **REST/SEA**: `statement.dispose` emitted by `StatementExecutionStatement.Dispose`, which brackets the `CloseStatementAsync` (HTTP DELETE) that releases the server statement. (There is no composite reader on the REST path.)

`DisposeCloseOperation_..._Issue489` stays Thrift-pinned by design — it measures the Thrift `TCloseOperationReq` RPC latency via a started/completed event pair, which has no SEA equivalent (the REST close is a single DELETE).

### `StatementExecutionStatement.Dispose()` (driver) — own span
To make the SEA branch's signal observable, `Dispose()` now starts its own span via `this.TraceActivity(...)` instead of annotating `Activity.Current`. `Dispose` typically runs outside any ambient activity (e.g. connection pooling), so the prior `Activity.Current?.AddEvent` was usually dropped — in tests **and in production**. This mirrors `DatabricksCompositeReader.Dispose` on the Thrift path and fixes a latent telemetry gap for `statement.dispose` / `statement.dispose.error`.

## Validation

E2E run on this branch (commit `f62dd55`) against the dual-protocol warehouse — **both jobs green**:
- **E2E Tests (thrift)** ✅
- **E2E Tests (rest)** ✅ — 1453 passed / 0 failed / 178 skipped.
- `CloseOperationE2ETest`: failed under REST when Thrift-pinned in an earlier revision; now passes under REST via the `statement.dispose` branch.
- `CloudFetchE2ETest`: all 10 cases pass under REST.

## Out of scope (intentionally unchanged)

- Genuine Thrift-vs-SEA **parity** tests that open both connections in one test: `SeaMetadataE2ETests`, `IntervalValueTests`.
- **REST/SEA-specific** tests that pin `"rest"` by design and pass today: `ServerSidePropertyE2ETest`, `StatementExecutionDriverE2ETests`.

This pull request and its description were written by Isaac.