### PR TITLE
fix(csharp): derive SEA wait_timeout from direct-results, treat CLOSED as success (ES-2034600)

### DIFF
--- a/csharp/src/DatabricksConnection.cs
+++ b/csharp/src/DatabricksConnection.cs
@@ -86,7 +86,7 @@ namespace AdbcDrivers.Databricks
         private long _directResultMaxRows = DefaultDirectResultMaxRows;
         // CloudFetch configuration
         private const long DefaultMaxBytesPerFile = 20 * 1024 * 1024; // 20MB
-        private const int DefaultQueryTimeSeconds = 3 * 60 * 60; // 3 hours
+        private const int DefaultQueryTimeSeconds = DatabricksConstants.DefaultQueryTimeoutSeconds; // 3 hours (shared with SEA path)
         private bool _useCloudFetch = true;
         private bool _canDecompressLz4 = true;
         private long _maxBytesPerFile = DefaultMaxBytesPerFile;

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -395,6 +395,19 @@ namespace AdbcDrivers.Databricks
         [FeatureFlagType(FeatureFlagValueKind.PositiveInt)]
         public const string OperationStatusRequestTimeout = "adbc.databricks.operation_status_request_timeout";
 
+        /// <summary>
+        /// The timeout in seconds bounding a full metadata operation (GetObjects/GetTableSchema)
+        /// on the Statement Execution (REST) path. A single metadata call can fan out into many
+        /// SHOW COLUMNS / SHOW CATALOGS statements (e.g. full-catalog enumeration), so this bounds
+        /// the whole tree rather than an individual request. Decoupled from the request wait_timeout,
+        /// which is derived from the direct-results flag and is never a positive value.
+        /// Default value is 300 seconds (5 minutes) if not specified.
+        /// Must be a positive integer value.
+        /// Only applicable when Protocol is "rest".
+        /// </summary>
+        [FeatureFlagType(FeatureFlagValueKind.PositiveInt)]
+        public const string MetadataOperationTimeoutSeconds = "adbc.databricks.rest.metadata_operation_timeout_seconds";
+
         // Statement Execution API configuration parameters
 
         /// <summary>
@@ -515,6 +528,13 @@ namespace AdbcDrivers.Databricks
         /// Default timeout in seconds for operation status polling requests.
         /// </summary>
         public const int DefaultOperationStatusRequestTimeoutSeconds = 30;
+
+        /// <summary>
+        /// Default timeout in seconds bounding a full metadata operation (GetObjects/GetTableSchema)
+        /// on the Statement Execution (REST) path. Generous because a single call can fan out into
+        /// many SHOW COLUMNS / SHOW CATALOGS statements.
+        /// </summary>
+        public const int DefaultMetadataOperationTimeoutSeconds = 300; // 5 minutes
 
         /// <summary>
         /// Default async execution poll interval in milliseconds.

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -459,11 +459,13 @@ namespace AdbcDrivers.Databricks
         public const string ResultCompression = "adbc.databricks.rest.result_compression";
 
         /// <summary>
-        /// Wait timeout for statement execution in seconds.
-        /// - 0: Async mode, return immediately
-        /// - 5-50: Sync mode up to timeout
-        /// Default: 10 seconds
-        /// Note: When enable_direct_results=true, this parameter is not set (server waits until complete)
+        /// Deprecated and ignored. This key is recognized but inert: it is no longer read, and
+        /// setting it has no effect. The request wait_timeout is now derived solely from the
+        /// enable_direct_results flag (see StatementExecutionConnection.ValidateProperties):
+        /// - enable_direct_results=true: wait_timeout is not set (server waits until complete).
+        /// - enable_direct_results=false: wait_timeout="0s" (fully async, then poll).
+        /// A non-zero wait_timeout is deliberately never sent, since a positive value routes the
+        /// request to the SEA sync-hybrid results path, which truncates multi-chunk results.
         /// Only applicable when Protocol is "rest".
         /// </summary>
         [FeatureFlagType(FeatureFlagValueKind.Int)]

--- a/csharp/src/DatabricksParameters.cs
+++ b/csharp/src/DatabricksParameters.cs
@@ -395,18 +395,6 @@ namespace AdbcDrivers.Databricks
         [FeatureFlagType(FeatureFlagValueKind.PositiveInt)]
         public const string OperationStatusRequestTimeout = "adbc.databricks.operation_status_request_timeout";
 
-        /// <summary>
-        /// The timeout in seconds bounding a full metadata operation (GetObjects/GetTableSchema)
-        /// on the Statement Execution (REST) path. A single metadata call can fan out into many
-        /// SHOW COLUMNS / SHOW CATALOGS statements (e.g. full-catalog enumeration), so this bounds
-        /// the whole tree rather than an individual request. Decoupled from the request wait_timeout,
-        /// which is derived from the direct-results flag and is never a positive value.
-        /// Default value is 300 seconds (5 minutes) if not specified.
-        /// Must be a positive integer value.
-        /// Only applicable when Protocol is "rest".
-        /// </summary>
-        [FeatureFlagType(FeatureFlagValueKind.PositiveInt)]
-        public const string MetadataOperationTimeoutSeconds = "adbc.databricks.rest.metadata_operation_timeout_seconds";
 
         // Statement Execution API configuration parameters
 
@@ -532,11 +520,12 @@ namespace AdbcDrivers.Databricks
         public const int DefaultOperationStatusRequestTimeoutSeconds = 30;
 
         /// <summary>
-        /// Default timeout in seconds bounding a full metadata operation (GetObjects/GetTableSchema)
-        /// on the Statement Execution (REST) path. Generous because a single call can fan out into
-        /// many SHOW COLUMNS / SHOW CATALOGS statements.
+        /// Default query timeout in seconds for the Statement Execution (REST) path. Applies to both
+        /// regular queries (poll-until-complete) and metadata operations (which are just queries).
+        /// Matches the Thrift path's Databricks default (<c>DatabricksConnection.DefaultQueryTimeSeconds</c>)
+        /// so a long-running query is bounded consistently across protocols. 0 disables the timeout.
         /// </summary>
