### PR TITLE
fix(csharp): treat catalog as a literal name on the Thrift metadata path (#525)

### DIFF
--- a/csharp/src/DatabricksStatement.cs
+++ b/csharp/src/DatabricksStatement.cs
@@ -672,6 +672,35 @@ namespace AdbcDrivers.Databricks
         }
 
         /// <summary>
+        /// Normalizes the catalog argument for the Thrift metadata path (GetSchemas/GetTables/GetColumns)
+        /// so that catalog behaves as an exact-name identifier rather than a SQL-LIKE pattern (issue #525),
+        /// matching the SEA path and PR #536.
+        ///
+        /// - A bare match-all wildcard ("%" or "*") — like a null argument — means "all catalogs", so it is
+        ///   mapped to null. On Thrift the server already expands "%"/"*", but mapping to null keeps the
+        ///   behavior identical to the SEA path (StatementExecutionStatement.EffectiveCatalog).
+        /// - Any other catalog name has its "_" and "%" wildcard characters escaped so the Thrift server
+        ///   matches it literally. The server honors the "\_"/"\%" escape (verified against a live warehouse);
+        ///   without escaping it treats "_" as a single-char wildcard, so e.g. catalog "comparator_tests"
+        ///   would also match "comparator-tests".
+        ///
+        /// When <paramref name="escapePatternWildcards"/> is true the base class (HiveServer2Statement) already
+        /// escapes the catalog argument, so the name is returned unescaped here (after the bare-wildcard
+        /// normalization) to avoid double-escaping.
+        /// </summary>
+        internal static string? NormalizeCatalogForThrift(string? catalog, bool escapePatternWildcards)
+        {
+            if (catalog == null || catalog == "%" || catalog == "*")
+            {
+                return null;
+            }
+
+            return escapePatternWildcards
+                ? catalog
+                : catalog.Replace("_", "\\_").Replace("%", "\\%");
+        }
+
+        /// <summary>
         /// Helper method that returns the fully qualified table name enclosed by backtick.
         /// The returned value can be used as table name in the SQL statement
         ///
@@ -764,6 +793,12 @@ namespace AdbcDrivers.Databricks
                 HandleSparkCatalog();
                 activity?.SetTag("statement.catalog_name_after_spark_handling", CatalogName ?? "(none)");
 
