### PR TITLE
ci(.github/workflows): adopt engine 1f9969e (#526 fixes) + honest publish-failure comment

### DIFF
--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -271,21 +271,28 @@ jobs:
         # The author outcome alone is NOT the run outcome: a `success` author
         # (it made a change) is followed by a separate `publish` step that opens
         # the PR, and publish can fail on its own (adbc #526: `git add` aborted
-        # on a stale touched-files path). Report PUBLISH's result in that case,
-        # so the issue never says `outcome=success` when no PR was opened.
-        # `steps.publish.outcome` is the built-in step result (success on a clean
-        # publish; failure if it errored; skipped when the author wasn't a
-        # success, so publish never ran — in which case we fall through to the
-        # author outcome, which carries the real no_change/failed/blocked story).
+        # on a stale touched-files path). The SOURCE OF TRUTH for "did this run
+        # succeed" is therefore whether publish produced a fix-PR URL
+        # (`steps.publish.outputs.coverage_pr_url`), NOT the publish step's exit
+        # status: a success result is reported ONLY when that URL is present.
+        # A `success` author with no PR URL means publish failed → report a
+        # failure and keep the issue open. A non-success author (no_change /
+        # blocked / failed) never ran publish, so it falls through to the author
+        # outcome + reason, which carries the real story.
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           OUTCOME: ${{ steps.author.outputs.outcome }}
           REASON: ${{ steps.author.outputs.reason }}
-          PUBLISH_RESULT: ${{ steps.publish.outcome }}
+          PR_URL: ${{ steps.publish.outputs.coverage_pr_url }}
         run: |
-          if [ "$OUTCOME" = "success" ] && [ "$PUBLISH_RESULT" != "success" ]; then
-            gh issue comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
-              --body "engineer-bot bug-fix: authored a fix but FAILED to open the PR (publish step: \`${PUBLISH_RESULT}\`). See the run log; this issue stays open for re-trigger."
+          if [ "$OUTCOME" = "success" ]; then
+            if [ -n "$PR_URL" ]; then
+              gh issue comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+                --body "engineer-bot bug-fix: outcome=\`success\`. Fix PR: ${PR_URL}. ${REASON}"
+            else
+              gh issue comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+                --body "engineer-bot bug-fix: outcome=\`failed\` — authored a fix but no PR was opened (publish produced no PR URL). See the run log; this issue stays open for re-trigger."
+            fi
           else
             gh issue comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
               --body "engineer-bot bug-fix: outcome=\`${OUTCOME}\`. ${REASON}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
+          ENGINE_REF: 1f9969eb1a26b12d78ebb7af9786ff884abd1f88
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -267,10 +267,26 @@ jobs:
         # values via env and reference them as shell variables so the shell never
         # parses them as command syntax. (`outcome` is a controlled enum, but it's
         # routed through env too for consistency.)
+        #
+        # The author outcome alone is NOT the run outcome: a `success` author
+        # (it made a change) is followed by a separate `publish` step that opens
+        # the PR, and publish can fail on its own (adbc #526: `git add` aborted
+        # on a stale touched-files path). Report PUBLISH's result in that case,
+        # so the issue never says `outcome=success` when no PR was opened.
+        # `steps.publish.outcome` is the built-in step result (success on a clean
+        # publish; failure if it errored; skipped when the author wasn't a
+        # success, so publish never ran — in which case we fall through to the
+        # author outcome, which carries the real no_change/failed/blocked story).
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           OUTCOME: ${{ steps.author.outputs.outcome }}
           REASON: ${{ steps.author.outputs.reason }}
+          PUBLISH_RESULT: ${{ steps.publish.outcome }}
         run: |
-          gh issue comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
-            --body "engineer-bot bug-fix: outcome=\`${OUTCOME}\`. ${REASON}"
+          if [ "$OUTCOME" = "success" ] && [ "$PUBLISH_RESULT" != "success" ]; then
+            gh issue comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+              --body "engineer-bot bug-fix: authored a fix but FAILED to open the PR (publish step: \`${PUBLISH_RESULT}\`). See the run log; this issue stays open for re-trigger."
+          else
+            gh issue comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+              --body "engineer-bot bug-fix: outcome=\`${OUTCOME}\`. ${REASON}"
+          fi


### PR DESCRIPTION
## Why

The bug-fix bot crashed opening the PR for [#526](https://github.com/adbc-drivers/databricks/issues/526) ([run](https://github.com/adbc-drivers/databricks/actions/runs/27988595738/job/82835799719)) with `fatal: Invalid path '/Users'`. The engine fixes are merged in [databricks-bot-engine#21](https://github.com/databricks/databricks-bot-engine/pull/21) (and #17), but this repo pins `ENGINE_REF` to the **old** `d37985b`, so the bot still runs the broken engine.

## Changes (both in `.github/workflows/engineer-bot.yaml`)

1. **Bump `ENGINE_REF` `d37985b` → `1f9969e`** (engine `main`), adopting:
   - `normalize_touched()` — resolve/exist-filter/dedup `touched_files` before `git add` (PR #21)
   - hard-deny of the SDK built-in `Edit`/`Bash`/… so the agent stays on the relative-path MCP tools (PR #17)
2. **Honest outcome comment** — the `Comment outcome on the issue` step ran `if: always()` and reported the **author** outcome, so a failed `publish` still commented `outcome=success`. It now reports the publish failure when the author succeeded but publish did not. Injection-safety (env-passed `REASON`) is preserved.

## Verification

After merge, re-trigger by re-applying the `engineer-bot` label on #526 and confirm the run reaches a clean `publish` (PR opened/updated) — or, on failure, that the issue comment now reflects it.

This pull request and its description were written by Isaac.