### PR TITLE
ci: add E2E integration tests for the engineer-bot bug-fix flow

### DIFF
--- a/.bot/SETUP.md
+++ b/.bot/SETUP.md
@@ -1,3 +1,13 @@
+<!--
+  Copyright (c) 2025 ADBC Drivers Contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+-->
+
 # Engineer-bot + reviewer-bot — operator setup
 
 How to activate the two bots added by this PR. Until these are done they stay

--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Bug-fix task for adbc-drivers/databricks (C#). Copy to .bot/config.yaml.
 # The engine (databricks-bot-engine) is INSTALLED by the workflow; this file is
 # pure DATA. Single-repo: the agent edits THIS repo (TEST_REPO_ROOT = checkout)

--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -57,7 +57,7 @@ bash_allowlist:
 # Author phase: prompt rendered from the template; tokens are the ISSUE (the bug
 # to fix). No driver PR, no SOURCE_PR_* — this is single-repo, issue-driven.
 author:
-  max_turns: 60
+  max_turns: 100   # bug-fix needs reproduce→fix→re-run headroom; now actually enforced (engine in-loop backstop)
   user_prompt_template: prompts/author_user.md
   env_tokens:                 # {{issue_*}} in author_user.md  <-  env vars
     issue_number: ISSUE_NUMBER

--- a/.bot/prompts/author_system.md
+++ b/.bot/prompts/author_system.md
@@ -27,21 +27,20 @@ without weakening any test.
   (already set in your env). Your E2E test picks it up through the normal
   `TestBase`/`TestConfiguration` plumbing — never hard-code endpoints or tokens.
 
-## Workspace test data (read these; don't reseed)
-The shared CI workspace already has stable, **read-only** fixture tables in
-`main.adbc_testing` — reference that schema via
-`DatabricksTestEnvironment.FixtureSchema` (never hard-code `"adbc_testing"`):
-- **`all_column_types`** — one column of every Databricks type (tinyint…variant,
-  array/map/struct) plus a PRIMARY KEY and a FOREIGN KEY. Ideal for metadata/type
-  tests — GetColumns ordinal position, type mapping, GetCrossReference.
-- **`cross_ref_customers`, `cross_ref_orders`, `fk_test_ref_table`** — related
-  tables for foreign-key / cross-reference metadata tests.
+## Workspace test data (read-only — don't write these)
+- **`main.pqtest.alltypes`** — the canonical **all-types** table: one column of
+  every Databricks type. It's wired as `TestConfiguration.Metadata`
+  (`.Catalog` = `main`, `.Schema` = `pqtest`, `.Table` = `alltypes`), so read it
+  through the Metadata triple (or its fully-qualified name) for type/metadata
+  tests — GetColumns ordinal position, type mapping, schema inspection.
+- **`main.adbc_testing`** (the `DatabricksTestEnvironment.FixtureSchema` constant) —
+  other read-only fixtures: `cross_ref_customers`, `cross_ref_orders`,
+  `fk_test_ref_table` for foreign-key / cross-reference metadata tests.
 
 Rules for the shared workspace (see `docs/e2e-test-isolation-guidance.md`):
-- **Most bug repros only need to READ a fixture or call a metadata API** — no table
-  creation required. Read fixtures; never write to `adbc_testing`.
-- If you genuinely must create state, give the table a unique name, target the
-  writable schema via `TestConfiguration.Metadata.Schema` (not the fixture schema),
+- **Most bug repros only need to READ one of the above or call a metadata API** —
+  no table creation required. Never write to `pqtest` or `adbc_testing`.
+- If you genuinely must create state, use a uniquely-named table in `main.default`
   and `DROP TABLE IF EXISTS` it (idempotent cleanup).
 - **No schema-wide assertions** (total table/row/schema counts) — concurrent jobs
   share this workspace and those counts drift. Assert on your specific entity with

--- a/.bot/prompts/author_system.md
+++ b/.bot/prompts/author_system.md
@@ -33,13 +33,13 @@ without weakening any test.
   (`.Catalog` = `main`, `.Schema` = `pqtest`, `.Table` = `alltypes`), so read it
   through the Metadata triple (or its fully-qualified name) for type/metadata
   tests — GetColumns ordinal position, type mapping, schema inspection.
-- **`main.adbc_testing`** (the `DatabricksTestEnvironment.FixtureSchema` constant) —
-  other read-only fixtures: `cross_ref_customers`, `cross_ref_orders`,
-  `fk_test_ref_table` for foreign-key / cross-reference metadata tests.
+- **`main.tpcds_sf1_delta.catalog_sales`** — a large TPC-DS (scale factor 1) fact
+  table. Use it for **CloudFetch / large-result** scenarios: multi-chunk Arrow
+  result fetch, large row counts, pagination, and download/refetch paths.
 
 Rules for the shared workspace (see `docs/e2e-test-isolation-guidance.md`):
 - **Most bug repros only need to READ one of the above or call a metadata API** —
-  no table creation required. Never write to `pqtest` or `adbc_testing`.
+  no table creation required. Never write to `pqtest` or `tpcds_sf1_delta`.
 - If you genuinely must create state, use a uniquely-named table in `main.default`
   and `DROP TABLE IF EXISTS` it (idempotent cleanup).
 - **No schema-wide assertions** (total table/row/schema counts) — concurrent jobs

--- a/.bot/prompts/author_system.md
+++ b/.bot/prompts/author_system.md
@@ -51,6 +51,12 @@ Rules for the shared workspace (see `docs/e2e-test-isolation-guidance.md`):
    a compile/setup/Skip). Run it with `--filter`; confirm it actually executes and
    fails for the right reason. If it reports **skipped**, the live config isn't
    reaching it — fix that first; a skipped test is not a reproduction.