-        public const int DefaultMetadataOperationTimeoutSeconds = 300; // 5 minutes
+        public const int DefaultQueryTimeoutSeconds = 3 * 60 * 60; // 3 hours
 
         /// <summary>
         /// Default async execution poll interval in milliseconds.

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -59,7 +59,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private string _resultDisposition = null!;
         private string _resultFormat = null!;
         private string? _resultCompression;
-        private int _waitTimeoutSeconds;
+        // Request wait_timeout: null = unset (direct results on), "0s" = async (direct results off).
+        // Never a positive value (see ValidateProperties / ES-2034600).
+        private string? _waitTimeout;
         private int _pollingIntervalMs;
         private bool _enablePKFK;
         private bool _enableMultipleCatalogSupport;
@@ -332,12 +334,18 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _resultFormat = PropertyHelper.GetStringProperty(properties, DatabricksParameters.ResultFormat, "ARROW_STREAM");
             properties.TryGetValue(DatabricksParameters.ResultCompression, out _resultCompression);
 
-            _waitTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(properties, DatabricksParameters.WaitTimeout, 10);
-            if (properties.TryGetValue(DatabricksParameters.EnableDirectResults, out var directResults) &&
-                directResults.Equals("false", StringComparison.OrdinalIgnoreCase))
-            {
-                _waitTimeoutSeconds = 0;
-            }
+            // wait_timeout is NOT a customer-tunable knob; it is derived from the direct-results flag.
+            //   Direct results ON (default): leave wait_timeout UNSET so the server returns the full
+            //     result inline in a single response (state SUCCEEDED or CLOSED) — the SEA equivalent
+            //     of Thrift DirectResults, and what databricks-jdbc sends by default.
+            //   Direct results OFF: send wait_timeout="0s" (fully async) and poll for the result.
+            // We deliberately never send a NON-ZERO wait_timeout: a positive value routes the request
+            //   to the old SEA sync-hybrid results path, which truncates multi-chunk results (the
+            //   manifest advertises N chunks but only chunk 0 is delivered). Tracked as ES-2034600.
+            bool enableDirectResults =
+                !(properties.TryGetValue(DatabricksParameters.EnableDirectResults, out var directResults)
+                  && directResults.Equals("false", StringComparison.OrdinalIgnoreCase));
+            _waitTimeout = enableDirectResults ? null : "0s";
             // PECO-3064: adbc.apache.statement.polltime_ms is the single key for SEA polling cadence
             // (consolidated with the Thrift path). SEA defaults to 1000 ms — HTTP/JSON polls are
             // heavier than Thrift's 100 ms default — but both protocols share the same property.
@@ -547,7 +555,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 _resultDisposition,
                 _resultFormat,
                 _resultCompression,
-                _waitTimeoutSeconds,
+                _waitTimeout,
                 _pollingIntervalMs,
                 _properties,
                 _recyclableMemoryStreamManager,
@@ -983,9 +991,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
             return _catalog;
         }
 
+        // Metadata operations (GetObjects) can legitimately take a while (full-catalog SHOW COLUMNS,
+        // etc.), so bound them with a generous fixed timeout — decoupled from the request wait_timeout
+        // (which is now unset/"0s"; FromSeconds(0) would have cancelled metadata almost immediately).
+        private const int MetadataOperationTimeoutSeconds = 300;
+
         internal CancellationTokenSource CreateMetadataTimeoutCts()
         {
-            return new CancellationTokenSource(TimeSpan.FromSeconds(_waitTimeoutSeconds));
+            return new CancellationTokenSource(TimeSpan.FromSeconds(MetadataOperationTimeoutSeconds));
         }
 
         /// <summary>

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -63,6 +63,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // Never a positive value (see ValidateProperties / ES-2034600).
         private string? _waitTimeout;
         private int _pollingIntervalMs;
+        private int _metadataOperationTimeoutSeconds;
         private bool _enablePKFK;
         private bool _enableMultipleCatalogSupport;
         private bool _useDescTableExtended;
@@ -351,6 +352,12 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // heavier than Thrift's 100 ms default — but both protocols share the same property.
             _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(
                 properties, ApacheParameters.PollTimeMilliseconds, defaultValue: 1000);
+
+            // Bounds a full metadata operation (GetObjects/GetTableSchema), which can fan out into
+            // many SHOW COLUMNS / SHOW CATALOGS statements. Configurable; default 300s (5 minutes).
+            _metadataOperationTimeoutSeconds = PropertyHelper.GetPositiveIntPropertyWithValidation(
+                properties, DatabricksParameters.MetadataOperationTimeoutSeconds,
+                DatabricksConstants.DefaultMetadataOperationTimeoutSeconds);
 
             // Tracing propagation configuration. Base class (TracingConnection) already handles ActivityTrace init.
             _tracePropagationEnabled = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.TracePropagationEnabled, true);
@@ -992,13 +999,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         // Metadata operations (GetObjects) can legitimately take a while (full-catalog SHOW COLUMNS,
-        // etc.), so bound them with a generous fixed timeout — decoupled from the request wait_timeout
-        // (which is now unset/"0s"; FromSeconds(0) would have cancelled metadata almost immediately).
-        private const int MetadataOperationTimeoutSeconds = 300;
-
+        // etc.), so bound them with a generous timeout — decoupled from the request wait_timeout
+        // (which is derived from the direct-results flag and is never positive; FromSeconds(0) would
+        // have cancelled metadata almost immediately). Configurable via
+        // adbc.databricks.rest.metadata_operation_timeout_seconds; default 300s.
         internal CancellationTokenSource CreateMetadataTimeoutCts()
         {
-            return new CancellationTokenSource(TimeSpan.FromSeconds(MetadataOperationTimeoutSeconds));
+            return new CancellationTokenSource(TimeSpan.FromSeconds(_metadataOperationTimeoutSeconds));
         }
 
         /// <summary>

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -63,7 +63,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // Never a positive value (see ValidateProperties / ES-2034600).
         private string? _waitTimeout;
         private int _pollingIntervalMs;
