### PR TITLE
ci: dispatch coverage-fanout (not csharp-coverage) on merged C# PRs

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -525,8 +525,9 @@ jobs:
   # =============================================================================
   # After merge: trigger AI test-coverage generation for C# changes
   # Fires when a PR lands on main (via merge queue or direct merge) and touches
-  # csharp/ files. Dispatches csharp-coverage to databricks-driver-test, which
-  # creates a tracking issue and runs the coverage agent as peco-engineer-bot.
+  # csharp/ files. Dispatches `coverage-fanout` to databricks-driver-test, whose
+  # coverage-fanout-tracker.yml creates a tracking issue and kicks off the
+  # multi-language fan-out (reference: csharp) as peco-engineer-bot.
   # =============================================================================
   trigger-csharp-coverage:
     if: |
@@ -566,5 +567,5 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: databricks/databricks-driver-test
-          event-type: csharp-coverage
-          client-payload: '{"pr_number": "${{ github.event.pull_request.number }}"}'
+          event-type: coverage-fanout
+          client-payload: '{"reference_language": "csharp", "pr_number": "${{ github.event.pull_request.number }}", "pr_url": "${{ github.event.pull_request.html_url }}"}'


### PR DESCRIPTION
## What

Post-merge C# coverage sender (`trigger-integration-tests.yml` → `trigger-csharp-coverage`) now dispatches **`coverage-fanout`** to `databricks-driver-test` with a language-tagged payload:

```json
{"reference_language": "csharp", "pr_number": "...", "pr_url": "..."}
```

instead of the old `csharp-coverage` event-type.

## Why

The coverage entry point in `databricks-driver-test` moved from the csharp-only `engineer-bot.yml` (being deleted) to the new `coverage-fanout-tracker.yml`, which creates a tracking issue and drives the **multi-language** fan-out (reference: csharp). See databricks-driver-test#857.

## ⚠️ Hard swap — lands with databricks-driver-test#857

The tracker listens **only** on `coverage-fanout` (no back-compat for `csharp-coverage`). This PR and databricks-driver-test#857 must merge together, or post-merge C# coverage pauses until both are in. No behavior change for any other job in this workflow.

This pull request and its description were written by Isaac.