### PR TITLE
ci(.github/workflows): install .NET 10 SDK alongside 8.0 for the engineer-bot build

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -195,7 +195,9 @@ jobs:
           DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Install bot engine (interim PAT git-install) + Claude SDK/CLI
         if: steps.filter.outputs.skip != 'true'

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -125,7 +125,9 @@ jobs:
           DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Install bot engine (interim PAT git-install) + Claude SDK/CLI
         env:


### PR DESCRIPTION
## Problem

The engineer-bot build fails on the peco-driver runner because the C# build graph includes **net10.0** targets (the `csharp/hiveserver2` submodule + multi-targeted projects), and `dotnet restore` evaluates all TFMs — but the runner only had net8 (#541's per-job install). `ubuntu-latest` has net10 pre-baked, which is why `csharp.yml` builds there.

## Fix

Install **both 8.0.x and 10.0.x** to the writable `DOTNET_INSTALL_DIR` in `engineer-bot.yaml` + `engineer-bot-followup.yml`. (net10 SDK builds the lower TFMs; net8 runtime is kept for running net8-targeted tests.)

## Runner prerequisite (already applied — not in this PR)

AlmaLinux 9's crypto policy disables **SHA-1 signatures**, which .NET **strong-name signing** requires (the hiveserver2 submodule grants `InternalsVisibleTo` with a public key, so unsigned builds fail with `CS0281`). Re-enabled on the runner via `update-crypto-policies --set DEFAULT:SHA1` (minimal subpolicy; matches `ubuntu-latest`).

Verified directly on the runner: with net10 installed **and** SHA-1 allowed, the build clears the restore + signing errors that previously blocked it.

This completes the engineer-bot's runner enablement (after #539 python, #540 npm, #541 .NET-install).

This pull request and its description were written by Isaac.