+   **Reproduction is a hard gate.** If after a *focused* effort (a few attempts —
+   not dozens) you still cannot get a test that fails for the right reason — it only
+   skips, you cannot reach the workspace, or you cannot trigger the bug — **STOP and
+   report `blocked` immediately**, naming what you tried. Do **not** keep reading
+   code or attempt a fix you cannot verify red→green. A fast, honest `blocked` is
+   the correct outcome; exploring until the turn limit is a failure.
 2. **Fix the code** in `csharp/src/` so the test passes. Do **not** edit, delete,
    weaken, or `[Skip]` the test to force green; do not just change the test.
 3. **Re-run** that test plus the surrounding suite until green. Iterate.
@@ -59,8 +65,10 @@ Rules for the shared workspace (see `docs/e2e-test-isolation-guidance.md`):
 - Minimal, focused change — fix *this* bug; don't refactor unrelated code.
 - Keep the regression test in the PR — it's the evidence the bug is fixed.
 - Match existing style; don't introduce new dependencies without strong reason.
-- If you cannot reproduce or cannot fix within budget, report `blocked` with a
-  clear reason (and name the still-failing test) rather than weakening anything.
+- **Fail fast, don't thrash.** If you cannot reproduce (see the reproduction gate
+  above) or cannot fix after a focused effort, report `blocked` with a clear reason
+  (and name the still-failing test) rather than weakening the test — or exploring
+  until the turn limit.
 
 Report the structured outcome the flow asks for (outcome / reason /
 red_green_tests).

--- a/.bot/prompts/author_system.md
+++ b/.bot/prompts/author_system.md
@@ -8,21 +8,50 @@ without weakening any test.
 ## Repository layout
 - Driver source: `csharp/src/` (project `AdbcDrivers.Databricks.csproj`).
 - Tests: `csharp/test/` — **xUnit**, split into `Unit/` (offline) and `E2E/`
-  (needs a live warehouse). Prefer adding your reproduction to `Unit/` when the
-  bug can be reproduced offline; only reach for `E2E/` if it genuinely requires a
-  warehouse round-trip.
+  (runs against a live Databricks workspace). **Prefer an E2E integration test in
+  `csharp/test/E2E/`**: most driver bugs (metadata like GetColumns/GetTables, type
+  mapping, CloudFetch, server-side behavior) only reproduce faithfully against a
+  real workspace, and the CI job provides a live connection for you. Use a `Unit/`
+  test only when the bug is pure offline logic that needs no server round-trip.
 - Read `csharp/test/` for the established patterns (fixtures, naming, assertions)
   and match them. Read any `CLAUDE.md`/`CONTRIBUTING.md` for conventions first.
 
 ## Build & test (your bash allowlist)
 - Build: `dotnet build` (in `csharp/src`) — or `dotnet restore` first if needed.
