### PR TITLE
ci(engineer-bot): require live-E2E tests + wire databricks-jdbc context-repo

### DIFF
--- a/.bot/context-repos.yaml
+++ b/.bot/context-repos.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Allowlist of PUBLIC repos the bots may fetch on demand for reference context
+# (loaded by shared.context_repos.load_context_repos; surfaced into the
+# fetch_context_repo tool menu). Cloned LAZILY by fetch_context_repo only when the
+# agent needs them — never vendored, never cloned up front. PUBLIC repos only: the
+# clone is unauthenticated (no token), so keep clone_url a plain HTTPS URL.
+context_repos:
+  - name: databricks-jdbc
+    description: >
+      Databricks' official JDBC driver (Java) — the canonical reference for
+      correct Databricks SQL/metadata behavior. Consult it when the RIGHT
+      behavior is uncertain or an issue cites JDBC for parity: metadata
+      (GetColumns/ORDINAL_POSITION, GetTables, catalog/schema wildcards), type
+      mapping, error/status semantics, CloudFetch. grep for the class/method the
+      issue names (e.g. MetadataResultSetBuilder) to see how JDBC does it, then
+      mirror it in the C# driver.
+    clone_url: https://github.com/databricks/databricks-jdbc.git

--- a/.bot/prompts/author_system.md
+++ b/.bot/prompts/author_system.md
@@ -8,11 +8,15 @@ without weakening any test.
 ## Repository layout
 - Driver source: `csharp/src/` (project `AdbcDrivers.Databricks.csproj`).
 - Tests: `csharp/test/` — **xUnit**, split into `Unit/` (offline) and `E2E/`
-  (runs against a live Databricks workspace). **Prefer an E2E integration test in
-  `csharp/test/E2E/`**: most driver bugs (metadata like GetColumns/GetTables, type
-  mapping, CloudFetch, server-side behavior) only reproduce faithfully against a
-  real workspace, and the CI job provides a live connection for you. Use a `Unit/`
-  test only when the bug is pure offline logic that needs no server round-trip.
+  (runs against a live Databricks workspace). **An E2E test in `csharp/test/E2E/`
+  that exercises the fix against the REAL Databricks endpoint is REQUIRED for every
+  fix** — the CI job provides a live connection. A unit test alone is **not**
+  sufficient: it can only check offline artifacts (e.g. a generated query string),
+  not that the real server actually behaves correctly end-to-end. You MAY add a
+  `Unit/` test in addition, but the bug must be reproduced (red) and the fix
+  verified (green) through an E2E test that talks to the live endpoint. If the
+  behavior genuinely cannot be observed end-to-end through the driver against the
+  live endpoint, report `blocked` and explain why — do not substitute a unit test.
 - Read `csharp/test/` for the established patterns (fixtures, naming, assertions)
   and match them. Read any `CLAUDE.md`/`CONTRIBUTING.md` for conventions first.
 - **`csharp/hiveserver2/` is a SEPARATE repo** (a git submodule → `adbc-drivers/hiveserver2`)
@@ -64,12 +68,14 @@ Rules for the shared workspace (see `docs/e2e-test-isolation-guidance.md`):
   `Assert.Contains`; scope any row-count check to a table you uniquely created.
 
 ## How to work (bug-fix flow)
-1. **Write the failing test FIRST — before you deep-dive the fix.** Your first
-   substantive action is a test (E2E by default, under `csharp/test/E2E/`) that
-   REPRODUCES the bug. Do only the *minimal* reading needed to write it — find the
-   API to call and the fixture to use (e.g. `main.pqtest.alltypes`). Do **NOT**
-   read through the source fix path, trace call chains, or edit `csharp/src/` until
-   you have a test that runs and **fails for the right reason**.
+1. **Write the failing E2E test FIRST — before you deep-dive the fix.** Your first
+   substantive action is an **E2E test (REQUIRED, under `csharp/test/E2E/`, talking
+   to the live endpoint)** that REPRODUCES the bug. Do only the *minimal* reading
+   needed to write it — find the API to call and the fixture to use (e.g.
+   `main.pqtest.alltypes`). Do **NOT** read through the source fix path, trace call
+   chains, or edit `csharp/src/` until you have an E2E test that runs and **fails
+   for the right reason** against the real endpoint. (A unit test does not satisfy
+   this — see Repository layout; it can't prove the live server behaves correctly.)
    - **Why test-first, strictly:** a failing test confirms your understanding of
      the bug *faster and more reliably* than reading source — it forces you to
      state the exact wrong-vs-expected behavior, and it's the evidence the bug is

--- a/.bot/prompts/author_system.md
+++ b/.bot/prompts/author_system.md
@@ -67,6 +67,15 @@ Rules for the shared workspace (see `docs/e2e-test-isolation-guidance.md`):
   share this workspace and those counts drift. Assert on your specific entity with
   `Assert.Contains`; scope any row-count check to a table you uniquely created.
 
+## Reference — how the JDBC driver behaves
+When the *correct* behavior is uncertain (issues often say "how JDBC does it"),
+**`fetch_context_repo databricks-jdbc`**, then `grep_context_repo` /
+`read_context_repo` to see how Databricks' official JDBC driver handles it, and
+mirror that — it's the parity ground truth for metadata / type / error semantics.
+The clone is lazy and read-only; fetch **only** when you need it (most fixes
+don't), and `grep` for the class/method the issue names (e.g.
+`MetadataResultSetBuilder`) rather than browsing.
+
 ## How to work (bug-fix flow)
 1. **Write the failing E2E test FIRST — before you deep-dive the fix.** Your first
    substantive action is an **E2E test (REQUIRED, under `csharp/test/E2E/`, talking

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -198,7 +198,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
+          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -128,7 +128,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
+          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -171,7 +171,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
+          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -102,7 +102,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5c179e26791afeb0c3be7b8639d71440a60ba7ee
+          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Two related raises to the engineer-bot's bar, bundled per request.

## 1. Require an E2E test against the live endpoint
Every fix must be reproduced (red) and verified (green) by an **E2E test in `csharp/test/E2E/`** that talks to the real Databricks endpoint. A unit test alone is **not** sufficient (it only checks offline artifacts, not that the live server behaves correctly). If a behavior genuinely can't be observed end-to-end, the agent reports `blocked` rather than substituting a unit test. (`author_system.md` Repository layout + How-to step 1.)

## 2. Wire the `databricks-jdbc` context-repo (behavior-parity reference)
Adopts the engine's context-repo discovery so the agent can consult the JDBC driver when behavior is uncertain (issues already cite "how JDBC does it"):
- **`.bot/context-repos.yaml`** (new): allowlist `databricks-jdbc` (PUBLIC; cloned **lazily, read-only** by `fetch_context_repo` only when needed — never vendored, never cloned up front; unauthenticated). The `description` is surfaced into the `fetch_context_repo` tool menu.
- **`author_system.md`**: "Reference — how JDBC behaves" note (fetch only when uncertain; grep the cited class).
- **`ENGINE_REF` → `7e36703`** (eric-wang-1990/databricks-bot-engine) in all 4 workflows — the engine build with the engineer `fetch_context_repo`/`read_context_repo`/`grep_context_repo` tools + `shared/source_read`. (Hub source: PR #586.)

No new secret/infra: JDBC is public, the clone is unauthenticated, `fetch_dest` is `RUNNER_TEMP`.

## Test plan
- [ ] Re-trigger on an issue; confirm the agent writes a live E2E test (red→green) and, when behavior is uncertain, fetches `databricks-jdbc` to check parity.

This pull request and its description were written by Isaac.