### PR TITLE
fix(csharp): correct enable_complex_datatype_support telemetry + map more connection params

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -773,7 +773,7 @@ namespace AdbcDrivers.Databricks
                 sessionId: sessionId,
                 mode: Telemetry.Proto.DriverMode.Types.Type.Thrift,
                 enableDirectResults: _enableDirectResults,
-                useDescTableExtended: _useDescTableExtended,
+                enableComplexDatatypeSupport: _enableComplexDatatypeSupport,
                 connectTimeoutMilliseconds: ConnectTimeoutMilliseconds,
                 activity: activity);
         }

--- a/csharp/src/Telemetry/ConnectionTelemetry.cs
+++ b/csharp/src/Telemetry/ConnectionTelemetry.cs
@@ -27,6 +27,7 @@ using AdbcDrivers.Databricks.Auth;
 using AdbcDrivers.Databricks.Http;
 using AdbcDrivers.Databricks.Telemetry.Models;
 using AdbcDrivers.HiveServer2;
+using AdbcDrivers.HiveServer2.Hive2;
 using AdbcDrivers.HiveServer2.Spark;
 using Apache.Arrow.Adbc;
 
@@ -78,7 +79,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             string sessionId,
             Proto.DriverMode.Types.Type mode,
             bool enableDirectResults,
-            bool useDescTableExtended,
+            bool enableComplexDatatypeSupport,
             int connectTimeoutMilliseconds,
             Activity? activity)
         {
@@ -124,7 +125,7 @@ namespace AdbcDrivers.Databricks.Telemetry
                     SafeBuildSystemConfiguration(assemblyVersion, activity);
                 Proto.DriverConnectionParameters driverConnectionParams =
                     SafeBuildDriverConnectionParams(
-                        properties, host, mode, enableDirectResults, useDescTableExtended,
+                        properties, host, mode, enableDirectResults, enableComplexDatatypeSupport,
                         connectTimeoutMilliseconds, activity);
                 string authType = SafeDetermineAuthType(properties, activity);
 
@@ -439,14 +440,14 @@ namespace AdbcDrivers.Databricks.Telemetry
             string host,
             Proto.DriverMode.Types.Type mode,
             bool enableDirectResults,
-            bool useDescTableExtended,
+            bool enableComplexDatatypeSupport,
             int connectTimeoutMilliseconds,
             Activity? activity)
         {
             try
             {
                 return BuildDriverConnectionParams(
-                    properties, host, mode, enableDirectResults, useDescTableExtended,
+                    properties, host, mode, enableDirectResults, enableComplexDatatypeSupport,
                     connectTimeoutMilliseconds);
             }
             catch (Exception ex)
@@ -474,7 +475,7 @@ namespace AdbcDrivers.Databricks.Telemetry
                     EnableArrow = true,
                     EnableDirectResults = enableDirectResults,
                     SocketTimeout = connectTimeoutMilliseconds > 0 ? connectTimeoutMilliseconds / 1000 : 0,
-                    EnableComplexDatatypeSupport = useDescTableExtended,
+                    EnableComplexDatatypeSupport = enableComplexDatatypeSupport,
                     AutoCommit = true,
                 };
             }
@@ -634,7 +635,7 @@ namespace AdbcDrivers.Databricks.Telemetry
             string host,
             Proto.DriverMode.Types.Type mode,
             bool enableDirectResults,
-            bool useDescTableExtended,
+            bool enableComplexDatatypeSupport,
             int connectTimeoutMilliseconds)
         {
             properties.TryGetValue(SparkParameters.Path, out string? httpPath);
@@ -666,7 +667,7 @@ namespace AdbcDrivers.Databricks.Telemetry
                 RowsFetchedPerBlock = batchSize,
                 SocketTimeout = connectTimeoutMilliseconds > 0 ? connectTimeoutMilliseconds / 1000 : 0,
                 EnableDirectResults = enableDirectResults,
-                EnableComplexDatatypeSupport = useDescTableExtended,
+                EnableComplexDatatypeSupport = enableComplexDatatypeSupport,
                 AutoCommit = true,
                 AsyncPollIntervalMillis = asyncPollIntervalMillis,
             };
@@ -683,6 +684,77 @@ namespace AdbcDrivers.Databricks.Telemetry
             // own try/catch so a future per-field source change cannot kill the whole payload.
             TrySetField(connectionParams, p => p.DiscoveryModeEnabled = false);
             TrySetField(connectionParams, p => p.EnableTokenCache = false);