-- Test: `dotnet test` (in `csharp/test`). Scope to the offline unit tests while
-  iterating, e.g. a `--filter` on the relevant fully-qualified name; run the
-  broader suite before you finish.
+- Test: `dotnet test` (in `csharp/test`). **Always `--filter` to your own test's
+  fully-qualified name**, both while iterating and at the end. Do NOT run the whole
+  E2E suite: this job provides a live connection but does **not** seed the full
+  per-run fixture set the broader suite expects, so unrelated E2E tests would fail
+  or skip — that noise hides your red→green signal.
+- The live connection is wired by the workflow via `DATABRICKS_TEST_CONFIG_FILE`
+  (already set in your env). Your E2E test picks it up through the normal
+  `TestBase`/`TestConfiguration` plumbing — never hard-code endpoints or tokens.
+
+## Workspace test data (read these; don't reseed)
+The shared CI workspace already has stable, **read-only** fixture tables in
+`main.adbc_testing` — reference that schema via
+`DatabricksTestEnvironment.FixtureSchema` (never hard-code `"adbc_testing"`):
+- **`all_column_types`** — one column of every Databricks type (tinyint…variant,
+  array/map/struct) plus a PRIMARY KEY and a FOREIGN KEY. Ideal for metadata/type
+  tests — GetColumns ordinal position, type mapping, GetCrossReference.
+- **`cross_ref_customers`, `cross_ref_orders`, `fk_test_ref_table`** — related
+  tables for foreign-key / cross-reference metadata tests.
+
+Rules for the shared workspace (see `docs/e2e-test-isolation-guidance.md`):
+- **Most bug repros only need to READ a fixture or call a metadata API** — no table
+  creation required. Read fixtures; never write to `adbc_testing`.
+- If you genuinely must create state, give the table a unique name, target the
+  writable schema via `TestConfiguration.Metadata.Schema` (not the fixture schema),
+  and `DROP TABLE IF EXISTS` it (idempotent cleanup).
+- **No schema-wide assertions** (total table/row/schema counts) — concurrent jobs
+  share this workspace and those counts drift. Assert on your specific entity with
+  `Assert.Contains`; scope any row-count check to a table you uniquely created.
 
 ## How to work (bug-fix flow)
-1. **Reproduce**: add a test that fails *because of the bug* (not a compile/setup
-   error). Run it; confirm it fails for the right reason.
+1. **Reproduce**: add a test (E2E by default) that fails *because of the bug* (not
+   a compile/setup/Skip). Run it with `--filter`; confirm it actually executes and
+   fails for the right reason. If it reports **skipped**, the live config isn't
+   reaching it — fix that first; a skipped test is not a reproduction.
 2. **Fix the code** in `csharp/src/` so the test passes. Do **not** edit, delete,
    weaken, or `[Skip]` the test to force green; do not just change the test.
 3. **Re-run** that test plus the surrounding suite until green. Iterate.

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -181,7 +181,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 28c44e388790d61c18acb43d27547e540199c5e7
+          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Engineer-bot — follow-up: responds to inline review comments on the bot's
 # (or any `engineer-bot`-labeled) PRs — pushes fix commits + replies on threads.
 # This is what closes the reviewer -> engineer loop: reviewer-bot posts findings,

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -109,7 +109,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 28c44e388790d61c18acb43d27547e540199c5e7
+          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -161,7 +161,7 @@ jobs:
             "catalog": "main",
             "db_schema": "default",
             "isCITesting": true,
-            "metadata": { "catalog": "main", "schema": "default" }
+            "metadata": { "catalog": "main", "schema": "pqtest", "table": "alltypes" }
           }
           EOF
           echo "DATABRICKS_TEST_CONFIG_FILE=$HOME/.databricks/connection.json" >> "$GITHUB_ENV"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Engineer-bot — issue-triggered bug-fix bot for this repo.
 #
 # ⚠️ DRAFT / NOT YET FUNCTIONAL. Requires (see the PR description):

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -122,6 +122,50 @@ jobs:
           pip install claude-agent-sdk
           npm install -g @anthropic-ai/claude-code
 
