### PR TITLE
ci(.github/workflows): bump reviewer engine ref to 4716b47 (forced structured review output)

### DIFF
--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
+          ENGINE_REF: 4716b47adc96f2269d1091bd84fca9851a1ef75b
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Adopts [databricks-bot-engine#32](https://github.com/databricks/databricks-bot-engine/pull/32): the reviewer forces a structured emit via `output_format`, so a review run can no longer fail with **0 comments** when the model ends without calling `finalize_review` (as happened on [#546](https://github.com/adbc-drivers/databricks/actions/runs/28059890806/job/83071332262)).

Bumps reviewer `ENGINE_REF` `d37985b` → `4716b47` (engine `main`, includes #32).

After merge: re-trigger the reviewer on #546 by re-applying the `review-bot` label.

This pull request and its description were written by Isaac.