### PR TITLE
ci(.github/workflows): npm install the claude CLI to a user-owned prefix

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -211,7 +211,13 @@ jobs:
           # Drop the `x-access-token:${ENGINE_PAT}@` prefix once the engine repo is public; ENGINE_REF stays pinned.
           pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           pip install claude-agent-sdk
+          # Global npm dir (/usr/local/lib) is root-owned on the self-hosted
+          # runner; install to a per-job prefix the runner user owns and put
+          # it on PATH so later steps find the `claude` CLI the SDK shells to.
+          export NPM_CONFIG_PREFIX="$RUNNER_TEMP/npm-global"
+          mkdir -p "$NPM_CONFIG_PREFIX/bin"
           npm install -g @anthropic-ai/claude-code
+          echo "$RUNNER_TEMP/npm-global/bin" >> "$GITHUB_PATH"
 
       # WORKFLOW -> followup.py env contract: all required vars come from
       # github.event.pull_request.* / github.repository (populated on BOTH event

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -144,7 +144,13 @@ jobs:
           pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           # The engine drives the Claude Agent SDK + Claude Code CLI (public registries).
           pip install claude-agent-sdk
+          # Global npm dir (/usr/local/lib) is root-owned on the self-hosted
+          # runner; install to a per-job prefix the runner user owns and put
+          # it on PATH so later steps find the `claude` CLI the SDK shells to.
+          export NPM_CONFIG_PREFIX="$RUNNER_TEMP/npm-global"
+          mkdir -p "$NPM_CONFIG_PREFIX/bin"
           npm install -g @anthropic-ai/claude-code
+          echo "$RUNNER_TEMP/npm-global/bin" >> "$GITHUB_PATH"
 
       # Give the agent a LIVE workspace connection so its E2E tests
       # (csharp/test/E2E/) actually run instead of silently Skip-ing — they gate on

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -184,7 +184,13 @@ jobs:
           # Drop the `x-access-token:${ENGINE_PAT}@` prefix once the engine repo is public; ENGINE_REF stays pinned.
           pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           pip install claude-agent-sdk
+          # Global npm dir (/usr/local/lib) is root-owned on the self-hosted
+          # runner; install to a per-job prefix the runner user owns and put
+          # it on PATH so later steps find the `claude` CLI the SDK shells to.
+          export NPM_CONFIG_PREFIX="$RUNNER_TEMP/npm-global"
+          mkdir -p "$NPM_CONFIG_PREFIX/bin"
           npm install -g @anthropic-ai/claude-code
+          echo "$RUNNER_TEMP/npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Run follow-up agent
         if: steps.filter.outputs.skip != 'true'

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -116,7 +116,13 @@ jobs:
           # `x-access-token:${ENGINE_PAT}@` prefix once it's public; ENGINE_REF stays pinned.
           pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
           pip install claude-agent-sdk
+          # Global npm dir (/usr/local/lib) is root-owned on the self-hosted
+          # runner; install to a per-job prefix the runner user owns and put
+          # it on PATH so later steps find the `claude` CLI the SDK shells to.
+          export NPM_CONFIG_PREFIX="$RUNNER_TEMP/npm-global"
+          mkdir -p "$NPM_CONFIG_PREFIX/bin"
           npm install -g @anthropic-ai/claude-code
+          echo "$RUNNER_TEMP/npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Run reviewer
         env:


### PR DESCRIPTION
## Problem

On the self-hosted peco-driver runner, `npm install -g @anthropic-ai/claude-code` fails:

> npm error EACCES: permission denied, mkdir '/usr/local/lib/node_modules'

The default global npm dir is root-owned; the runner runs as a non-root user (`azureuser`). (This is the step after the now-fixed Python setup + SSO'd engine clone.)

## Fix

All four bot workflows: install the CLI to a per-job prefix the runner user owns and put it on PATH:
```bash
export NPM_CONFIG_PREFIX="$RUNNER_TEMP/npm-global"
mkdir -p "$NPM_CONFIG_PREFIX/bin"
npm install -g @anthropic-ai/claude-code
echo "$RUNNER_TEMP/npm-global/bin" >> "$GITHUB_PATH"
```

So the `claude` CLI (which the Python `claude-agent-sdk` shells out to) is on PATH for the run step. Self-contained — no runner changes, survives runner reimage. Same per-job philosophy as the Python venv (#539).

This pull request and its description were written by Isaac.