### PR TITLE
chore(csharp): bump version to 1.1.6

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -18,6 +18,22 @@
 
 All notable changes to the C# Databricks ADBC driver are documented in this file.
 
+## [1.1.6] - 2026-07-02
+
+### Added
+
+- Add `enable_fast_metadata_query` flag for DESC TABLE EXTENDED (#456)
+
+### Fixed
+
+- Apply cached feature flags on connect (warm cache) (#563)
+- Correct getTables types filter for empty array `[]` and lowercase case-sensitivity differences between protocols (#546)
+- Emit `http.response.status_code` on DownloadFile (#496)
+
+### Changed
+
+- Bump hiveserver2 submodule for empty table-types GetTables fix (#559)
+
 ## [1.1.5] - 2026-06-11
 
 ### Added

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>1.1.5</VersionPrefix>
+    <VersionPrefix>1.1.6</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` from `1.1.5` → `1.1.6` in `csharp/Directory.Build.props`
- Add a dated `[1.1.6] - 2026-07-02` section to `csharp/CHANGELOG.md`

The 1.1.6 patch captures everything merged to `main` since the 1.1.5 cut (#518). All changes are additive/opt-in with no breaking changes, so this stays on the `v1.1.x` line — consistent with 1.1.4/1.1.5, which were also patch bumps despite having "Added" sections.

### Added
- Add `enable_fast_metadata_query` flag for DESC TABLE EXTENDED (#456)

### Fixed
- Apply cached feature flags on connect (warm cache) (#563)
- Correct getTables types filter for empty array `[]` and lowercase case-sensitivity differences between protocols (#546)
- Emit `http.response.status_code` on DownloadFile (#496)

### Changed
- Bump hiveserver2 submodule for empty table-types GetTables fix (#559)

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, `csharp-sync-latest.yml` pushes `main` to `release/csharp/v1.1.latest`, tags the tip `csharp/v1.1.6`, and updates `release/csharp/latest`

This pull request and its description were written by Isaac.