### PR TITLE
feat(ci): structured bug-fix PR body (Test plan + Files changed); adopt engine d37985b

### DIFF
--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -53,9 +53,11 @@ pr_body_template: |-
 
   {summary}
 
+  ## Files changed
+  {files_changed}
+
   ## Test plan
-  - [x] Added a regression test that reproduces the bug; it fails before the fix
-        and passes after. Full suite run on the runner before this PR was opened.
+  {test_plan}
 
   Fixes #{issue_number}
 

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
+          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
+          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -236,6 +236,11 @@ jobs:
           TOUCHED_FILES: ${{ steps.author.outputs.touched_files }}
           TOUCHED_COUNT: ${{ steps.author.outputs.touched_count }}
           SUMMARY:       ${{ steps.author.outputs.summary }}
+          # Bug-fix flow's structured test lists → build_pr_body renders the
+          # {test_plan} token (each added test, red→green vs regression). Absent
+          # for non-bug-fix flows → publish falls back to a generic line.
+          RED_GREEN_TESTS: ${{ steps.author.outputs.red_green_tests }}
+          TESTS_ADDED:     ${{ steps.author.outputs.tests_added }}
         run: python -m databricks_bot_engine.engineer_bot.publish
 
       - name: Label the fix PR for review

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
+          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8260576f8eb1d3d54e592faceedea66676ed768d
+          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
## Summary

Adopt the engine's new PR-body render tokens so engineer-bot opens **structured** fix PRs. Motivation: PR #546's body was one run-on paragraph with a single generic Test-plan checkbox — it didn't list which tests it added. Now the body lists exactly that.

Engine changes adopted (`databricks/databricks-bot-engine`):
- **#13** — multi-facet bug-fix prompt discipline (cover every facet; already-correct facets get a regression test).
- **#14** — `build_pr_body` `{test_plan}` (checklist of every added test, red→green vs regression) + `{files_changed}` (bullet list) tokens; `run_author` emits `red_green_tests` / `tests_added`.

## Changes

- **`.bot/config.yaml`** — `pr_body_template` uses `{files_changed}` + `{test_plan}` instead of the hardcoded boilerplate checkbox.
- **`engineer-bot.yaml`** — pass the author step's `red_green_tests` / `tests_added` outputs to publish via `RED_GREEN_TESTS` / `TESTS_ADDED` env.
- **`ENGINE_REF` 8260576f → d37985b5** across all four bot workflows (kept in lockstep; the intervening engine commits touch only the bug-fix author + publish paths, so reviewer/followup behavior is unchanged).

## Resulting body shape

```markdown
## Summary
<short reason>

## Files changed
- `csharp/src/StatementExecution/StatementExecutionStatement.cs`
- `csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs`

## Test plan
- [x] `…SeaMetadataE2ETests.GetTables_TypesFilter_LowercaseTable_IsCaseSensitive_ReturnsNothing` — fails (red) against the original code, passes (green) after the fix
- [x] `…GetTables_EmptyOrWhitespaceTypeFilter_MatchesAllTypes` — regression test (locks in already-correct behavior)
```

## Test plan

- [x] Rendered `.bot/config.yaml`'s template through the engine's `build_pr_body` (pinned SHA d37985b5) — no KeyError; all tokens (`{files_changed}`, `{test_plan}`, `{summary}`, `{issue_*}`) resolve.
- [x] All four `ENGINE_REF` pins verified at d37985b5.
- [ ] End-to-end: re-fire engineer-bot on issue #526 and confirm the opened PR's body is structured.

This pull request and its description were written by Isaac.