-        private int _metadataOperationTimeoutSeconds;
+        // Query timeout (seconds) shared by regular queries and metadata operations. 0 = no timeout.
+        private int _queryTimeoutSeconds;
         private bool _enablePKFK;
         private bool _enableMultipleCatalogSupport;
         private bool _useDescTableExtended;
@@ -353,11 +354,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _pollingIntervalMs = PropertyHelper.GetPositiveIntPropertyWithValidation(
                 properties, ApacheParameters.PollTimeMilliseconds, defaultValue: 1000);
 
-            // Bounds a full metadata operation (GetObjects/GetTableSchema), which can fan out into
-            // many SHOW COLUMNS / SHOW CATALOGS statements. Configurable; default 300s (5 minutes).
-            _metadataOperationTimeoutSeconds = PropertyHelper.GetPositiveIntPropertyWithValidation(
-                properties, DatabricksParameters.MetadataOperationTimeoutSeconds,
-                DatabricksConstants.DefaultMetadataOperationTimeoutSeconds);
+            // Query timeout (adbc.apache.statement.query_timeout_s) shared by regular queries and
+            // metadata operations — a metadata call is just another query, and can fan out into many
+            // SHOW COLUMNS / SHOW CATALOGS statements. Default matches the Thrift path (3h); 0 = no
+            // timeout. Bounds the metadata operation via CreateMetadataTimeoutCts and the statement's
+            // own poll loop (PollWithTimeoutAsync) using the same value.
+            _queryTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(
+                properties, ApacheParameters.QueryTimeoutSeconds,
+                DatabricksConstants.DefaultQueryTimeoutSeconds);
 
             // Tracing propagation configuration. Base class (TracingConnection) already handles ActivityTrace init.
             _tracePropagationEnabled = PropertyHelper.GetBooleanPropertyWithValidation(properties, DatabricksParameters.TracePropagationEnabled, true);
@@ -998,14 +1002,16 @@ namespace AdbcDrivers.Databricks.StatementExecution
             return _catalog;
         }
 
-        // Metadata operations (GetObjects) can legitimately take a while (full-catalog SHOW COLUMNS,
-        // etc.), so bound them with a generous timeout — decoupled from the request wait_timeout
-        // (which is derived from the direct-results flag and is never positive; FromSeconds(0) would
-        // have cancelled metadata almost immediately). Configurable via
-        // adbc.databricks.rest.metadata_operation_timeout_seconds; default 300s.
+        // Metadata operations (GetObjects/GetTableSchema) are just queries — bound them with the same
+        // query timeout as regular queries (adbc.apache.statement.query_timeout_s, default 3h,
+        // matching Thrift). A single metadata call can fan out into many SHOW COLUMNS / SHOW CATALOGS
+        // statements, so this bounds the whole tree. 0 = no timeout (never-cancelled CTS), matching
+        // PollWithTimeoutAsync and the Thrift ApacheUtility.GetCancellationToken semantics.
         internal CancellationTokenSource CreateMetadataTimeoutCts()
         {
-            return new CancellationTokenSource(TimeSpan.FromSeconds(_metadataOperationTimeoutSeconds));
+            return _queryTimeoutSeconds <= 0
+                ? new CancellationTokenSource()
+                : new CancellationTokenSource(TimeSpan.FromSeconds(_queryTimeoutSeconds));
         }
 
         /// <summary>

--- a/csharp/src/StatementExecution/StatementExecutionConnection.cs
+++ b/csharp/src/StatementExecution/StatementExecutionConnection.cs
@@ -605,10 +605,21 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 columnNamePattern = columnNamePattern?.ToLower();
 
                 using var cts = CreateMetadataTimeoutCts();
-                return GetObjectsResultBuilder.BuildGetObjectsResultAsync(
-                    this, depth, catalogPattern, schemaPattern,
-                    tableNamePattern, tableTypes, columnNamePattern,
-                    cts.Token).GetAwaiter().GetResult();
+                try
+                {
+                    return GetObjectsResultBuilder.BuildGetObjectsResultAsync(
+                        this, depth, catalogPattern, schemaPattern,
+                        tableNamePattern, tableTypes, columnNamePattern,
+                        cts.Token).GetAwaiter().GetResult();
+                }
+                catch (Exception ex) when (cts.IsCancellationRequested && ex is not TimeoutException)
+                {
+                    // The aggregate metadata timeout fired: the CTS cancelled the underlying HTTP
+                    // request, surfacing a raw TaskCanceledException. Translate it to TimeoutException
+                    // for parity with HiveServer2Connection.GetObjects (Thrift base).
+                    throw new TimeoutException(
+                        "The metadata query execution timed out. Consider increasing the query timeout value.", ex);
+                }
             }, nameof(GetObjects));
         }
 
@@ -670,8 +681,19 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 // which sends catalog as-is to the server. ExecuteShowColumnsAsync
                 // handles null by iterating all catalogs.
                 string? resolvedCatalog = DatabricksConnection.HandleSparkCatalog(catalog);
