### PR TITLE
ci: thread author touched_files/summary into the engineer-bot publish step

### DIFF
--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -34,6 +34,12 @@ denied_subpaths:
   - .gitleaksignore
   - .github
   - .bot
+  # csharp/hiveserver2 is a SEPARATE repo (git submodule -> adbc-drivers/hiveserver2).
+  # Edits there cannot be committed to a parent-repo PR, so deny them. The author
+  # prompt instructs the agent to STOP and report `blocked` (naming the hiveserver2
+  # file/symbol) when a fix would require changing it — the issue-comment step then
+  # posts that reason back to the issue.
+  - csharp/hiveserver2
 
 # The opened fix PR. publish is issue-driven, so {issue_number}/{issue_title}/{issue_url}
 # are the TRIGGERING ISSUE's number/title/url (NOT a PR). "Fixes #" auto-closes

--- a/.bot/prompts/author_system.md
+++ b/.bot/prompts/author_system.md
@@ -15,6 +15,14 @@ without weakening any test.
   test only when the bug is pure offline logic that needs no server round-trip.
 - Read `csharp/test/` for the established patterns (fixtures, naming, assertions)
   and match them. Read any `CLAUDE.md`/`CONTRIBUTING.md` for conventions first.
+- **`csharp/hiveserver2/` is a SEPARATE repo** (a git submodule → `adbc-drivers/hiveserver2`)
+  that you **cannot modify or open a PR for** from here. If the fix requires changing
+  code under `csharp/hiveserver2/`, do **NOT** attempt edits there (they are denied
+  and unpublishable) and do **NOT** keep exploring — **STOP immediately and report
+  `blocked`**, with a reason that names the file/symbol and states the fix belongs in
+  the `adbc-drivers/hiveserver2` repo. (Adding a *test* under `csharp/test/` is fine;
+  only `csharp/hiveserver2/` *source* is off-limits — and if the only viable fix is
+  there, `blocked` is the correct outcome.)
 
 ## Work efficiently — batch your tool calls
 You have a limited turn budget; a turn is one of your messages, regardless of how

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -218,6 +218,13 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE:  ${{ github.event.issue.title }}
           ISSUE_URL:    ${{ github.event.issue.html_url }}
+          # publish.py reads the agent's edit set from these author-step outputs
+          # (run_author emits touched_files/touched_count/summary). Without them
+          # publish sees TOUCHED_FILES="" and refuses with "empty but outcome was
+          # success". GITHUB_REPOSITORY / RUNNER_TEMP are GHA defaults (auto-set).
+          TOUCHED_FILES: ${{ steps.author.outputs.touched_files }}
+          TOUCHED_COUNT: ${{ steps.author.outputs.touched_count }}
+          SUMMARY:       ${{ steps.author.outputs.summary }}
         run: python -m databricks_bot_engine.engineer_bot.publish
 
       - name: Label the fix PR for review


### PR DESCRIPTION
The #520 run's agent **succeeded** (`outcome=change_made`, finished cleanly), but **"Open fix PR" failed**:
```
TOUCHED_FILES is empty but the agent outcome was success. ... Refusing to create an empty PR.
```

`run_author` emits `touched_files`/`touched_count`/`summary` as step outputs, and `publish.py` reads them from env — but the self-contained adbc workflow's **publish step never passed them through** (only `GH_TOKEN`/`ENGINEER_BOT_APP_ID`/`TEST_REPO_ROOT`/`ISSUE_*`). So publish saw `TOUCHED_FILES=""` and aborted. The hub doesn't hit this because it runs author+publish in one composite-action step.

Fix: wire `steps.author.outputs.touched_files/touched_count/summary` into the `Open fix PR` env. (`GITHUB_REPOSITORY`/`RUNNER_TEMP`, also read by publish, are GHA defaults.)

This blocks **every** successful run, including parent-repo-only fixes.

## Test plan
- [ ] Re-trigger on a parent-repo issue; confirm a successful author run now opens a PR instead of failing at publish.

This pull request and its description were written by Isaac.