### PR TITLE
ci(.github/workflows): bump ENGINE_REF to e6994fa (engine #83)

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
+          ENGINE_REF: e6994fa3ca073d2281a0bf1aa6c7d9db6251ca89
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
+          ENGINE_REF: e6994fa3ca073d2281a0bf1aa6c7d9db6251ca89
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
+          ENGINE_REF: e6994fa3ca073d2281a0bf1aa6c7d9db6251ca89
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: b1d2d564c69bbf1612c647728594782e70a8c434
+          ENGINE_REF: e6994fa3ca073d2281a0bf1aa6c7d9db6251ca89
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
Adopts [databricks-bot-engine #83](https://github.com/databricks/databricks-bot-engine/pull/83) (merged, `e6994fa3ca073d2281a0bf1aa6c7d9db6251ca89`): explicit **context-repo fetch logging** (`[context-repo] downloading … cache MISS` / `reused … cache HIT`), so a run log shows when the agent actually pulls a context repo vs reuses the per-run cache.

Bumps `ENGINE_REF` in all four bot workflows in lock step.

This pull request and its description were written by Isaac.