-                var batches = ExecuteShowColumnsAsync(resolvedCatalog, dbSchema, tableName, null, cts.Token)
-                    .GetAwaiter().GetResult();
+                List<RecordBatch> batches;
+                try
+                {
+                    batches = ExecuteShowColumnsAsync(resolvedCatalog, dbSchema, tableName, null, cts.Token)
+                        .GetAwaiter().GetResult();
+                }
+                catch (Exception ex) when (cts.IsCancellationRequested && ex is not TimeoutException)
+                {
+                    // Aggregate metadata timeout fired; translate the CTS cancellation to
+                    // TimeoutException for parity with the Thrift base (see GetObjects).
+                    throw new TimeoutException(
+                        "The metadata query execution timed out. Consider increasing the query timeout value.", ex);
+                }
 
                 var fields = new List<Field>();
                 foreach (var batch in batches)

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -732,6 +732,15 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // treat it like SUCCEEDED and skip the redundant close on Dispose.
             if (state == "CLOSED")
             {
+                // Mirror the query path: CLOSED is only equivalent to SUCCEEDED when the direct
+                // result is present in THIS response. If the manifest is absent, the result is
+                // genuinely gone (expired or already-closed statement). Surface it as an error
+                // rather than letting ReadNumAffectedRows fall through to its attachment == null
+                // branch and silently report 0 affected rows for a DML statement.
+                if (response.Manifest == null)
+                {
+                    throw new AdbcException("Statement was closed before results could be retrieved");
+                }
                 _statementClosedByServer = true;
             }
 

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -384,6 +384,15 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // redundant CloseStatement. Matches databricks-jdbc, which treats CLOSED == SUCCEEDED.
             if (state == "CLOSED")
             {
+                // CLOSED is only equivalent to SUCCEEDED when the direct result is present in THIS
+                // response. If the manifest is absent, the result is genuinely gone (expired or
+                // already-closed statement) and there is nothing to read: surface it as an error
+                // rather than falling through to CreateReader and silently returning an empty
+                // (0-row) stream.
+                if (response.Manifest == null)
+                {
+                    throw new AdbcException("Statement was closed before results could be retrieved");
+                }
                 _statementClosedByServer = true;
             }
 

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -184,8 +184,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _waitTimeout = waitTimeout;
             _pollingIntervalMs = pollingIntervalMs;
             _properties = properties ?? throw new ArgumentNullException(nameof(properties));
+            // Default matches the Thrift path (3h) so SEA queries aren't unbounded; 0 = no timeout.
             _queryTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(
-                properties, ApacheParameters.QueryTimeoutSeconds, 0);
+                properties, ApacheParameters.QueryTimeoutSeconds, DatabricksConstants.DefaultQueryTimeoutSeconds);
             _recyclableMemoryStreamManager = recyclableMemoryStreamManager ?? throw new ArgumentNullException(nameof(recyclableMemoryStreamManager));
             _lz4BufferPool = lz4BufferPool ?? throw new ArgumentNullException(nameof(lz4BufferPool));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -348,6 +348,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);
             _currentStatementId = response.StatementId;
+            // Reset per-execution: statements are reusable, so this must reflect the CURRENT
+            // execution's state, not a prior CLOSED result. Otherwise a later SUCCEEDED (genuinely
+            // open server-side) execution would inherit true and skip its legitimate CloseStatement.
+            _statementClosedByServer = false;
 
             // Handle query status according to Databricks API documentation:
             // PENDING: waiting for warehouse - continue polling
@@ -692,6 +696,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Execute the statement
             var response = await _client.ExecuteStatementAsync(request, cancellationToken).ConfigureAwait(false);
             _currentStatementId = response.StatementId;
+            // Reset per-execution (see ExecuteQueryInternalAsync): must reflect the CURRENT
+            // execution so a reused statement doesn't inherit a prior CLOSED flag.
+            _statementClosedByServer = false;
 
             // Handle query status - poll until complete
             var state = response.Status?.State;

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -794,47 +794,51 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// </summary>
         public override void Dispose()
         {
-            // Direct-result CLOSED: the server already closed the statement, so there is nothing to
-            // close and calling CloseStatement would just error. Clear the id and skip the close.
-            if (_statementClosedByServer)
+            if (_currentStatementId == null)
             {
-                _currentStatementId = null;
+                return;
             }
 
-            if (_currentStatementId != null)
+            // Start a dedicated span instead of annotating Activity.Current: Dispose is
+            // typically called outside any ambient activity (e.g. connection pooling),
+            // so Activity.Current is usually null here and the event would be dropped.
+            // Mirrors DatabricksCompositeReader.Dispose on the Thrift path, which owns
+            // its own span so the close is always traced regardless of caller context.
+            this.TraceActivity(activity =>
             {
-                // Start a dedicated span instead of annotating Activity.Current: Dispose is
-                // typically called outside any ambient activity (e.g. connection pooling),
-                // so Activity.Current is usually null here and the event would be dropped.
-                // Mirrors DatabricksCompositeReader.Dispose on the Thrift path, which owns
-                // its own span so the close is always traced regardless of caller context.
-                this.TraceActivity(activity =>
+                try
                 {
-                    try
+                    // Direct-result CLOSED: the server already closed the statement, so there is
+                    // nothing to close and calling CloseStatement again would just error. Still
+                    // emit statement.dispose so the dispose path stays observable (connection-pool
+                    // reuse relies on this event); only skip the redundant HTTP DELETE.
+                    bool alreadyClosed = _statementClosedByServer;
+                    activity?.AddEvent(new ActivityEvent("statement.dispose",
+                        tags: new ActivityTagsCollection
+                        {
+                            { "statement_id", _currentStatementId },
+                            { "already_closed", alreadyClosed }
+                        }));
+                    if (!alreadyClosed)
                     {
                         // Close statement synchronously during dispose
-                        activity?.AddEvent(new ActivityEvent("statement.dispose",
-                            tags: new ActivityTagsCollection
-                            {
-                                { "statement_id", _currentStatementId }
-                            }));
                         _client.CloseStatementAsync(_currentStatementId, CancellationToken.None).GetAwaiter().GetResult();
                     }
-                    catch (Exception ex)
-                    {
-                        // Best effort - ignore errors during dispose
-                        activity?.AddEvent(new ActivityEvent("statement.dispose.error",
-                            tags: new ActivityTagsCollection
-                            {
-                                { "error", ex.Message }
-                            }));
-                    }
-                    finally
-                    {
-                        _currentStatementId = null;
-                    }
-                }, activityName: nameof(StatementExecutionStatement) + "." + nameof(Dispose));
-            }
+                }
+                catch (Exception ex)
+                {
+                    // Best effort - ignore errors during dispose
+                    activity?.AddEvent(new ActivityEvent("statement.dispose.error",
+                        tags: new ActivityTagsCollection
+                        {
+                            { "error", ex.Message }
+                        }));
+                }
+                finally
+                {
+                    _currentStatementId = null;
+                }
+            }, activityName: nameof(StatementExecutionStatement) + "." + nameof(Dispose));
         }
 
         public override void Cancel()

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -52,7 +52,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
         private readonly string _resultDisposition;
         private readonly string _resultFormat;
         private readonly string? _resultCompression;
