### PR TITLE
ci(.github/workflows): bump engine ref to 0f749f0 (bug-fix adds only red→green tests)

### DIFF
--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 1f9969eb1a26b12d78ebb7af9786ff884abd1f88
+          ENGINE_REF: 0f749f0ec5a3cc65888020dedcc0256078311474
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Adopts [databricks-bot-engine#22](https://github.com/databricks/databricks-bot-engine/pull/22): the bug-fix flow now adds **only red→green tests** — it no longer adds regression tests for already-correct facets and the red↔green classification step is gone, so the [#546](https://github.com/adbc-drivers/databricks/pull/546) Test-plan mislabeling can't recur.

Bumps `ENGINE_REF` `1f9969e` → `0f749f0` (engine `main`, includes #22 + the earlier #21/#17 fixes).

After merge: re-trigger #526 by re-applying the `engineer-bot` label and confirm the PR Test plan lists only red→green tests.

This pull request and its description were written by Isaac.