### PR TITLE
ci(engineer-bot): early "started" comment + write E2E integration tests against the workspace

### DIFF
--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -53,6 +53,21 @@ jobs:
           app-id: ${{ secrets.ENGINEER_BOT_APP_ID }}
           private-key: ${{ secrets.ENGINEER_BOT_PRIVATE_KEY }}
 
+      # Post an early "I've started" comment with a link to this run, so the issue
+      # shows the bot is working before the (multi-minute) author phase finishes.
+      # The final "Comment outcome on the issue" step reports success/no_change/
+      # failed at the end. Values go via env (never interpolated into the script) so
+      # an untrusted issue title can't inject shell — the run URL is GHA-derived.
+      - name: Comment that the bot has started
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+            --body "🤖 engineer-bot is on it — working on a fix. Progress: [run log](${RUN_URL}). I'll comment again with the outcome (and open a fix PR if I make changes)."
+
       - name: Checkout (the PR will be opened against this repo)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:


### PR DESCRIPTION
Two related engineer-bot improvements.

## 1. Early "started" comment
New step (right after the App-token mint) posts a comment on the triggering issue with a link to the Actions run, so the issue shows the bot is working during the multi-minute author phase. Final outcome comment is unchanged. Values pass via `env:` (no `${{ }}` in `run:`), so an untrusted issue title can't inject shell. Matches the hub's "Acknowledge trigger" pattern.

## 2. E2E integration tests against the workspace
The bug-fix bot now targets **live E2E tests** (`csharp/test/E2E/`) instead of offline unit tests — most driver bugs (metadata, type mapping, server behavior) only reproduce against a real workspace.

- **`author_system.md`**: prefer E2E; documents the read-only fixtures in `main.adbc_testing` (`all_column_types`, `cross_ref_*`, `fk_test_ref_table`) and when to use them; isolation rules (read fixtures, never write them; unique table + `DROP IF EXISTS` for the rare write; no schema-wide assertions); `--filter` to your own test (don't run the whole E2E suite — fixtures aren't fully seeded in this job); a *skipped* test is not a reproduction.
- **`engineer-bot.yaml`**: new "Create E2E test config" step — **lighter** setup (OAuth client-credentials against the existing shared warehouse, **no** per-run schema/seeding) that writes `~/.databricks/connection.json` and sets `DATABRICKS_TEST_CONFIG_FILE`, so E2E tests actually run instead of silently skipping. Runs on `ubuntu-latest`, matching every other adbc E2E workflow.

### Note on the writable schema
The config points the writable schema at `main.default`. The shared read-only fixtures are the primary path (most repros only read); if a future test needs to write and `default` isn't writable for the SP, that's a one-line config tweak — the prompt steers strongly toward read-only fixtures + metadata APIs.

## Test plan
- [ ] Label an issue `engineer-bot`; confirm the early "started" comment appears, the E2E config step mints a token + writes `connection.json`, and the bot's E2E test runs (not skipped) red→green via `--filter`.

This pull request and its description were written by Isaac.