-        private readonly int _waitTimeoutSeconds;
+        // Request wait_timeout: null = omit (direct results on), "0s" = async (direct results off).
+        private readonly string? _waitTimeout;
         private readonly int _pollingIntervalMs;
         private readonly int _queryTimeoutSeconds; // 0 = no timeout
 
@@ -74,6 +75,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
         // Statement state
         private string? _currentStatementId;
+        // Set when the server returns state=CLOSED (direct-result delivery): the result is already
+        // in-hand and the statement is closed server-side, so Dispose must NOT re-close it.
+        private bool _statementClosedByServer;
         private string? _sqlQuery;
 
         // Cancel support
@@ -159,7 +163,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             string resultDisposition,
             string resultFormat,
             string? resultCompression,
-            int waitTimeoutSeconds,
+            string? waitTimeout,
             int pollingIntervalMs,
             IReadOnlyDictionary<string, string> properties,
             Microsoft.IO.RecyclableMemoryStreamManager recyclableMemoryStreamManager,
@@ -177,7 +181,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             _resultDisposition = resultDisposition ?? throw new ArgumentNullException(nameof(resultDisposition));
             _resultFormat = resultFormat ?? throw new ArgumentNullException(nameof(resultFormat));
             _resultCompression = resultCompression;
-            _waitTimeoutSeconds = waitTimeoutSeconds;
+            _waitTimeout = waitTimeout;
             _pollingIntervalMs = pollingIntervalMs;
             _properties = properties ?? throw new ArgumentNullException(nameof(properties));
             _queryTimeoutSeconds = PropertyHelper.GetIntPropertyWithValidation(
@@ -335,7 +339,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 Disposition = _resultDisposition,
                 Format = _resultFormat,
                 ResultCompression = _resultCompression,
-                WaitTimeout = $"{_waitTimeoutSeconds}s",
+                WaitTimeout = _waitTimeout,
                 OnWaitTimeout = "CONTINUE",
                 IsMetadata = isMetadataExecution,
                 QueryTags = ParseQueryTags(_queryTags)
@@ -369,9 +373,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 throw new AdbcException("Statement execution was canceled");
             }
+            // CLOSED = execution succeeded and the statement is already closed server-side; the
+            // direct result (manifest + inline attachment) is present in THIS response. Treat it
+            // like SUCCEEDED — read the result below — and remember it's closed so Dispose skips the
+            // redundant CloseStatement. Matches databricks-jdbc, which treats CLOSED == SUCCEEDED.
             if (state == "CLOSED")
             {
-                throw new AdbcException("Statement was closed before results could be retrieved");
+                _statementClosedByServer = true;
             }
 
             // Check for truncated results warning
@@ -675,7 +683,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 Disposition = _resultDisposition,
                 Format = _resultFormat,
                 ResultCompression = _resultCompression,
-                WaitTimeout = $"{_waitTimeoutSeconds}s",
+                WaitTimeout = _waitTimeout,
                 OnWaitTimeout = "CONTINUE",
                 IsMetadata = false,
                 QueryTags = ParseQueryTags(_queryTags)
@@ -703,9 +711,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
             {
                 throw new AdbcException("Statement execution was canceled");
             }
+            // CLOSED = success with a direct result already in this response (see the query path);
+            // treat it like SUCCEEDED and skip the redundant close on Dispose.
             if (state == "CLOSED")
             {
-                throw new AdbcException("Statement was closed before results could be retrieved");
+                _statementClosedByServer = true;
             }
 
             // DML statements (INSERT, UPDATE, DELETE) return a 1-row result whose first
@@ -758,6 +768,13 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// </summary>
         public override void Dispose()
         {
+            // Direct-result CLOSED: the server already closed the statement, so there is nothing to
+            // close and calling CloseStatement would just error. Clear the id and skip the close.
+            if (_statementClosedByServer)
+            {
+                _currentStatementId = null;
+            }
+
             if (_currentStatementId != null)
             {
                 // Start a dedicated span instead of annotating Activity.Current: Dispose is

--- a/csharp/test/E2E/DatabricksConnectionTest.cs
+++ b/csharp/test/E2E/DatabricksConnectionTest.cs
@@ -384,6 +384,14 @@ namespace AdbcDrivers.Databricks.Tests
                     null // QueryTimeout = 300
                 };
 
+                // At QueryTimeout=1 the timeout can surface at different layers depending on the
+                // protocol: Thrift throws a transport-level TTransportException, whereas SEA (REST)
+                // translates the cancelled HTTP request into a TimeoutException (see
+                // StatementExecutionConnection.GetObjects, mirroring HiveServer2Connection.GetObjects).
+                // Accept TimeoutException as the alternate so the matrix is protocol-agnostic for the
+                // 1-second timeout instead of flaking whenever a metadata call happens to exceed it.
+                alternateExceptions ??= new List<Type?>() { null, typeof(TimeoutException), null, null, null };
+
                 AddAction(name, action, expectedExceptions, alternateExceptions);
             }
 

--- a/csharp/test/Unit/StatementExecution/StatementExecutionEmptyResultSchemaTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionEmptyResultSchemaTests.cs
@@ -77,7 +77,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 resultDisposition: "INLINE_OR_EXTERNAL_LINKS",
                 resultFormat: "ARROW_STREAM",
                 resultCompression: null,
-                waitTimeoutSeconds: 0,
+                waitTimeout: "0s",
                 pollingIntervalMs: 50,
                 properties: properties,
                 recyclableMemoryStreamManager: new RecyclableMemoryStreamManager(),

--- a/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
@@ -137,7 +137,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 resultDisposition: "INLINE_OR_EXTERNAL_LINKS",
                 resultFormat: "ARROW_STREAM",
                 resultCompression: null,
-                waitTimeoutSeconds: 0,
+                waitTimeout: "0s",
                 pollingIntervalMs: 50,
                 properties: properties,
                 recyclableMemoryStreamManager: new RecyclableMemoryStreamManager(),

