### PR TITLE
chore(csharp): bump version to 1.1.5

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -18,7 +18,33 @@
 
 All notable changes to the C# Databricks ADBC driver are documented in this file.
 
-## [1.1.4] - Unreleased
+## [1.1.5] - 2026-06-11
+
+### Added
+
+- Emit telemetry for session/cancel/close operations (PECO-2991) (#437)
+- Support `ADBC_DATABRICKS_CONFIG_FILE` environment variable (#454)
+- Honor `adbc.spark.connect_timeout_ms` on SEA path (PECO-3059) (#466)
+- Honor `adbc.databricks.apply_ssp_with_queries` on SEA path (PECO-3062) (#468)
+- Enable feature flag cache by default (#500)
+
+### Fixed
+
+- Fix concurrent Dispose deadlock (#385)
+- Honor `EnableComplexDatatypeSupport` on SEA path (PECO-3047) (#457)
+- Emit valid JSON for Thrift MAP values containing quotes (#458)
+- Consolidate SEA polling interval onto `polltime_ms` (PECO-3064) (#470)
+- Bracket `close_operation` event for measurable latency (#492)
+- Tag `download_slot_acquired` with `wait_duration_ms` (#495)
+- Correct `enable_complex_datatype_support` telemetry and map more connection params (#517)
+
+### Changed
+
+- Reduce allocations and copies in result transfer (#474)
+- Unify user-agent on `UserAgentHelper` with capital-ADBC prefix (#503)
+- Make `ConnectionTelemetry.Create` protocol-agnostic (PECO-3022) (#460)
+
+## [1.1.4] - 2026-05-08
 
 ### Changed
 

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` from `1.1.4` → `1.1.5` in `csharp/Directory.Build.props`
- Mark `[1.1.4]` as released (2026-05-08) and add a dated `[1.1.5] - 2026-06-11` section in `CHANGELOG.md`

The 1.1.5 patch release captures everything merged since the 1.1.4 cut, including session/cancel/close telemetry (#437), the concurrent Dispose deadlock fix (#385), SEA-path config fixes (#457, #466, #468, #470), result-transfer perf improvements (#474), the feature flag cache enabled by default (#500), and connection-parameter telemetry corrections (#517).

Note: unlike #453, the new section is dated immediately rather than left as "Unreleased" — the release tag is cut from this PR's merge commit, so the "Unreleased" label would go stale the moment it lands.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, `csharp-sync-latest.yml` creates tag `csharp/v1.1.5` and updates `release/csharp/latest`

This pull request and its description were written by Isaac.