### PR TITLE
ci(.github/workflows): install .NET to a user-writable dir on peco-driver

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -189,6 +189,10 @@ jobs:
 
       - name: Setup .NET
         if: steps.filter.outputs.skip != 'true'
+        # Self-hosted peco-driver runs as non-root; setup-dotnet's default
+        # /usr/share/dotnet is root-owned (EACCES). Install to a writable dir.
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
           dotnet-version: '8.0.x'

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -119,6 +119,10 @@ jobs:
           echo "$RUNNER_TEMP/bot-venv/bin" >> "$GITHUB_PATH"
 
       - name: Setup .NET
+        # Self-hosted peco-driver runs as non-root; setup-dotnet's default
+        # /usr/share/dotnet is root-owned (EACCES). Install to a writable dir.
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
           dotnet-version: '8.0.x'


### PR DESCRIPTION
## Problem

The engineer-bot Fix workflow fails at **Setup .NET** on the self-hosted peco-driver runner:
> mkdir: cannot create directory '/usr/share/dotnet': Permission denied
> ##[error]Failed to install dotnet, exit code: 1

`actions/setup-dotnet` installs to root-owned `/usr/share/dotnet`, but the runner runs as non-root (`azureuser`).

## Fix

Set `DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet` on the Setup .NET step in `engineer-bot.yaml` + `engineer-bot-followup.yml`, so it installs to a user-writable dir (setup-dotnet then adds it to PATH + sets DOTNET_ROOT for later steps). Self-contained; works regardless of which peco-driver runner the job lands on.

Same non-root-runner class we already fixed for the Python venv (#539) and the npm prefix (#540). (`reyden-rest-nightly.yml` happens to land on runners with .NET pre-installed, so it no-ops setup-dotnet — but the bots can't rely on that.)

This pull request and its description were written by Isaac.