### PR TITLE
chore(bot): allow bots to fetch the hiveserver2 submodule as context

### DIFF
--- a/.bot/context-repos.yaml
+++ b/.bot/context-repos.yaml
@@ -28,3 +28,16 @@ context_repos:
       issue names (e.g. MetadataResultSetBuilder) to see how JDBC does it, then
       mirror it in the C# driver.
     clone_url: https://github.com/databricks/databricks-jdbc.git
+  - name: hiveserver2
+    description: >
+      The HiveServer2/Thrift base that the C# drivers build on — the source for
+      the `csharp/hiveserver2` submodule, which is NOT checked out in this
+      workspace and can't be fetched otherwise. Consult it when a decision turns
+      on how the Thrift base actually behaves: metadata fan-out
+      (HiveServer2Connection.GetObjects and the GetCatalogs/GetSchemas/GetTables/
+      GetColumns RPCs it issues), cancellation/timeout bounding
+      (ApacheUtility.GetCancellationToken — whether a token is per-RPC or shared
+      across a call tree), type mapping, and error/status semantics. grep for the
+      class/method the issue names (e.g. HiveServer2Connection, ApacheUtility)
+      under csharp/src/AdbcDrivers.HiveServer2/ to see how the base does it.
+    clone_url: https://github.com/adbc-drivers/hiveserver2.git


### PR DESCRIPTION
## What

Adds the public `adbc-drivers/hiveserver2` repo to the bots' context-repo allowlist (`.bot/context-repos.yaml`) so `fetch_context_repo` can lazily clone it on demand.

## Why

On #566 the engineer-bot was [blocked](https://github.com/adbc-drivers/databricks/pull/566#discussion_r3515359253): the decision on whether to keep `CreateMetadataTimeoutCts` depends on how the HiveServer2/Thrift base bounds `GetObjects`' fan-out RPCs — i.e. whether `ApacheUtility.GetCancellationToken` hands out a per-RPC token or one shared across the call tree. That code lives in the `csharp/hiveserver2` submodule, which isn't checked out in the workspace and the bot's tools can't fetch, so it couldn't resolve the thread.

The submodule points at `git@github.com:adbc-drivers/hiveserver2.git`, which is a **public** repo, so it satisfies the allowlist's public-repos-only rule. The entry uses the required plain HTTPS `clone_url`.

Verified the files the bot needs both exist in that repo:
- `csharp/src/AdbcDrivers.HiveServer2/Hive2/HiveServer2Connection.cs`
- `csharp/src/AdbcDrivers.HiveServer2/ApacheUtility.cs`

This pull request and its description were written by Isaac.