### PR TITLE
ci(bots): bump bot-engine ENGINE_REF to b89a502 (#70 fix-landed-earlier guard)

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
+          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
+          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
+          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 8abd625accfbcf89ab444ffc18a7fbee68084ed9
+          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
## What
Bump all four bot workflows' `ENGINE_REF` from `8abd625` → **`b89a502`** (latest `databricks/databricks-bot-engine` `main`), in lockstep.

## Why
`b89a502` lands engine **#70**: `run_author` no longer discards a fix the agent applied in an *earlier* phase. On adbc #526 the agent fixed the in-scope **SEA GetTables case-sensitivity** facet during the `author_tests` phase and the `fix` phase only re-confirmed green — so the old guard saw "final phase touched nothing", reverted the whole correct fix, and opened **no PR** (`outcome=failed`).

With #70, when the cross-phase union has edits and the agent reports red→green evidence, the run publishes the fix and carries `out_of_scope` facets into the PR body. So a multi-bug request like #526 now produces a PR with the **fixable** part (SEA) and **lists the unfixable** part (the Thrift `[]` filter, which lives in the read-only `hiveserver2` submodule) for human follow-up — instead of throwing everything away.

## Notes
- Engine repo is internal; install keeps `BOT_ENGINE_PAT` (pip + PAT works regardless of the engine's visibility). No secret change.
- `ENGINE_REF` stays an immutable commit SHA (the `@main` guard is unchanged).