+                // Issue #525: on Thrift, catalog is an exact-name identifier, not a LIKE pattern.
+                // Map a bare match-all wildcard to null ("all catalogs") and escape any other catalog
+                // name so the server matches it literally (parity with the SEA path / PR #536).
+                CatalogName = NormalizeCatalogForThrift(CatalogName, EscapePatternWildcards);
+                activity?.SetTag("statement.catalog_name_after_pattern_normalization", CatalogName ?? "(none)");
+
                 // If EnableMultipleCatalogSupport is false and catalog is not null or SPARK, return empty result without RPC call
                 if (!enableMultipleCatalogSupport && CatalogName != null)
                 {
@@ -810,6 +845,12 @@ namespace AdbcDrivers.Databricks
                 HandleSparkCatalog();
                 activity?.SetTag("statement.catalog_name_after_spark_handling", CatalogName ?? "(none)");
 
+                // Issue #525: on Thrift, catalog is an exact-name identifier, not a LIKE pattern.
+                // Map a bare match-all wildcard to null ("all catalogs") and escape any other catalog
+                // name so the server matches it literally (parity with the SEA path / PR #536).
+                CatalogName = NormalizeCatalogForThrift(CatalogName, EscapePatternWildcards);
+                activity?.SetTag("statement.catalog_name_after_pattern_normalization", CatalogName ?? "(none)");
+
                 // If EnableMultipleCatalogSupport is false and catalog is not null or SPARK, return empty result without RPC call
                 if (!enableMultipleCatalogSupport && CatalogName != null)
                 {
@@ -855,6 +896,12 @@ namespace AdbcDrivers.Databricks
                 // Handle SPARK catalog case
                 HandleSparkCatalog();
                 activity?.SetTag("statement.catalog_name_after_spark_handling", CatalogName ?? "(none)");
+
+                // Issue #525: on Thrift, catalog is an exact-name identifier, not a LIKE pattern.
+                // Map a bare match-all wildcard to null ("all catalogs") and escape any other catalog
+                // name so the server matches it literally (parity with the SEA path / PR #536).
+                CatalogName = NormalizeCatalogForThrift(CatalogName, EscapePatternWildcards);
+                activity?.SetTag("statement.catalog_name_after_pattern_normalization", CatalogName ?? "(none)");
 
                 // If EnableMultipleCatalogSupport is false and catalog is not null, return empty result without RPC call
                 if (!enableMultipleCatalogSupport && CatalogName != null)

--- a/csharp/test/Unit/DatabricksStatementUnitTests.cs
+++ b/csharp/test/Unit/DatabricksStatementUnitTests.cs
@@ -56,6 +56,37 @@ namespace AdbcDrivers.Databricks.Tests.Unit
         }
 
         /// <summary>
+        /// Issue #525: on the Thrift metadata path the catalog argument must behave as an exact-name
+        /// identifier, not a SQL-LIKE pattern. NormalizeCatalogForThrift maps a bare match-all wildcard
+        /// ("%"/"*") — like null — to null ("all catalogs"), and escapes "_"/"%" in any other catalog
+        /// name so the server matches it literally. When EscapePatternWildcards is already enabled the
+        /// base class escapes catalog itself, so the literal name is returned unchanged to avoid
+        /// double-escaping.
+        /// </summary>
+        [Theory]
+        // bare match-all wildcards (and null) -> null ("all catalogs"), regardless of the escape flag
+        [InlineData(null, false, null)]
+        [InlineData("%", false, null)]
+        [InlineData("*", false, null)]
+        [InlineData("%", true, null)]
+        [InlineData("*", true, null)]
+        // plain name with no wildcard chars -> unchanged
+        [InlineData("main", false, "main")]
+        [InlineData("main", true, "main")]
+        // name containing "_" -> escaped so it matches literally (flag off)
+        [InlineData("comparator_tests", false, "comparator\\_tests")]
+        [InlineData("hive_metastore", false, "hive\\_metastore")]
+        // "%" inside a name -> escaped too (flag off)
+        [InlineData("a%b_c", false, "a\\%b\\_c")]
+        // flag on: base class escapes, so leave the literal name unchanged here (no double-escape)
+        [InlineData("comparator_tests", true, "comparator_tests")]
+        public void NormalizeCatalogForThrift_NormalizesAndEscapesCatalog(string? input, bool escapePatternWildcards, string? expected)
+        {
+            string? actual = DatabricksStatement.NormalizeCatalogForThrift(input, escapePatternWildcards);
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
         /// Tests that query_tags parameter is captured and added to confOverlay.
         /// </summary>
         [Fact]


### PR DESCRIPTION
## Summary

Makes the **Thrift** metadata path treat the `catalog` argument of `GetSchemas`/`GetTables`/`GetColumns` as an **exact-name identifier**, not a SQL-LIKE pattern — matching the SEA path and PR #536.

Today the catalog is sent to the server's Thrift `GetSchemas`/`GetTables`/`GetColumns` RPC as a pattern, so `_`/`%` act as wildcards and **over-match**. Per the JDBC/ODBC contract (catalog is an exact name; only schema/table/column are patterns) and for Thrift↔SEA parity, catalog should match literally.

## Change

`DatabricksStatement` normalizes the catalog after SPARK handling and before the base RPC call (`NormalizeCatalogForThrift`):

- **Bare match-all wildcard** (`%` or `*`, like null) → `null` ("all catalogs"), mirroring the SEA path (`StatementExecutionStatement.EffectiveCatalog`) / #536.
- **Any other catalog name** → escape `_`/`%` so the server matches it literally. The Thrift server honors the `\_`/`\%` escape.
- When `escape_pattern_wildcards` is already enabled, the base `HiveServer2Statement` escapes catalog itself — so we return it unescaped here to **avoid double-escaping**.

The `AdbcDrivers.HiveServer2` submodule is **not** modified; the change lives entirely in the Databricks-owned `DatabricksStatement` overrides.

## Evidence (live Thrift warehouse)

Verified against a live Thrift SQL warehouse via `GetSchemas`:

| catalog arg | matched | 
|---|---|
| `None` / `%` / `*` | all catalogs |
| `comparator_tests` (unescaped `_`) | **comparator-tests AND comparator_tests** (over-match) |
| `comparator\_tests` (escaped) | **comparator_tests only** (literal) |

So escaping produces the correct literal match, and `%`/`*` still return all catalogs.

## Test plan

- [x] Unit: `DatabricksStatementUnitTests.NormalizeCatalogForThrift_NormalizesAndEscapesCatalog` — 11 cases: `%`/`*`/null→null, plain name unchanged, `_`/`%` escaped (flag off), no double-escape (flag on).
- [ ] CI runs unit + E2E (the change targets net10.0 via the submodule; couldn't build locally on SDK 9.0 — will validate in CI).

## Notes

- Part of #519 (Thrift↔SEA metadata parity); companion to #536 (SEA `%`/`*`→null). Suggest merging after #536 so the pair reads together.
- Minor behavior change: multi-catalog **disabled** + `catalog="%"` now returns the session default catalog's schemas (was empty), intentionally matching SEA/#536.

This pull request and its description were written by Isaac.
