### PR TITLE
ci(.github/workflows): move engine install to databricks/databricks-bot-engine@76a6e590

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -198,13 +198,13 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
+          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
           python -m pip install --upgrade pip
           # Drop the `x-access-token:${ENGINE_PAT}@` prefix once the engine repo is public; ENGINE_REF stays pinned.
-          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/eric-wang-1990/databricks-bot-engine@${ENGINE_REF}"
+          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           pip install claude-agent-sdk
           npm install -g @anthropic-ai/claude-code
 

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -97,7 +97,7 @@ jobs:
           && !startsWith(github.event.sender.login, 'peco-engineer-bot')
         )
       )
-    runs-on: ubuntu-latest   # VERIFY: a protected/self-hosted runner if the fix-verification tests need a warehouse
+    runs-on: [self-hosted, Linux, X64, peco-driver]
     # 55 min: the App installation token expires at 60; PRs with many threads need headroom
     # (the agent pushes fixes + posts replies at the END of the run).
     timeout-minutes: 55

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -57,7 +57,7 @@ jobs:
     # auto-label on the fix PR) is a `pull_request` event and never re-triggers
     # this job, so the single shared label can't cause a fix→PR→fix loop.
     if: github.event.label.name == 'engineer-bot'
-    runs-on: ubuntu-latest   # VERIFY: a protected/self-hosted runner if E2E tests need a warehouse
+    runs-on: [self-hosted, Linux, X64, peco-driver]
     timeout-minutes: 45
     steps:
       - name: Mint engineer-bot App token

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -18,7 +18,7 @@
 #   - secrets BOT_ENGINE_PAT, ENGINEER_BOT_APP_ID/PRIVATE_KEY (DATABRICKS_HOST + DATABRICKS_TOKEN already exist in adbc CI)
 #   - ENGINE_REF in the install step is pinned to an immutable commit SHA (never @main);
 #     bump it to adopt engine changes. claude-agent-sdk / @anthropic-ai/claude-code are
-#     unpinned to match the hub. The engine repo (eric-wang-1990/databricks-bot-engine)
+#     unpinned to match the hub. The engine repo (databricks/databricks-bot-engine)
 #     is PRIVATE for now, so BOT_ENGINE_PAT is scoped to it; when it goes public, drop
 #     the PAT (anonymous install) but keep ENGINE_REF pinned to a tag/SHA (never @main)
 #   - an `engineer-bot` label that only maintainers can apply (one label does both:
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install bot engine (interim PAT git-install) + Claude SDK/CLI
         env:
-          # Fine-grained PAT, read-only Contents on eric-wang-1990/databricks-bot-engine.
+          # Fine-grained PAT, read-only Contents on databricks/databricks-bot-engine.
           ENGINE_PAT: ${{ secrets.BOT_ENGINE_PAT }}
           # SUPPLY-CHAIN PIN: the engine is pinned to an immutable commit SHA — never
           # install from the force-pushable `@main` ref in a secret-bearing job. Bump
@@ -128,7 +128,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
+          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -136,7 +136,7 @@ jobs:
           # The dedicated engine repo (PRIVATE for now → install via the PAT). Once
           # it's public, drop the `x-access-token:${ENGINE_PAT}@` prefix (anonymous);
           # ENGINE_REF stays pinned to a commit SHA / release tag for reproducibility.
-          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/eric-wang-1990/databricks-bot-engine@${ENGINE_REF}"
+          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           # The engine drives the Claude Agent SDK + Claude Code CLI (public registries).
           pip install claude-agent-sdk
           npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -61,7 +61,7 @@ jobs:
       github.event.pull_request.head.repo.fork == false
       && github.event.pull_request.state == 'open'
       && contains(github.event.pull_request.labels.*.name, 'review-bot')
-    runs-on: ubuntu-latest   # VERIFY: a protected runner if model creds come from the runner env
+    runs-on: [self-hosted, Linux, X64, peco-driver]
     timeout-minutes: 15
     steps:
       - name: Mint review-bot App token

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -171,13 +171,13 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
+          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
           python -m pip install --upgrade pip
           # Drop the `x-access-token:${ENGINE_PAT}@` prefix once the engine repo is public; ENGINE_REF stays pinned.
-          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/eric-wang-1990/databricks-bot-engine@${ENGINE_REF}"
+          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           pip install claude-agent-sdk
           npm install -g @anthropic-ai/claude-code
 

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -68,7 +68,7 @@ jobs:
     # short-lived model credential distinct from the CI DATABRICKS_TOKEN). As long
     # as the live workspace token is reachable in env, an LLM run over untrusted PR
     # content must NOT execute on a shared GitHub-hosted runner. See .bot/SETUP.md.
-    runs-on: ubuntu-latest   # DRAFT default only — replace per the note above before activation
+    runs-on: [self-hosted, Linux, X64, peco-driver]
     timeout-minutes: 30
     steps:
       - name: Mint review-bot App token

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -18,7 +18,7 @@
 #   - secrets BOT_ENGINE_PAT, REVIEW_BOT_APP_ID/PRIVATE_KEY (DATABRICKS_HOST + DATABRICKS_TOKEN already exist in adbc CI)
 #   - ENGINE_REF in the install step is pinned to an immutable commit SHA (never @main);
 #     bump it to adopt engine changes. claude-agent-sdk / @anthropic-ai/claude-code are
-#     unpinned to match the hub. The engine repo (eric-wang-1990/databricks-bot-engine)
+#     unpinned to match the hub. The engine repo (databricks/databricks-bot-engine)
 #     is PRIVATE for now, so BOT_ENGINE_PAT is scoped to it; when it goes public, drop
 #     the PAT (anonymous install) but keep ENGINE_REF pinned to a tag/SHA (never @main)
 #
@@ -102,14 +102,14 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 7e36703f5cae56a3db12fd25620735315fc4c506
+          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
           python -m pip install --upgrade pip
           # The dedicated engine repo (PRIVATE for now → install via the PAT). Drop the
           # `x-access-token:${ENGINE_PAT}@` prefix once it's public; ENGINE_REF stays pinned.
-          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/eric-wang-1990/databricks-bot-engine@${ENGINE_REF}"
+          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           pip install claude-agent-sdk
           npm install -g @anthropic-ai/claude-code
 


### PR DESCRIPTION
## What

Two related changes to all four bot workflows:

1. **Install the engine from the org repo.** Repoint from the personal `eric-wang-1990/databricks-bot-engine` to `databricks/databricks-bot-engine`, pinned to **`ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846`** (initial org import, extracted from `databricks/databricks-driver-test@898d020e`).
2. **Run on the peco-driver self-hosted runner.** `runs-on: [self-hosted, Linux, X64, peco-driver]` (was `ubuntu-latest`). The install pulls from a **private** org repo and the tests hit the live endpoint, so the job must run on a runner with access to the internal `databricks` network/org — the same runner adbc's reyden nightly uses. Resolves the "VERIFY: pick a protected/self-hosted runner" placeholders.

## Why

The canonical published engine moved from a personal repo to the org repo. `76a6e590` includes the reviewer fix this PR originally carried (review-phase `max_turns` 20→100 + explicit out-of-turns failure, fixing the reviewer death on #536) plus current hub `main`.

## Secret

The existing `BOT_ENGINE_PAT` reads the org repo (confirmed) — no secret change needed. It just has to be reachable from the peco-driver runner.

## Verify

After merge, re-run the reviewer on **#536** — it should complete with `max_turns=100` (or fail with the explicit cap message).

This pull request and its description were written by Isaac.