+
+            // Map additional ADBC connection properties when present (left unset/null otherwise,
+            // matching JDBC). Each set is wrapped per-field so a parse/lookup problem on one
+            // field cannot drop the whole payload.
+            TrySetField(connectionParams, p =>
+            {
+                if (properties.TryGetValue(DatabricksParameters.QueryTags, out string? queryTags) &&
+                    !string.IsNullOrEmpty(queryTags))
+                {
+                    p.QueryTags = queryTags;
+                }
+            });
+            TrySetField(connectionParams, p =>
+            {
+                if (properties.TryGetValue(DatabricksParameters.OAuthScope, out string? authScope) &&
+                    !string.IsNullOrEmpty(authScope))
+                {
+                    p.AuthScope = authScope;
+                }
+            });
+
+            // Proxy configuration (use_proxy / proxy_host_info / non_proxy_hosts).
+            TrySetField(connectionParams, p =>
+            {
+                if (properties.TryGetValue(HttpProxyOptions.UseProxy, out string? useProxy) &&
+                    bool.TryParse(useProxy, out bool useProxyValue))
+                {
+                    p.UseProxy = useProxyValue;
+                }
+            });
+            TrySetField(connectionParams, p =>
+            {
+                if (properties.TryGetValue(HttpProxyOptions.ProxyHost, out string? proxyHost) &&
+                    !string.IsNullOrEmpty(proxyHost))
+                {
+                    var proxyInfo = new Proto.HostDetails { HostUrl = proxyHost };
+                    if (properties.TryGetValue(HttpProxyOptions.ProxyPort, out string? proxyPort) &&
+                        int.TryParse(proxyPort, out int proxyPortValue))
+                    {
+                        proxyInfo.Port = proxyPortValue;
+                    }
+                    p.ProxyHostInfo = proxyInfo;
+                }
+            });
+            TrySetField(connectionParams, p =>
+            {
+                if (properties.TryGetValue(HttpProxyOptions.ProxyIgnoreList, out string? ignoreList) &&
+                    !string.IsNullOrEmpty(ignoreList))
+                {
+                    foreach (string entry in ignoreList.Split(','))
+                    {
+                        string trimmed = entry.Trim();
+                        if (trimmed.Length > 0)
+                        {
+                            p.NonProxyHosts.Add(trimmed);
+                        }
+                    }
+                }
+            });
+
+            // TLS: only allow_self_signed_support has a C# equivalent. The other TLS proto
+            // fields (use_system_trust_store, ssl_trust_store_type, check_certificate_revocation)
+            // are JDBC-only concepts with no driver setting, so they are intentionally left unset.
+            TrySetField(connectionParams, p =>
+            {
+                if (properties.TryGetValue(HttpTlsOptions.AllowSelfSigned, out string? allowSelfSigned) &&
+                    bool.TryParse(allowSelfSigned, out bool allowSelfSignedValue))
+                {
+                    p.AllowSelfSignedSupport = allowSelfSignedValue;
+                }
+            });
 
             return connectionParams;
         }

--- a/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
+++ b/csharp/test/E2E/Telemetry/ConnectionParametersTests.cs
@@ -419,7 +419,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
                 var properties = TestEnvironment.GetDriverParameters(TestConfiguration);
 
                 // Enable complex datatype support explicitly
-                properties[DatabricksParameters.UseDescTableExtended] = "true";
+                properties[DatabricksParameters.EnableComplexDatatypeSupport] = "true";
 
                 (connection, exporter) = TelemetryTestHelpers.CreateConnectionWithCapturingTelemetry(properties);
 
@@ -440,7 +440,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
                 // Assert enable_complex_datatype_support is populated
                 Assert.NotNull(protoLog.DriverConnectionParams);
                 Assert.True(protoLog.DriverConnectionParams.EnableComplexDatatypeSupport,
-                    "enable_complex_datatype_support should match UseDescTableExtended config");
+                    "enable_complex_datatype_support should match EnableComplexDatatypeSupport config");
 
                 OutputHelper?.WriteLine($"✓ enable_complex_datatype_support: {protoLog.DriverConnectionParams.EnableComplexDatatypeSupport}");
             }
@@ -610,7 +610,7 @@ namespace AdbcDrivers.Databricks.Tests.E2E.Telemetry
                 properties[ApacheParameters.BatchSize] = "10000";
                 properties[SparkParameters.ConnectTimeoutMilliseconds] = "90000";
                 properties[DatabricksParameters.EnableDirectResults] = "true";
