### PR TITLE
ci: fetch hiveserver2 submodule in engineer-bot checkouts (unblocks dotnet build)

### DIFF
--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -71,7 +71,7 @@ bash_allowlist:
 # Author phase: prompt rendered from the template; tokens are the ISSUE (the bug
 # to fix). No driver PR, no SOURCE_PR_* — this is single-repo, issue-driven.
 author:
-  max_turns: 100   # bug-fix needs reproduce→fix→re-run headroom; now actually enforced (engine in-loop backstop)
+  max_turns: 200   # bug-fix needs reproduce→fix→re-run headroom (incl. discovery on a blind start); enforced by the engine in-loop backstop
   user_prompt_template: prompts/author_user.md
   env_tokens:                 # {{issue_*}} in author_user.md  <-  env vars
     issue_number: ISSUE_NUMBER

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -143,6 +143,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}   # so the fix push authenticates as the bot
+          # csharp/test depends on the csharp/hiveserver2 submodule (PUBLIC) to build;
+          # the followup re-runs dotnet test to verify fixes. Mirrors e2e-tests.yml.
+          submodules: recursive
           # SECURITY — deliberate asymmetry with the reviewer workflows (they set
           # persist-credentials: false, keeping their token out of .git/config so a
           # prompt-injected PR can't read it). Here the App token is Contents+PR

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -88,6 +88,11 @@ jobs:
           token: ${{ steps.token.outputs.token }}   # so the fix-branch push authenticates as the bot
           persist-credentials: true
           fetch-depth: 0
+          # csharp/test depends on the csharp/hiveserver2 submodule (PUBLIC); without
+          # it `dotnet build`/`dotnet test` fails and the agent can't verify its repro
+          # test red→green. Mirrors e2e-tests.yml. The sandbox bash can't run
+          # `git submodule`, so it MUST be fetched at checkout.
+          submodules: recursive
 
       - name: Configure bot git identity
         env:


### PR DESCRIPTION
The #522 re-run finally wrote a repro test (turn 72, `SeaMetadataE2ETests.GetColumns_OrdinalPositionIsRealOneBasedTablePosition`) — but couldn't build it: `csharp/test` depends on the **`csharp/hiveserver2` submodule**, which the engineer checkouts didn't fetch, and the sandbox bash can't run `git submodule`. It spent its remaining turns trying to work around the missing dependency, then hit the backstop.

Adds `submodules: recursive` to both engineer checkouts (`engineer-bot.yaml`, `engineer-bot-followup.yml`), mirroring `e2e-tests.yml`. `adbc-drivers/hiveserver2` is **public**, so the App token fetches it without extra auth.

## Test plan
- [ ] Re-trigger on #522; confirm `dotnet test` builds (no missing-submodule error) and the repro test actually executes.

This pull request and its description were written by Isaac.