### PR TITLE
ci(bots): bump bot-engine ENGINE_REF to latest (867dd84) + lockstep all four

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
+          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 4716b47adc96f2269d1091bd84fca9851a1ef75b
+          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: d37985b5f68b2259f62acd9dca2be709afb3e8f3
+          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 4716b47adc96f2269d1091bd84fca9851a1ef75b
+          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
## What

Bump the bot-engine pin in all four bot workflows to the current `databricks/databricks-bot-engine` `main` HEAD (`867dd84`), and get them in **lockstep**.

Before, the four workflows pinned two different, older org-engine commits:

| Workflow | Was | Now |
|---|---|---|
| `engineer-bot.yaml` (author + publish) | `4716b47a` | `867dd84` |
| `reviewer-bot.yml` (review) | `4716b47a` | `867dd84` |
| `engineer-bot-followup.yml` | `d37985b5` | `867dd84` |
| `reviewer-bot-followup.yml` | `d37985b5` | `867dd84` |

## Why

`867dd84` is the latest reviewed engine `main`. It carries the cross-repo composite de-nest fix and the centralized lock-drift guard. This repo consumes the engine by **pip install + inline env contract** (not the `uses:`-based composites — those can't be consumed by a public repo from an internal engine), so the practical gain here is simply running the latest reviewed engine, and ending the two-ref drift.

## Compatibility

Verified the inline invocations still match the engine's entrypoints and env contract at `867dd84`:
- `engineer_bot.run --phase author|followup`, `engineer_bot.publish`, `reviewer_bot.run_review`, `reviewer_bot.followup` all still exist and read the same env vars these workflows set.
- `.bot/config.yaml` `flow: bug-fix` is still in the engine flow registry.

No new required env vars; no workflow-body changes needed beyond the pin.

## Notes

- The engine repo is **internal**, so the install keeps `BOT_ENGINE_PAT` (pip + PAT works regardless of the engine's visibility). `main` already installs from the org repo, so the PAT is already scoped correctly — no secret change required.
- `ENGINE_REF` stays an immutable commit SHA (the `@main` guard is unchanged).