-                properties[DatabricksParameters.UseDescTableExtended] = "true";
+                properties[DatabricksParameters.EnableComplexDatatypeSupport] = "true";
 
                 (connection, exporter) = TelemetryTestHelpers.CreateConnectionWithCapturingTelemetry(properties);
 

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryAuthMechTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryAuthMechTests.cs
@@ -49,7 +49,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
             Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
@@ -67,7 +67,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
             Assert.Equal(DriverAuthFlowType.ClientCredentials, connParams.AuthFlow);
@@ -87,7 +87,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
             Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
@@ -108,7 +108,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
             Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);
@@ -121,7 +121,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
             Assert.Equal(DriverAuthFlowType.TokenPassthrough, connParams.AuthFlow);

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryConnectionParamsMappingTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryConnectionParamsMappingTests.cs
@@ -1,0 +1,124 @@
+/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using AdbcDrivers.Databricks.Telemetry;
+using AdbcDrivers.HiveServer2.Hive2;
+using AdbcDrivers.HiveServer2.Spark;
+using DriverModeType = AdbcDrivers.Databricks.Telemetry.Proto.DriverMode.Types.Type;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Verifies <see cref="ConnectionTelemetry.BuildDriverConnectionParams"/> maps ADBC
+    /// connection properties onto the <c>driver_connection_params</c> proto:
+    /// <list type="bullet">
+    /// <item>the <c>enable_complex_datatype_support</c> fix — it must reflect its own
+    /// setting, NOT <c>use_desc_table_extended</c> (which is a distinct property and has
+    /// no proto home);</item>
+    /// <item>newly-mapped fields: <c>query_tags</c>, <c>auth_scope</c>, proxy
+    /// (<c>use_proxy</c>/<c>proxy_host_info</c>/<c>non_proxy_hosts</c>), and
+    /// <c>allow_self_signed_support</c>.</item>
+    /// </list>
+    /// </summary>
+    public class ConnectionTelemetryConnectionParamsMappingTests
+    {
+        private const string Host = "params-mapping.databricks.com";
+        private const int TimeoutMs = 900_000;
+
+        [Fact]
+        public void NewConnectionParamFields_AreMappedFromProperties()
+        {
+            var props = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123" },
+                { DatabricksParameters.QueryTags, "team:peco,env:test" },
+                { DatabricksParameters.OAuthScope, "all-apis" },
+                { HttpProxyOptions.UseProxy, "true" },
+                { HttpProxyOptions.ProxyHost, "proxy.internal" },
+                { HttpProxyOptions.ProxyPort, "8080" },
+                { HttpProxyOptions.ProxyIgnoreList, "localhost, .corp.example.com" },
+                { HttpTlsOptions.AllowSelfSigned, "true" },
+            };
+
+            var result = ConnectionTelemetry.BuildDriverConnectionParams(
+                props, Host, DriverModeType.Thrift,
+                enableDirectResults: true,
+                enableComplexDatatypeSupport: false,
+                connectTimeoutMilliseconds: TimeoutMs);
+
+            Assert.Equal("team:peco,env:test", result.QueryTags);
+            Assert.Equal("all-apis", result.AuthScope);
+            Assert.True(result.UseProxy);
+            Assert.NotNull(result.ProxyHostInfo);
+            Assert.Equal("proxy.internal", result.ProxyHostInfo.HostUrl);
+            Assert.Equal(8080, result.ProxyHostInfo.Port);
+            Assert.Equal(new[] { "localhost", ".corp.example.com" }, result.NonProxyHosts);
+            Assert.True(result.AllowSelfSignedSupport);
+        }
+
+        [Fact]
+        public void EnableComplexDatatypeSupport_ComesFromOwnSetting_NotUseDescTableExtended()
+        {
+            // Regression for the mis-wired field: enable_complex_datatype_support must reflect
+            // its own setting, independent of use_desc_table_extended. Set use_desc_table_extended
+            // = true but request complex-datatype support = false -> proto field must be false.
+            var props = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123" },
+                { DatabricksParameters.UseDescTableExtended, "true" },
+            };
+
+            var disabled = ConnectionTelemetry.BuildDriverConnectionParams(
+                props, Host, DriverModeType.Thrift,
+                enableDirectResults: true,
+                enableComplexDatatypeSupport: false,
+                connectTimeoutMilliseconds: TimeoutMs);
+            Assert.False(disabled.EnableComplexDatatypeSupport);
+
+            var enabled = ConnectionTelemetry.BuildDriverConnectionParams(
+                props, Host, DriverModeType.Thrift,
+                enableDirectResults: true,
+                enableComplexDatatypeSupport: true,
+                connectTimeoutMilliseconds: TimeoutMs);
+            Assert.True(enabled.EnableComplexDatatypeSupport);
+        }
+
+        [Fact]
+        public void OptionalFields_LeftUnset_WhenPropertiesAbsent()
+        {
+            var props = new Dictionary<string, string>
+            {
+                { SparkParameters.Path, "/sql/1.0/warehouses/abc123" },
+            };
+
+            var result = ConnectionTelemetry.BuildDriverConnectionParams(
+                props, Host, DriverModeType.Thrift,
+                enableDirectResults: true,
+                enableComplexDatatypeSupport: false,
+                connectTimeoutMilliseconds: TimeoutMs);
+
+            // Absent properties leave the proto fields unset (null/empty), matching JDBC.
+            Assert.False(result.HasQueryTags);
+            Assert.False(result.HasAuthScope);
+            Assert.False(result.HasUseProxy);
+            Assert.Null(result.ProxyHostInfo);
+            Assert.Empty(result.NonProxyHosts);
+            Assert.False(result.HasAllowSelfSignedSupport);
+        }
+    }
+}

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryCreateSignatureTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryCreateSignatureTests.cs
@@ -67,7 +67,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 sessionId: SessionId,
                 mode: DriverModeType.Thrift,
                 enableDirectResults: true,
