### PR TITLE
ci(.github/workflows): bump ENGINE_REF to b1d2d56 (engine #82)

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
+          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
+          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
+          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 6eeb5ed24251880f169be2b0d3ffa57bc052c28f
+          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Adopts [databricks-bot-engine #82](https://github.com/databricks/databricks-bot-engine/pull/82) (merged, `b1d2d564c69bbf1612c647728594782e70a8c434`):

1. **Visible NEEDS-HUMAN banner** on blocked review-thread replies — `⛔ **NEEDS HUMAN DECISION**` leads the reply, so the still-open thread's needs-human state is obvious to a reviewer.
2. **Active-flow logging** — the engineer bot prints which flow ran at startup, e.g. `[engineer] flow: bug-fix (3 phases: plan -> author_tests -> fix) — …`.

Bumps `ENGINE_REF` in all four bot workflows (`engineer-bot.yaml`, `engineer-bot-followup.yml`, `reviewer-bot.yml`, `reviewer-bot-followup.yml`) in lock step.

This pull request and its description were written by Isaac.