### PR TITLE
fix(csharp): report informational version in telemetry driver_version

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -55,6 +55,14 @@ namespace AdbcDrivers.Databricks
         internal static new readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksConnection));
         internal static readonly string DriverVersion = s_assemblyVersion;
 
+        // Version reported in the telemetry payload's driver_version. Uses the assembly's
+        // AssemblyInformationalVersion (e.g. "1.1.4-SNAPSHOT+<sha>") rather than the numeric
+        // AssemblyVersion in s_assemblyVersion (e.g. "1.1.4"), so telemetry can pinpoint the
+        // exact build/commit and matches the JDBC driver's version format. Falls back to the
+        // numeric version if the assembly carries no AssemblyInformationalVersionAttribute.
+        internal static readonly string s_telemetryDriverVersion =
+            ApacheUtility.GetAssemblyProductVersion(typeof(DatabricksConnection), s_assemblyVersion);
+
         /// <summary>
         /// The environment variable name that contains the path to the default Databricks configuration file.
         /// Takes precedence over <see cref="DefaultConfigEnvironmentVariable"/> when both are set.
@@ -768,7 +776,7 @@ namespace AdbcDrivers.Databricks
             _telemetry = Telemetry.ConnectionTelemetry.Create(
                 properties: Properties,
                 host: GetHost(),
-                assemblyVersion: s_assemblyVersion,
+                assemblyVersion: s_telemetryDriverVersion,
                 oauthTokenProvider: _oauthTokenProvider,
                 sessionId: sessionId,
                 mode: Telemetry.Proto.DriverMode.Types.Type.Thrift,

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryDriverVersionTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryDriverVersionTests.cs
@@ -1,0 +1,83 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Reflection;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Regression tests pinning that the telemetry <c>driver_version</c> reports the assembly's
+    /// <see cref="AssemblyInformationalVersionAttribute"/> (e.g. <c>"1.1.4-SNAPSHOT+&lt;sha&gt;"</c>)
+    /// rather than the bare numeric <c>AssemblyVersion</c> (e.g. <c>"1.1.4"</c>).
+    ///
+    /// <para>
+    /// Background: <see cref="DatabricksConnection.s_assemblyVersion"/> is
+    /// <c>Assembly.GetName().Version.ToString(3)</c> — purely numeric, so it drops the
+    /// <c>-SNAPSHOT</c> prerelease label and the <c>+&lt;commit-sha&gt;</c> build metadata.
+    /// Production lumberjack data shows builds reporting <c>"0.23.0-SNAPSHOT+&lt;sha&gt;"</c>
+    /// (an informational version), which is what lets analysts pinpoint the exact build/commit
+    /// and matches the JDBC driver's version format. Feeding the numeric version into telemetry
+    /// makes every <c>1.1.4</c> build indistinguishable.
+    /// </para>
+    ///
+    /// <para>
+    /// The fix introduces <see cref="DatabricksConnection.s_telemetryDriverVersion"/>
+    /// (= <c>ApacheUtility.GetAssemblyProductVersion</c>, the informational version) and feeds
+    /// that into <c>ConnectionTelemetry.Create</c> instead of the numeric version.
+    /// </para>
+    /// </summary>
+    public class ConnectionTelemetryDriverVersionTests
+    {
+        private static string? InformationalVersion =>
+            typeof(DatabricksConnection).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        [Fact]
+        public void TelemetryDriverVersion_EqualsAssemblyInformationalVersion()
+        {
+            string? info = InformationalVersion;
+            Assert.False(
+                string.IsNullOrEmpty(info),
+                "The Databricks driver assembly must carry an AssemblyInformationalVersion.");
+
+            // The value fed to ConnectionTelemetry.Create (and therefore the telemetry payload's
+            // driver_version) must be the informational version, not the numeric AssemblyVersion.
+            Assert.Equal(info, DatabricksConnection.s_telemetryDriverVersion);
+        }
+
+        [Fact]
+        public void TelemetryDriverVersion_IsRicherThanNumericAssemblyVersion()
+        {
+            string numeric = DatabricksConnection.s_assemblyVersion;          // e.g. "1.1.4"
+            string telemetry = DatabricksConnection.s_telemetryDriverVersion; // e.g. "1.1.4-SNAPSHOT+<sha>"
+
+            // The informational version is a superset of the numeric base version.
+            Assert.StartsWith(numeric, telemetry);
+
+            // VersionSuffix=SNAPSHOT (Directory.Build.props) makes every dev/CI build carry a
+            // "-SNAPSHOT" (and usually "+<sha>") suffix. When that metadata is present, telemetry
+            // must NOT collapse to the bare numeric version. This is the discriminating regression
+            // guard: before the fix, driver_version was GetAssemblyVersion (numeric), so it would
+            // have equalled `numeric` and this assertion would fail.
+            bool hasMetadata = telemetry.Contains('-') || telemetry.Contains('+');
+            if (hasMetadata)
+            {
+                Assert.NotEqual(numeric, telemetry);
+            }
+        }
+    }
+}

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryDriverVersionTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryDriverVersionTests.cs
@@ -73,7 +73,9 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
             // must NOT collapse to the bare numeric version. This is the discriminating regression
             // guard: before the fix, driver_version was GetAssemblyVersion (numeric), so it would
             // have equalled `numeric` and this assertion would fail.
