### PR TITLE
test(csharp): enable client telemetry for all e2e tests

### DIFF
--- a/csharp/test/E2E/DatabricksTestEnvironment.cs
+++ b/csharp/test/E2E/DatabricksTestEnvironment.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Data.SqlTypes;
 using System.Text;
 using Apache.Arrow.Adbc;
+using AdbcDrivers.Databricks.Telemetry;
 using AdbcDrivers.HiveServer2;
 using AdbcDrivers.HiveServer2.Hive2;
 using AdbcDrivers.HiveServer2.Spark;
@@ -259,6 +260,13 @@ namespace AdbcDrivers.Databricks.Tests
                     }
                 }
             }
+
+            // Force client telemetry on for all e2e runs so the suite emits real events
+            // to {host}/telemetry-ext under the current driver version. Telemetry is off by
+            // default (TelemetryConfiguration.Enabled = false); the driver reads this key via
+            // TelemetryConfiguration.FromProperties. Indexer assignment keeps this idempotent
+            // if a future config field also sets the key.
+            parameters[TelemetryConfiguration.PropertyKeyEnabled] = "true";
 
             return parameters;
         }


### PR DESCRIPTION
## What

Force `adbc.databricks.telemetry.enabled=true` in `DatabricksTestEnvironment.GetDriverParameters`, so every e2e connection now emits real client telemetry to `{host}/telemetry-ext`.

## Why

Telemetry is **off by default** (`TelemetryConfiguration.Enabled = false`). As a result, the only ADBC traffic currently landing in `main.eng_lumberjack.prod_frontend_log_sql_driver_log` comes from a stale build (`0.23.0-SNAPSHOT+b716671`, commit for #341) — no current-version (`1.1.4`) telemetry reaches lumberjack at all. Enabling it at the test-env layer gives the e2e suite real, current-build telemetry coverage (session/statement/metadata events, retry/chunk fields, etc.) and a live signal that the export path works end-to-end against the real endpoint.

## Scope / impact

- Affects **only** the e2e test environment (`csharp/test/E2E/DatabricksTestEnvironment.cs`); no driver/runtime code changes.
- Every e2e run will now POST to `/telemetry-ext`. This is intentional. Sends are non-blocking and guarded by the circuit breaker, so a telemetry failure cannot fail a functional test.
- Idempotent indexer assignment, so a future config-gated `telemetryEnabled` field can override it without conflict.

## Verification

Build could not be run locally due to an unrelated `net10.0` submodule/SDK mismatch. To confirm end-to-end: with `DATABRICKS_TEST_CONFIG_FILE` set (non-SEA, with token), run an e2e test (e.g. `CloudFetchE2ETest`), wait ~30 min for ingestion, then query `prod_frontend_log_sql_driver_log` for a fresh `driver_version LIKE '1.1.4%'` row — absent on `main`, present with this change.

This pull request and its description were written by Isaac.