### PR TITLE
ci(.github/workflows): use the runner's system Python 3.11 (peco-driver)

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -178,9 +178,14 @@ jobs:
 
       - name: Setup Python
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.11'
+        shell: bash
+        # actions/setup-python can't provision on this self-hosted runner
+        # (no hosted tool-cache). The runner is provisioned with system
+        # python3.11; use it via a venv so pip installs stay isolated and
+        # `pip` / `python -m` resolve to 3.11 for the later steps.
+        run: |
+          python3.11 -m venv "$RUNNER_TEMP/bot-venv"
+          echo "$RUNNER_TEMP/bot-venv/bin" >> "$GITHUB_PATH"
 
       - name: Setup .NET
         if: steps.filter.outputs.skip != 'true'

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -109,9 +109,14 @@ jobs:
           git config user.email "${bot_id}+${bot_login}@users.noreply.github.com"
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.11'
+        shell: bash
+        # actions/setup-python can't provision on this self-hosted runner
+        # (no hosted tool-cache). The runner is provisioned with system
+        # python3.11; use it via a venv so pip installs stay isolated and
+        # `pip` / `python -m` resolve to 3.11 for the later steps.
+        run: |
+          python3.11 -m venv "$RUNNER_TEMP/bot-venv"
+          echo "$RUNNER_TEMP/bot-venv/bin" >> "$GITHUB_PATH"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -157,9 +157,14 @@ jobs:
 
       - name: Setup Python
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.11'
+        shell: bash
+        # actions/setup-python can't provision on this self-hosted runner
+        # (no hosted tool-cache). The runner is provisioned with system
+        # python3.11; use it via a venv so pip installs stay isolated and
+        # `pip` / `python -m` resolve to 3.11 for the later steps.
+        run: |
+          python3.11 -m venv "$RUNNER_TEMP/bot-venv"
+          echo "$RUNNER_TEMP/bot-venv/bin" >> "$GITHUB_PATH"
 
       - name: Install bot engine (interim PAT git-install) + Claude SDK/CLI
         if: steps.filter.outputs.skip != 'true'

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -89,9 +89,14 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.11'
+        shell: bash
+        # actions/setup-python can't provision on this self-hosted runner
+        # (no hosted tool-cache). The runner is provisioned with system
+        # python3.11; use it via a venv so pip installs stay isolated and
+        # `pip` / `python -m` resolve to 3.11 for the later steps.
+        run: |
+          python3.11 -m venv "$RUNNER_TEMP/bot-venv"
+          echo "$RUNNER_TEMP/bot-venv/bin" >> "$GITHUB_PATH"
 
       - name: Install bot engine (interim PAT git-install) + Claude SDK/CLI
         env:


### PR DESCRIPTION
## Problem

After moving the bot workflows to the self-hosted **peco-driver** runner (#538), `actions/setup-python` fails there:

> Version 3.11 was not found in the local cache … not found for this operating system.

Self-hosted runners have no GitHub tool-cache (that's why setup-python "just worked" on `ubuntu-latest`), and this one can't reach the version manifest.

## Fix

The runner is provisioned with system **python3.11** + **Node**. All four bot workflows drop `actions/setup-python` and instead build a venv from the runner's `python3.11`, put on `$GITHUB_PATH` so later `pip` / `python -m …` steps resolve to 3.11 unchanged. Node (for `@anthropic-ai/claude-code`, which the Python SDK shells out to) comes from the runner.

Followup workflows keep their `if: skip != 'true'` guard. YAML validated; title checked against adbc's checker.

## Requires (runner provisioning, one-time)

`python3.11` + `python3.11-venv` and Node/npm installed on the peco-driver runner and on the runner service's PATH.

This pull request and its description were written by Isaac.