### PR TITLE
ci(.github/workflows): bump ENGINE_REF to 8260576f + drop repo max_turns config

### DIFF
--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -77,7 +77,6 @@ bash_allowlist:
 # Author phase: prompt rendered from the template; tokens are the ISSUE (the bug
 # to fix). No driver PR, no SOURCE_PR_* — this is single-repo, issue-driven.
 author:
-  max_turns: 200   # bug-fix needs reproduce→fix→re-run headroom (incl. discovery on a blind start); enforced by the engine in-loop backstop
   user_prompt_template: prompts/author_user.md
   env_tokens:                 # {{issue_*}} in author_user.md  <-  env vars
     issue_number: ISSUE_NUMBER
@@ -91,7 +90,6 @@ author:
 # the system prompt. TRIGGER_COMMENT_ID is empty on the labeled path (catch-up
 # mode) — followup_user.md handles that case.
 followup:
-  max_turns: 60
   user_prompt_template: prompts/followup_user.md
   env_tokens:                 # {{...}} in followup_user.md  <-  env vars (set by the workflow)
     pr_number:          PR_NUMBER

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
+          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
+          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
+          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 76a6e5902b217606b72a9476636df0d761260846
+          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Adopts `databricks-bot-engine@8260576f`:
- centralizes `max_turns` to one engine constant (`DEFAULT_MAX_TURNS=200`) for all bot phases, no longer read from repo config;
- re-homes the generic REPLY_ONLY/BLOCKED followup routing.

So this bumps `ENGINE_REF` in all 4 bot workflows and **removes** `author.max_turns` (was 200) + `followup.max_turns` (was 60) from `.bot/config.yaml` — the engine governs the turn cap now.

This pull request and its description were written by Isaac.