### PR TITLE
chore(csharp): bump version to 1.1.7

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to the C# Databricks ADBC driver are documented in this file
 
 ## [Unreleased]
 
+## [1.1.7] - 2026-07-08
+
 ### Changed
 
 - **`adbc.databricks.rest.result_compression` is now ignored** (deprecated). Result
@@ -29,6 +31,13 @@ All notable changes to the C# Databricks ADBC driver are documented in this file
   `LZ4_FRAME` by default. To opt out of LZ4 compression, set
   `adbc.databricks.cloudfetch.lz4.enabled=false`; explicit `result_compression=none`
   (or `gzip`) values are no longer honored.
+
+### Fixed
+
+- Fix `*`/`%` wildcard semantics and `TABLE_CAT` identifier echo divergence between the
+  Thrift and REST/SEA metadata paths (#536, #525)
+- Derive SEA `wait_timeout` from the direct-results setting and treat a `CLOSED` statement
+  state as success (#566)
 
 ## [1.1.6] - 2026-07-02
 

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -30,7 +30,7 @@ limitations under the License.
   <PropertyGroup>
     <Product>ADBC Driver for Databricks</Product>
     <Copyright>Copyright 2025 ADBC Drivers Contributors</Copyright>
-    <VersionPrefix>1.1.6</VersionPrefix>
+    <VersionPrefix>1.1.7</VersionPrefix>
     <VersionSuffix>SNAPSHOT</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` from `1.1.6` → `1.1.7` in `csharp/Directory.Build.props`
- Roll the `[Unreleased]` CHANGELOG entries into a dated `[1.1.7] - 2026-07-08` section

The 1.1.7 patch captures everything merged to `main` since the 1.1.6 cut (#565). All changes are additive / opt-in with no breaking changes, so this stays on the `v1.1.x` line — consistent with 1.1.4/1.1.5/1.1.6.

### Changed
- `adbc.databricks.rest.result_compression` is now ignored (deprecated); compression on REST/SEA derives from `cloudfetch.lz4.enabled` (#562)

### Fixed
- `*`/`%` wildcard semantics and `TABLE_CAT` identifier echo divergence between Thrift and REST/SEA metadata paths (#536, #525)
- SEA `wait_timeout` derived from direct-results; treat `CLOSED` statement state as success (#566)

This pull request and its description were written by Isaac.
