### PR TITLE
ci(.github/workflows): revert DOTNET_INSTALL_DIR patch (provisioned on the runner)

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -189,10 +189,6 @@ jobs:
 
       - name: Setup .NET
         if: steps.filter.outputs.skip != 'true'
-        # Self-hosted peco-driver runs as non-root; setup-dotnet's default
-        # /usr/share/dotnet is root-owned (EACCES). Install to a writable dir.
-        env:
-          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
           dotnet-version: '8.0.x'

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -119,10 +119,6 @@ jobs:
           echo "$RUNNER_TEMP/bot-venv/bin" >> "$GITHUB_PATH"
 
       - name: Setup .NET
-        # Self-hosted peco-driver runs as non-root; setup-dotnet's default
-        # /usr/share/dotnet is root-owned (EACCES). Install to a writable dir.
-        env:
-          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
           dotnet-version: '8.0.x'


### PR DESCRIPTION
Reverts the `DOTNET_INSTALL_DIR` redirect from #541 — `setup-dotnet` goes back to plain `dotnet-version: '8.0.x'` (matching `csharp.yml`).

## Why now
The peco-driver VM (single, managed, temporary — moving to a public runner later) has been **provisioned to mimic `ubuntu-latest`**:
- **net8 (8.0.422) + net10 (10.0.301)** installed in `/usr/share/dotnet`, owned by the runner user, `dotnet` on PATH.
- **SHA-1 signatures re-enabled** (`update-crypto-policies --set DEFAULT:SHA1`) for .NET strong-name signing.

So plain `setup-dotnet` finds the system net8, and the build's net10 targets resolve — no workflow patch needed. This keeps the bot workflows standard, so nothing changes when the runner moves to a public one. (#542's per-job net10 install was closed in favor of this.)

Validated on the runner: with net8+net10 present and SHA-1 allowed, the build clears the restore + signing errors. The full red→green is confirmed by re-running the engineer-bot on a clean checkout.

This pull request and its description were written by Isaac.