### PR TITLE
ci(.github/workflows): bump engine ref to 4716b47 + wire OUT_OF_SCOPE (activate out-of-scope listing)

### DIFF
--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 0f749f0ec5a3cc65888020dedcc0256078311474
+          ENGINE_REF: 4716b47adc96f2269d1091bd84fca9851a1ef75b
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -236,11 +236,13 @@ jobs:
           TOUCHED_FILES: ${{ steps.author.outputs.touched_files }}
           TOUCHED_COUNT: ${{ steps.author.outputs.touched_count }}
           SUMMARY:       ${{ steps.author.outputs.summary }}
-          # Bug-fix flow's structured test lists → build_pr_body renders the
-          # {test_plan} token (each added test, red→green vs regression). Absent
-          # for non-bug-fix flows → publish falls back to a generic line.
+          # Bug-fix flow outputs. RED_GREEN_TESTS → build_pr_body renders the
+          # {test_plan} token (every added test is red→green; the flow no longer
+          # adds regression tests). OUT_OF_SCOPE → publish lists facets the bot
+          # couldn't fix here, with the reason, for a human to follow up. Both
+          # absent for non-bug-fix flows → publish falls back to a generic line.
           RED_GREEN_TESTS: ${{ steps.author.outputs.red_green_tests }}
-          TESTS_ADDED:     ${{ steps.author.outputs.tests_added }}
+          OUT_OF_SCOPE:    ${{ steps.author.outputs.out_of_scope }}
         run: python -m databricks_bot_engine.engineer_bot.publish
 
       - name: Label the fix PR for review


### PR DESCRIPTION
Activates [databricks-bot-engine#28](https://github.com/databricks/databricks-bot-engine/pull/28): the bug-fix bot now **lists facets it couldn't fix here (with the reason)** in the PR description, so a human can follow up (e.g. a Thrift-side divergence whose code is in the read-only `csharp/hiveserver2` submodule).

- Bumps engineer-bot `ENGINE_REF` `0f749f0` → `4716b47` (engine `main`; also pulls in #32, etc.).
- Passes `OUT_OF_SCOPE: ${{ steps.author.outputs.out_of_scope }}` to the publish step.
- Drops the now-dead `TESTS_ADDED` (removed from the engine in #22 — the flow adds only red→green tests, so `red_green_tests` is the complete list).

After merge, a re-run of any bug-fix issue (e.g. #525) will surface its out-of-scope facets in the PR body.

This pull request and its description were written by Isaac.