-            bool hasMetadata = telemetry.Contains('-') || telemetry.Contains('+');
+            // Use string overloads of Contains: the driver multi-targets net472/netstandard2.0,
+            // where string.Contains(char) does not exist (only string.Contains(string)).
+            bool hasMetadata = telemetry.Contains("-") || telemetry.Contains("+");
             if (hasMetadata)
             {
                 Assert.NotEqual(numeric, telemetry);


### PR DESCRIPTION
## What

Telemetry's `driver_version` now reports the assembly's **`AssemblyInformationalVersion`** (e.g. `1.1.4-SNAPSHOT+<sha>`) instead of the bare numeric **`AssemblyVersion`** (`1.1.4`).

## Why

`DatabricksConnection.InitializeTelemetry` passed `s_assemblyVersion` into `ConnectionTelemetry.Create`, and `s_assemblyVersion = ApacheUtility.GetAssemblyVersion(...) = Assembly.GetName().Version.ToString(3)` — a purely numeric `major.minor.build`. That **drops the `-SNAPSHOT` prerelease label and the `+<commit-sha>` build metadata**, so:

- Every `1.1.4` build (nightly, PR CI, release — each a different commit) reports an *identical* `driver_version`; you can't pinpoint which build/commit emitted an event (defeats build-cutover detection).
- It's inconsistent with historical telemetry: production lumberjack rows show `0.23.0-SNAPSHOT+b716671<sha>` (an informational version), so the field's semantics had silently regressed to the coarser numeric form.
- It diverges from the JDBC driver's version format.
- It's fragile: `AssemblyVersion` is the strong-name binding identity and is commonly pinned; if it's ever pinned for binding stability, telemetry would report a stale/wrong version.

The assembly *selection* was already correct (the `new` override reads the Databricks assembly, not the base Apache/HiveServer2 one) — only the version *field* was wrong.

## Change

- Add `DatabricksConnection.s_telemetryDriverVersion` = `ApacheUtility.GetAssemblyProductVersion(typeof(DatabricksConnection), s_assemblyVersion)` (the informational version, falling back to the numeric version if the attribute is absent), and feed it into `ConnectionTelemetry.Create`.
- `s_assemblyVersion` (numeric) stays the source for the ADBC `AssemblyVersion` property and trace tags — unchanged.

## Test

`ConnectionTelemetryDriverVersionTests` pins that:
1. The telemetry version equals the assembly's `AssemblyInformationalVersion`.
2. When a `-SNAPSHOT`/`+sha` suffix is present (true for all dev/CI builds via `VersionSuffix=SNAPSHOT`), it does **not** collapse to the bare numeric `AssemblyVersion` — the discriminating regression guard (this assertion fails on the pre-fix numeric source).

## Verification

Could not build/run locally due to an unrelated `net10.0` submodule vs. SDK 9.0.304 mismatch (all build errors are in `hiveserver2/*`, none in the changed files). CI will compile and run `ConnectionTelemetryDriverVersionTests`.

This pull request and its description were written by Isaac.