### PR TITLE
ci(.github/workflows): inject repo conventions (csharp/rust CLAUDE.md) + bump ENGINE_REF to 6eeb5ed2 (engine #81)

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
+          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -239,5 +239,6 @@ jobs:
           # the bare hostname hosting the databricks-claude-opus-4-8 serving endpoint;
           # DATABRICKS_TOKEN authenticates it (Bearer). Both already exist as adbc CI secrets.
           MODEL_ENDPOINT:   https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/databricks-claude-opus-4-8/invocations
+          REPO_RULES_FILES: csharp/CLAUDE.md,rust/CLAUDE.md   # adbc keeps conventions per-language (no root CLAUDE.md)
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
         run: python -m databricks_bot_engine.engineer_bot.run --phase followup --bot .bot

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
+          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
+          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -210,6 +210,7 @@ jobs:
           # databricks-claude-opus-4-8 serving endpoint; DATABRICKS_TOKEN authenticates it
           # (Bearer). Both already exist as adbc CI secrets — no new secrets needed.
           MODEL_ENDPOINT:   https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/databricks-claude-opus-4-8/invocations
+          REPO_RULES_FILES: csharp/CLAUDE.md,rust/CLAUDE.md   # adbc keeps conventions per-language (no root CLAUDE.md)
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
         run: python -m databricks_bot_engine.engineer_bot.run --phase author --bot .bot
 

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
+          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
+          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -207,6 +207,7 @@ jobs:
           # the bare hostname hosting the databricks-claude-opus-4-8 serving endpoint;
           # DATABRICKS_TOKEN authenticates it (Bearer). Both already exist as adbc CI secrets.
           MODEL_ENDPOINT:   https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/databricks-claude-opus-4-8/invocations
+          REPO_RULES_FILES: csharp/CLAUDE.md,rust/CLAUDE.md   # adbc keeps conventions per-language (no root CLAUDE.md)
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           DRY_RUN: 'false'
           RUNNER_TEMP: ${{ runner.temp }}

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
+          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b89a5023e2a19d601313d0059db38532ebf05b7b
+          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
@@ -135,6 +135,7 @@ jobs:
           # the bare hostname hosting the databricks-claude-opus-4-8 serving endpoint;
           # DATABRICKS_TOKEN authenticates it (Bearer). Both already exist as adbc CI secrets.
           MODEL_ENDPOINT:   https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/databricks-claude-opus-4-8/invocations
+          REPO_RULES_FILES: csharp/CLAUDE.md,rust/CLAUDE.md   # adbc keeps conventions per-language (no root CLAUDE.md)
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           DRY_RUN: 'false'
           RUNNER_TEMP: ${{ runner.temp }}

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 9d63045eb40ec3f9fc61090411f4672373c28770
+          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Two coupled changes to the four bot workflows (lockstep):

**1. Bump `ENGINE_REF` `b89a502` → `9d63045`** (databricks-bot-engine `main`, post-#71). Picks up: the bug-fix `plan` turn-cap fix (was capped at 40), per-phase progress + output logging, and the new `REPO_RULES_FILES` support.

**2. Inject repo conventions** via `REPO_RULES_FILES: csharp/CLAUDE.md,rust/CLAUDE.md` in each workflow's run-step `env:`.

Why #2: adbc keeps its conventions **per-language** (`csharp/CLAUDE.md`, `rust/CLAUDE.md`) — there's **no root `CLAUDE.md`/`AGENTS.md`**, so the engine's default lookup injected *nothing*. Pointing `REPO_RULES_FILES` at the actual files makes both bots see adbc's coding conventions. (The list is static per workflow, so a single-language PR also sees the other language's conventions — mild, harmless context.)

Requires the post-#71 engine (which #1 provides), since `REPO_RULES_FILES` only exists there.

This pull request and its description were written by Isaac.