-                useDescTableExtended: false,
+                enableComplexDatatypeSupport: false,
                 connectTimeoutMilliseconds: DefaultTimeoutMs,
                 activity: null);
 
@@ -102,7 +102,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 sessionId: string.Empty,
                 mode: DriverModeType.Thrift,
                 enableDirectResults: true,
-                useDescTableExtended: false,
+                enableComplexDatatypeSupport: false,
                 connectTimeoutMilliseconds: DefaultTimeoutMs,
                 activity: null);
 
@@ -132,7 +132,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 sessionId: "session-thrift",
                 mode: DriverModeType.Thrift,
                 enableDirectResults: true,
-                useDescTableExtended: false,
+                enableComplexDatatypeSupport: false,
                 connectTimeoutMilliseconds: DefaultTimeoutMs,
                 activity: null);
 
@@ -163,7 +163,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 sessionId: "session-sea",
                 mode: DriverModeType.Sea,
                 enableDirectResults: true,
-                useDescTableExtended: false,
+                enableComplexDatatypeSupport: false,
                 connectTimeoutMilliseconds: DefaultTimeoutMs,
                 activity: null);
 
@@ -205,7 +205,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 sessionId: "session-throwing-http",
                 mode: DriverModeType.Thrift,
                 enableDirectResults: true,
-                useDescTableExtended: false,
+                enableComplexDatatypeSupport: false,
                 connectTimeoutMilliseconds: DefaultTimeoutMs,
                 activity: null);
 

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryDiscoveryFieldsTests.cs
@@ -59,7 +59,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasDiscoveryModeEnabled);
             Assert.False(connParams.DiscoveryModeEnabled);
@@ -77,7 +77,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasDiscoveryModeEnabled);
             Assert.False(connParams.DiscoveryModeEnabled);
@@ -93,7 +93,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             // The C# driver hardcodes the OIDC token endpoint and never performs
             // .well-known discovery, so there is no URL to report. Leaving the
@@ -110,7 +110,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasEnableTokenCache);
             Assert.False(connParams.EnableTokenCache);
@@ -128,7 +128,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.True(connParams.HasEnableTokenCache);
             Assert.False(connParams.EnableTokenCache);

--- a/csharp/test/Unit/Telemetry/ConnectionTelemetryPartialInitTests.cs
+++ b/csharp/test/Unit/Telemetry/ConnectionTelemetryPartialInitTests.cs
@@ -62,7 +62,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
             string authType = ConnectionTelemetry.DetermineAuthType(properties);
 
             Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
@@ -82,7 +82,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
             string authType = ConnectionTelemetry.DetermineAuthType(properties);
 
             Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
@@ -105,7 +105,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
             string authType = ConnectionTelemetry.DetermineAuthType(properties);
 
             Assert.Equal(DriverAuthMechType.Oauth, connParams.AuthMech);