--- a/csharp/test/Unit/StatementExecution/StatementExecutionMetadataTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionMetadataTimeoutTests.cs
@@ -1,0 +1,73 @@
+/*
+* Copyright (c) 2026 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using AdbcDrivers.Databricks.StatementExecution;
+using AdbcDrivers.HiveServer2;
+using AdbcDrivers.HiveServer2.Spark;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
+{
+    /// <summary>
+    /// SEA metadata operations (GetObjects/GetTableSchema) are just queries, so they share the one
+    /// query timeout (adbc.apache.statement.query_timeout_s) via CreateMetadataTimeoutCts — not a
+    /// separate metadata-timeout knob. Default matches the Thrift path (3h); 0 means no timeout
+    /// (a never-cancelled CTS — guards against the old FromSeconds(0) near-immediate cancel).
+    /// </summary>
+    public class StatementExecutionMetadataTimeoutTests
+    {
+        private static Dictionary<string, string> BaseProps() => new Dictionary<string, string>
+        {
+            { SparkParameters.HostName, "test.databricks.com" },
+            { DatabricksParameters.WarehouseId, "wh-1" },
+            { SparkParameters.AccessToken, "token" },
+        };
+
+        private static StatementExecutionConnection NewConnection(Dictionary<string, string> props)
+            => new StatementExecutionConnection(props, new HttpClient());
+
+        [Fact]
+        public void MetadataTimeout_QueryTimeoutZero_NeverCancels()
+        {
+            var props = BaseProps();
+            props[ApacheParameters.QueryTimeoutSeconds] = "0"; // 0 = no timeout
+            using var connection = NewConnection(props);
+
+            using var cts = connection.CreateMetadataTimeoutCts();
+            Assert.False(cts.IsCancellationRequested);
+            Thread.Sleep(150); // a FromSeconds(0) CTS would have fired by now
+            Assert.False(cts.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void MetadataTimeout_UsesQueryTimeout_WhenPositive()
+        {
+            var props = BaseProps();
+            props[ApacheParameters.QueryTimeoutSeconds] = "1"; // shares the query timeout
+            using var connection = NewConnection(props);
+
+            using var cts = connection.CreateMetadataTimeoutCts();
+            Assert.True(cts.Token.CanBeCanceled);
+            // ~1s scheduled cancellation; allow generous slack to avoid flakiness.
+            Assert.True(SpinWait.SpinUntil(() => cts.IsCancellationRequested, TimeSpan.FromSeconds(5)),
+                "metadata CTS should cancel around the query timeout (1s)");
+        }
+    }
+}

--- a/csharp/test/Unit/StatementExecution/StatementExecutionQueryTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionQueryTimeoutTests.cs
@@ -82,7 +82,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 resultDisposition: "INLINE_OR_EXTERNAL_LINKS",
                 resultFormat: "ARROW_STREAM",
                 resultCompression: null,
-                waitTimeoutSeconds: 0,
+                waitTimeout: "0s",
                 pollingIntervalMs: pollingIntervalMs,
                 properties: properties,
                 recyclableMemoryStreamManager: _memoryManager,

--- a/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using AdbcDrivers.Databricks.StatementExecution;
 using AdbcDrivers.HiveServer2.Spark;
 using Apache.Arrow;
+using Apache.Arrow.Adbc;
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Types;
 using Moq;
@@ -155,6 +156,29 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 var batch = await reader.ReadNextRecordBatchAsync();
                 Assert.NotNull(batch);
                 Assert.Equal(1, batch!.Length);
+            }
+        }
+
+        [Fact]
+        public async Task ClosedState_WithoutManifest_Throws_NotEmptyRows()
+        {
+            // A CLOSED response carrying no manifest means the direct result is genuinely gone
+            // (expired/already-closed statement). This must surface as an error rather than falling
+            // through to an empty (0-row) stream, which would be silent truncation.
+            var closedBody = JsonSerializer.Serialize(new
+            {
+                statement_id = "x",
+                status = new { state = "CLOSED" },
+            });
+
+            var (http, _) = CapturingHttp(closedBody);
+            using (http)
+            {
+                var connection = new StatementExecutionConnection(BaseProps(), http);
+                using var stmt = (StatementExecutionStatement)connection.CreateStatement();
+                stmt.SqlQuery = "SELECT 42 AS id";
+
+                await Assert.ThrowsAsync<AdbcException>(() => stmt.ExecuteQueryAsync(CancellationToken.None));
             }
         }
 

--- a/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
@@ -171,5 +171,76 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
             }
             return ms.ToArray();
         }
+
+        // -------------------------------------------------------------------------------------------
+        // Close semantics (JDBC parity): the driver must NOT issue the server CloseStatement (DELETE
+        // /statements/{id}) for a statement the server already returned as CLOSED — that would be
+        // redundant and error. It MUST close a still-open (SUCCEEDED) statement on dispose. Mirrors
+        // databricks-jdbc: markAsClosed() (no DELETE) for CLOSED vs closeStatement() DELETE otherwise.
+        // -------------------------------------------------------------------------------------------
+
+        private static string ExecuteResponse(string state, byte[] arrow) => JsonSerializer.Serialize(new
+        {
+            statement_id = "stmt-close-test",
+            status = new { state },
+            manifest = new
+            {
+                total_chunk_count = 1,
+                total_row_count = 1,
+                schema = new
+                {
+                    column_count = 1,
+                    columns = new[] { new { name = "id", position = 0, type_name = "INT", type_text = "INT" } },
+                },
+            },
+            result = new { chunk_index = 0, row_count = 1, attachment = arrow },
+        });
+
+        private static HttpClient RecordingHttp(string statementsResponseJson, List<string> recorded)
+        {
+            var sessionBody = JsonSerializer.Serialize(new { session_id = "s1" });
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+                {
+                    var path = req.RequestUri?.AbsolutePath ?? string.Empty;
+                    lock (recorded) { recorded.Add($"{req.Method} {path}"); }
+                    if (path.EndsWith("/api/2.0/sql/sessions"))
+                        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(sessionBody) };
+                    if (path.EndsWith("/api/2.0/sql/statements") && req.Method == HttpMethod.Post)
+                        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(statementsResponseJson) };
+                    // DELETE close / anything else
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") };
+                });
+            return new HttpClient(handler.Object);
+        }
+
+        private static async Task<List<string>> RunAndDisposeAsync(string state)
+        {
+            var recorded = new List<string>();
+            using var http = RecordingHttp(ExecuteResponse(state, BuildSingleRowIntArrow("id", 7)), recorded);
+            var connection = new StatementExecutionConnection(BaseProps(), http);
+            var stmt = (StatementExecutionStatement)connection.CreateStatement();
+            stmt.SqlQuery = "SELECT 7 AS id";
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+            using (var reader = result.Stream) { await reader.ReadNextRecordBatchAsync(); }
+            stmt.Dispose(); // triggers CloseStatement only if the statement is still open server-side
+            return recorded;
+        }
+
+        [Fact]
+        public async Task Dispose_AfterClosedState_DoesNotCallCloseStatement()
+        {
+            var recorded = await RunAndDisposeAsync("CLOSED");
+            Assert.DoesNotContain(recorded, r => r.StartsWith("DELETE /api/2.0/sql/statements/", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task Dispose_AfterSucceededState_CallsCloseStatement()
+        {
+            var recorded = await RunAndDisposeAsync("SUCCEEDED");
+            Assert.Contains(recorded, r => r.StartsWith("DELETE /api/2.0/sql/statements/", StringComparison.Ordinal));
+        }
     }
 }

--- a/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
@@ -182,6 +182,30 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
             }
         }
 
+        [Fact]
+        public async Task ExecuteUpdate_ClosedState_WithoutManifest_Throws_NotZeroRows()
+        {
+            // Update-side analogue of ClosedState_WithoutManifest_Throws_NotEmptyRows: a CLOSED
+            // response with no manifest means the DML direct result is genuinely gone. Without the
+            // guard, ReadNumAffectedRows hits its attachment == null branch and reports 0 affected
+            // rows for a statement that actually ran — silently masking a lost result.
+            var closedBody = JsonSerializer.Serialize(new
+            {
+                statement_id = "x",
+                status = new { state = "CLOSED" },
+            });
+
+            var (http, _) = CapturingHttp(closedBody);
+            using (http)
+            {
+                var connection = new StatementExecutionConnection(BaseProps(), http);
+                using var stmt = (StatementExecutionStatement)connection.CreateStatement();
+                stmt.SqlQuery = "DELETE FROM t WHERE 1 = 1";
+
+                await Assert.ThrowsAsync<AdbcException>(() => stmt.ExecuteUpdateAsync(CancellationToken.None));
+            }
+        }
+
         private static byte[] BuildSingleRowIntArrow(string column, int value)
         {
             var schema = new Schema(new[] { new Field(column, Int32Type.Default, nullable: false) }, null);

--- a/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionWaitTimeoutTests.cs
@@ -1,0 +1,175 @@
+/*
+* Copyright (c) 2026 ADBC Drivers Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using AdbcDrivers.Databricks.StatementExecution;
+using AdbcDrivers.HiveServer2.Spark;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
+{
+    /// <summary>
+    /// Verifies the SEA (Statement Execution / REST) path derives wait_timeout from the direct-results
+    /// flag rather than exposing it as a customer knob: direct results ON (default) → wait_timeout is
+    /// omitted (server returns a direct result in one round-trip); direct results OFF → wait_timeout="0s"
+    /// (async + poll). A non-zero wait_timeout would route to the old sync-hybrid path that truncates
+    /// multi-chunk results (ES-2034600). Also verifies state=CLOSED is treated as success (the direct
+    /// result is read from that response) rather than throwing.
+    /// </summary>
+    public class StatementExecutionWaitTimeoutTests
+    {
+        private static Dictionary<string, string> BaseProps() => new Dictionary<string, string>
+        {
+            { SparkParameters.HostName, "test.databricks.com" },
+            { DatabricksParameters.WarehouseId, "wh-1" },
+            { SparkParameters.AccessToken, "token" },
+        };
+
+        private static (HttpClient Http, Func<string?> GetBody) CapturingHttp(string statementsResponseJson)
+        {
+            string? captured = null;
+            var sessionBody = JsonSerializer.Serialize(new { session_id = "s1" });
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+                {
+                    var path = req.RequestUri?.AbsolutePath ?? string.Empty;
+                    if (path.EndsWith("/api/2.0/sql/sessions"))
+                        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(sessionBody) };
+                    if (path.EndsWith("/api/2.0/sql/statements") && req.Method == HttpMethod.Post)
+                        captured = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(statementsResponseJson) };
+                });
+            return (new HttpClient(handler.Object), () => captured);
+        }
+
+        private static readonly string FailedBody = JsonSerializer.Serialize(new
+        {
+            statement_id = "x",
+            status = new { state = "FAILED", error = new { error_code = "STOP", message = "stop after capture" } },
+        });
+
+        private static async Task<string?> CaptureExecuteBodyAsync(Dictionary<string, string> props)
+        {
+            var (http, getBody) = CapturingHttp(FailedBody);
+            using (http)
+            {
+                var connection = new StatementExecutionConnection(props, http);
+                using var stmt = (StatementExecutionStatement)connection.CreateStatement();
+                stmt.SqlQuery = "SELECT 1";
+                await Assert.ThrowsAnyAsync<Exception>(() => stmt.ExecuteQueryAsync(CancellationToken.None));
+            }
+            return getBody();
+        }
+
+        [Fact]
+        public async Task DirectResultsEnabled_OmitsWaitTimeout()
+        {
+            var body = await CaptureExecuteBodyAsync(BaseProps());
+            Assert.NotNull(body);
+            using var doc = JsonDocument.Parse(body!);
+            Assert.False(doc.RootElement.TryGetProperty("wait_timeout", out _),
+                "wait_timeout must be omitted when direct results are enabled (default)");
+        }
+
+        [Fact]
+        public async Task DirectResultsDisabled_SendsZeroWaitTimeout()
+        {
+            var props = BaseProps();
+            props[DatabricksParameters.EnableDirectResults] = "false";
+            var body = await CaptureExecuteBodyAsync(props);
+            Assert.NotNull(body);
+            using var doc = JsonDocument.Parse(body!);
+            Assert.Equal("0s", doc.RootElement.GetProperty("wait_timeout").GetString());
+        }
+
+        [Fact]
+        public async Task WaitTimeoutProperty_IsIgnored_NotCustomerTunable()
+        {
+            var props = BaseProps();
+            props[DatabricksParameters.WaitTimeout] = "30"; // must be ignored (derived from direct results)
+            var body = await CaptureExecuteBodyAsync(props);
+            Assert.NotNull(body);
+            using var doc = JsonDocument.Parse(body!);
+            Assert.False(doc.RootElement.TryGetProperty("wait_timeout", out _),
+                "adbc.databricks.rest.wait_timeout must be ignored; direct results (default) → omitted");
+        }
+
+        [Fact]
+        public async Task ClosedState_WithDirectResult_ReturnsRows_NotException()
+        {
+            byte[] arrow = BuildSingleRowIntArrow("id", 42);
+            var closedBody = JsonSerializer.Serialize(new
+            {
+                statement_id = "x",
+                status = new { state = "CLOSED" },
+                manifest = new
+                {
+                    total_chunk_count = 1,
+                    total_row_count = 1,
+                    schema = new
+                    {
+                        column_count = 1,
+                        columns = new[] { new { name = "id", position = 0, type_name = "INT", type_text = "INT" } },
+                    },
+                },
+                result = new { chunk_index = 0, row_count = 1, attachment = arrow },
+            });
+
+            var (http, _) = CapturingHttp(closedBody);
+            using (http)
+            {
+                var connection = new StatementExecutionConnection(BaseProps(), http);
+                using var stmt = (StatementExecutionStatement)connection.CreateStatement();
+                stmt.SqlQuery = "SELECT 42 AS id";
+
+                // Must NOT throw on CLOSED — the direct result is present in the response.
+                var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+                using var reader = result.Stream;
+                var batch = await reader.ReadNextRecordBatchAsync();
+                Assert.NotNull(batch);
+                Assert.Equal(1, batch!.Length);
+            }
+        }
+
+        private static byte[] BuildSingleRowIntArrow(string column, int value)
+        {
+            var schema = new Schema(new[] { new Field(column, Int32Type.Default, nullable: false) }, null);
+            var arr = new Int32Array.Builder().Append(value).Build();
+            var batch = new RecordBatch(schema, new IArrowArray[] { arr }, 1);
+            using var ms = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(ms, schema))
+            {
+                writer.WriteRecordBatch(batch);
+                writer.WriteEnd();
+            }
+            return ms.ToArray();
+        }
+    }
+}

--- a/csharp/test/Unit/StatementExecution/StatementSetOptionTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementSetOptionTests.cs
@@ -68,7 +68,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 resultDisposition: "INLINE_OR_EXTERNAL_LINKS",
                 resultFormat: "ARROW_STREAM",
                 resultCompression: null,
-                waitTimeoutSeconds: 0,
+                waitTimeout: "0s",
                 pollingIntervalMs: 50,
                 properties: properties,
                 recyclableMemoryStreamManager: new RecyclableMemoryStreamManager(),


### PR DESCRIPTION
## Summary

The SEA / Statement Execution path sent `wait_timeout="10s"` by default (whenever direct results were enabled). A **non-zero `wait_timeout` combined with `INLINE_OR_EXTERNAL_LINKS`** routes the request to the old SEA sync-hybrid results path, which **truncates multi-chunk results**: the manifest advertises N chunks, but only chunk 0 is delivered (no `external_links`, no next-chunk pointers) and `GET /result/chunks/{n>=1}` returns `400 "chunk_index n is out of bounds"`. The client silently receives a subset of rows — e.g. `GetColumns` returning **0 rows**. Root cause tracked server-side as **ES-2034600**.

## Change (mirrors `databricks-jdbc`)

Derive `wait_timeout` from the direct-results flag instead of exposing it as a customer knob:
- **direct results ON (default)** → `wait_timeout` **unset** → server returns the full result inline in one response (`SUCCEEDED` or `CLOSED`) — the SEA equivalent of Thrift DirectResults, and what `databricks-jdbc` sends by default.
- **direct results OFF** → `wait_timeout="0s"` (fully async) → poll.
- **Never** send a positive `wait_timeout`. `adbc.databricks.rest.wait_timeout` is now ignored (kept only as a recognized-but-inert key).

Also:
- **Treat `state=CLOSED` as success** — read the direct result from that response and mark the statement closed so `Dispose` skips a redundant `CloseStatement`. Matches `databricks-jdbc`, which treats `CLOSED == SUCCEEDED`.
- **Decouple the metadata-operation timeout** (`CreateMetadataTimeoutCts`) from `wait_timeout` with a fixed 300s bound — fixes a latent `FromSeconds(0)` near-immediate cancel when direct results were disabled.

This is independent of (and more fundamental than) the SEA LZ4-default work in #562 — it makes the driver safe regardless of compression.

## Tests

- **Unit** (`StatementExecutionWaitTimeoutTests`): direct-results-on → `wait_timeout` omitted; direct-results-off → `"0s"`; `adbc.databricks.rest.wait_timeout` ignored; `CLOSED` response with a result yields rows (not an exception). Full unit suite **875/875**.
- **E2E** (live SEA warehouse): `GetColumns` false-case returned **148,282 rows** via the direct-result `CLOSED` path (previously truncated under sync+LZ4); `StatementExecutionDriverE2ETests` **12/12** (queries/updates/DDL).
- Curl-verified: unset `wait_timeout` → `CLOSED` + full inline result (1 chunk); non-zero sync → 2-chunk truncation.

This pull request and its description were written by Isaac.