### PR TITLE
ci(bots): bump bot-engine ENGINE_REF to 8abd625 (plan turn-cap fix + phase logging)

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
+          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
+          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
+          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 867dd8404af7a043a46297f2c4c479e97117c70d
+          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Bumps the pinned `ENGINE_REF` (all four bot workflows, in lockstep) to `8abd625` — `databricks/databricks-bot-engine` `main` including PR #69:

- **Removes the bug-fix `plan` phase 40-turn cap** — it now tracks the engine default (200). The previous run on issue #526 failed because `plan` hit 40 turns mid-diagnosis of a cross-protocol bug.
- **Per-phase progress + output logging** — the multi-phase flow now logs `=== Phase i/N 'name' starting ===` and `Phase '…' output: …` so a long phase no longer looks like a hang.

No workflow-structure change — engine pin only.

This pull request and its description were written by Isaac.