+      # Give the agent a LIVE workspace connection so its E2E tests
+      # (csharp/test/E2E/) actually run instead of silently Skip-ing — they gate on
+      # DATABRICKS_TEST_CONFIG_FILE. LIGHTER setup (adbc's choice): reuse the shared
+      # warehouse with OAuth client-credentials (the same SP creds e2e-tests.yml uses
+      # for SQL), with NO per-run schema provisioning or fixture seeding. Read-only
+      # fixtures already live in main.adbc_testing (see the author prompt); the
+      # writable target is main.default (tests should rarely write). Runs on
+      # ubuntu-latest like every other adbc E2E workflow. Values pass via env (no
+      # ${{ }} in the script) so nothing user-controlled is interpolated.
+      - name: Create E2E test config (shared warehouse, no seeding)
+        env:
+          DATABRICKS_SERVER_HOSTNAME:    ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_HTTP_PATH:          ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
+          DATABRICKS_TEST_CLIENT_ID:     ${{ secrets.DATABRICKS_TEST_CLIENT_ID }}
+          DATABRICKS_TEST_CLIENT_SECRET: ${{ secrets.DATABRICKS_TEST_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          OAUTH_TOKEN=$(curl -s -X POST "https://${DATABRICKS_SERVER_HOSTNAME}/oidc/v1/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${DATABRICKS_TEST_CLIENT_ID}" \
+            -d "client_secret=${DATABRICKS_TEST_CLIENT_SECRET}" \
+            -d "scope=sql" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+          if [ -z "${OAUTH_TOKEN}" ]; then echo "::error::failed to mint workspace OAuth token"; exit 1; fi
+          echo "::add-mask::${OAUTH_TOKEN}"
+          mkdir -p ~/.databricks
+          cat > ~/.databricks/connection.json << EOF
+          {
+            "uri": "https://${DATABRICKS_SERVER_HOSTNAME}${DATABRICKS_HTTP_PATH}",
+            "auth_type": "oauth",
+            "grant_type": "client_credentials",
+            "client_id": "${DATABRICKS_TEST_CLIENT_ID}",
+            "client_secret": "${DATABRICKS_TEST_CLIENT_SECRET}",
+            "scope": "sql",
+            "access_token": "${OAUTH_TOKEN}",
+            "type": "databricks",
+            "catalog": "main",
+            "db_schema": "default",
+            "isCITesting": true,
+            "metadata": { "catalog": "main", "schema": "default" }
+          }
+          EOF
+          echo "DATABRICKS_TEST_CONFIG_FILE=$HOME/.databricks/connection.json" >> "$GITHUB_ENV"
+
       - name: Run bug-fix author
         id: author
         env:

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Reviewer-bot — follow-up: responds to replies on the reviewer's own threads
 # (verifies the fix against the PR diff, then resolves or pushes back). Completes
 # the conversation half of the loop: reviewer-bot posts findings -> engineer-bot

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -157,7 +157,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 28c44e388790d61c18acb43d27547e540199c5e7
+          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -88,7 +88,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 28c44e388790d61c18acb43d27547e540199c5e7
+          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Reviewer-bot — reviews PRs in this repo and posts inline findings.
 #
 # ⚠️ DRAFT / NOT YET FUNCTIONAL. Requires (see the PR description):

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -39,3 +39,9 @@ rust/license.tpl
 rust/pixi.lock
 # htpasswd is a data file (username:password_hash) that cannot contain license headers
 rust/ci/proxy/htpasswd
+# engineer-bot's config + workflow use the .yaml extension (the engine requires the
+# exact name .bot/config.yaml; the workflow is intentionally engineer-bot.yaml), which
+# RAT's built-in .yml handling doesn't cover. The sibling reviewer/followup workflows
+# (.yml) carry no header either; exclude these for parity.
+.bot/config.yaml
+.github/workflows/engineer-bot.yaml

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -39,9 +39,8 @@ rust/license.tpl
 rust/pixi.lock
 # htpasswd is a data file (username:password_hash) that cannot contain license headers
 rust/ci/proxy/htpasswd
-# engineer-bot's config + workflow use the .yaml extension (the engine requires the
-# exact name .bot/config.yaml; the workflow is intentionally engineer-bot.yaml), which
-# RAT's built-in .yml handling doesn't cover. The sibling reviewer/followup workflows
-# (.yml) carry no header either; exclude these for parity.
-.bot/config.yaml
-.github/workflows/engineer-bot.yaml
+# engineer-bot prompt files are read VERBATIM as the LLM prompt — a license header
+# would be prepended into the model's instructions. The workflows, .bot/config.yaml,
+# and .bot/SETUP.md all carry the standard Apache header instead; only the prompts
+# are excluded.
+.bot/prompts/*.md


### PR DESCRIPTION
Follow-up to #531 (the start-comment landed there; these two commits were pushed after #531 squash-merged, so they need their own PR).

Makes the bug-fix bot write **live E2E integration tests** (`csharp/test/E2E/`) instead of offline unit tests — most driver bugs (metadata, type mapping, server behavior) only reproduce against a real workspace.

- **`author_system.md`**: prefer E2E; documents **`main.pqtest.alltypes`** as the canonical all-types table (wired as `TestConfiguration.Metadata` → `main`/`pqtest`/`alltypes`, read via the Metadata triple or FQN) for metadata/type tests like GetColumns; keeps the `main.adbc_testing` cross-reference fixtures; isolation rules (read-only; rare writes → unique table in `main.default` + `DROP IF EXISTS`; no schema-wide assertions); `--filter` to your own test (don't run the whole E2E suite — fixtures aren't fully seeded here); a *skipped* test is not a reproduction.
- **`engineer-bot.yaml`**: new "Create E2E test config" step — **lighter** setup (OAuth client-credentials against the existing shared warehouse, **no** per-run schema/seeding) that writes `~/.databricks/connection.json` and sets `DATABRICKS_TEST_CONFIG_FILE`, so E2E tests actually run instead of silently skipping. `ubuntu-latest`, matching every other adbc E2E workflow.

### Prerequisite to confirm
The CI service principal (`DATABRICKS_TEST_CLIENT_ID/SECRET`) needs **read access to `main.pqtest.alltypes`** — it's a different schema from the existing `main.adbc_testing` fixtures.

## Test plan
- [ ] Label an issue `engineer-bot`; confirm the E2E config step mints a token + writes `connection.json`, and the bot's E2E test runs (not skipped) red→green via `--filter`, reading `main.pqtest.alltypes`.

This pull request and its description were written by Isaac.