### PR TITLE
test(csharp): cover production-shaped warehouse path in fast-metadata + org-id parsing

### DIFF
--- a/csharp/test/Unit/DatabricksConnectionUnitTests.cs
+++ b/csharp/test/Unit/DatabricksConnectionUnitTests.cs
@@ -177,6 +177,7 @@ namespace AdbcDrivers.Databricks.Tests
         [InlineData("/sql/1.0/warehouses/abc123")]
         [InlineData("/sql/1.0/warehouses/abc123/")]
         [InlineData("/sql/1.0/warehouses/abc123?o=987654")]
+        [InlineData("/sql/1.0/warehouses/8d1707669a5ea9e2?o=6051921418418893")] // real-world hex warehouse id + numeric org id
         [InlineData("/sql/1.0/endpoints/abc123")]
         [InlineData("/sql/1.0/endpoints/abc123?o=111&foo=bar")]
         public void IsWarehousePath_WarehousePaths_ReturnsTrue(string path)

--- a/csharp/test/Unit/StatementExecution/StatementExecutionConnectionOrgIdTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionConnectionOrgIdTests.cs
@@ -71,6 +71,17 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         }
 
         [Fact]
+        public void Constructor_RealWorldWarehousePathWithOrgId_ExtractsWarehouseIdAndOrgId()
+        {
+            // Production-shaped path: 16-char hex warehouse id and a long numeric org id.
+            using var connection = new StatementExecutionConnection(
+                BaseProperties("/sql/1.0/warehouses/8d1707669a5ea9e2?o=6051921418418893"));
+
+            Assert.Equal("8d1707669a5ea9e2", GetWarehouseId(connection));
+            Assert.Equal("6051921418418893", GetOrgId(connection));
+        }
+
+        [Fact]
         public void Constructor_PathWithoutQueryString_OrgIdIsNull()
         {
             using var connection = new StatementExecutionConnection(


### PR DESCRIPTION
## What

Adds test cases that pin the real-world SQL warehouse path shape — `/sql/1.0/warehouses/{16-char-hex}?o={numeric-org-id}` — to the warehouse-classification and org-id parsing tests. Existing tests only exercised placeholder ids (`abc123` / `987654`).

- `DatabricksConnectionUnitTests.IsWarehousePath_WarehousePaths_ReturnsTrue`: adds `/sql/1.0/warehouses/8d1707669a5ea9e2?o=6051921418418893`, asserting the fast-metadata warehouse classification strips the `?o=` query string and matches the warehouse regex.
- `StatementExecutionConnectionOrgIdTests.Constructor_RealWorldWarehousePathWithOrgId_ExtractsWarehouseIdAndOrgId`: asserts the SEA path extracts both warehouse id (`8d1707669a5ea9e2`) and org id (`6051921418418893`) from the same path shape.

## Why

Verifying a question about whether the fast-metadata path correctly detects the warehouse type for a production path like `/sql/1.0/warehouses/8d1707669a5ea9e2?o=6051921418418893`. Both the Thrift path (`DatabricksConnection.IsWarehousePath`) and the SEA path (`StatementExecutionConnection`) already strip the query string before regex matching and handle this correctly — these tests lock in the concrete production-shaped case so it can't regress.

## Test

Both new cases run and pass:

```
Passed  ...IsWarehousePath_WarehousePaths_ReturnsTrue(path: "/sql/1.0/warehouses/8d1707669a5ea9e2?o=6051921418418893")
Passed  ...Constructor_RealWorldWarehousePathWithOrgId_ExtractsWarehouseIdAndOrgId
```

Tests only — no production code change.

This pull request and its description were written by Isaac.