@@ -124,7 +124,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
             string authType = ConnectionTelemetry.DetermineAuthType(properties);
 
             Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
@@ -139,7 +139,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
             string authType = ConnectionTelemetry.DetermineAuthType(properties);
 
             Assert.Equal(DriverAuthMechType.Pat, connParams.AuthMech);
@@ -193,7 +193,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.BuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true, DefaultTimeoutMs);
+                enableDirectResults: true, enableComplexDatatypeSupport: true, DefaultTimeoutMs);
 
             Assert.True(connParams.EnableArrow);
             Assert.True(connParams.EnableDirectResults);
@@ -222,7 +222,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
 
             var connParams = ConnectionTelemetry.SafeBuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: false,
+                enableDirectResults: true, enableComplexDatatypeSupport: false,
                 connectTimeoutMilliseconds: DefaultTimeoutMs, activity: null);
 
             Assert.NotNull(connParams);
@@ -260,7 +260,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.Telemetry
                 "1.2.3", activity: null);
             var connParams = ConnectionTelemetry.SafeBuildDriverConnectionParams(
                 properties, Host, DriverModeType.Thrift,
-                enableDirectResults: true, useDescTableExtended: true,
+                enableDirectResults: true, enableComplexDatatypeSupport: true,
                 connectTimeoutMilliseconds: DefaultTimeoutMs, activity: null);
             string authType = ConnectionTelemetry.SafeDetermineAuthType(properties, activity: null);
 


### PR DESCRIPTION
## What

Two related changes to the `driver_connection_params` telemetry payload (`ConnectionTelemetry.BuildDriverConnectionParams`):

**1. Bug fix — `enable_complex_datatype_support` reported the wrong setting.**
It was sourced from `useDescTableExtended` (`adbc.databricks.use_desc_table_extended`) — a *distinct* setting from `_enableComplexDatatypeSupport` (`adbc.databricks.enable_complex_datatype_support`). So that telemetry column reflected DESC-TABLE-EXTENDED usage, not complex-datatype support. The threaded parameter is renamed `useDescTableExtended` → `enableComplexDatatypeSupport`, and `InitializeTelemetry` now feeds it `_enableComplexDatatypeSupport`. `use_desc_table_extended` has no proto field, so it's simply no longer (mis)reported.

**2. Map additional ADBC connection properties** that already exist in the proto (and therefore the `prod_frontend_log_sql_driver_log` schema) but were left `null`:

| proto field | source |
|---|---|
| `query_tags` | `adbc.databricks.query_tags` |
| `auth_scope` | `adbc.databricks.oauth.scope` |
| `use_proxy` | HTTP proxy `use_proxy` |
| `proxy_host_info` (`host_url`/`port`) | HTTP proxy `proxy_host` / `proxy_port` |
| `non_proxy_hosts` | HTTP proxy `proxy_ignore_list` (comma-split) |
| `allow_self_signed_support` | HTTP TLS `allow_self_signed` |

Each is set only when the property is present (left unset/null otherwise, matching JDBC), and wrapped per-field so one parse problem can't drop the payload.

### Intentionally NOT mapped
The remaining TLS proto fields — `use_system_trust_store`, `ssl_trust_store_type`, `check_certificate_revocation` — have no corresponding C# driver setting. They're left unset rather than wired to mismatched concepts (which would repeat the exact class of bug fixed in #1). Same for other JDBC/ODBC-only fields (`http_connection_pool_size`, `string_column_length`, `google_*`, etc.).

## Test

`ConnectionTelemetryConnectionParamsMappingTests` (new):
- `enable_complex_datatype_support` reflects its own setting, **not** `use_desc_table_extended` (sets `use_desc_table_extended=true`, passes `enableComplexDatatypeSupport: false`, asserts the proto field is `false`) — discriminating against the pre-fix wiring.
- the new fields (`query_tags`, `auth_scope`, `use_proxy`, `proxy_host_info`, `non_proxy_hosts`, `allow_self_signed_support`) are populated from properties, and left unset when absent.

Existing telemetry unit tests are updated for the renamed parameter.

## Verification

Built locally with a .NET 10 SDK — `dotnet build` succeeds (0 errors). The unit testhost couldn't be run in my environment (an unrelated macOS security agent SIGKILLs the side-loaded runtime), so the new test runs in CI.

This pull request and its description were written by Isaac.