### PR TITLE
ci: send reference_repo (not reference_language) in coverage-fanout dispatch

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -568,4 +568,4 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: databricks/databricks-driver-test
           event-type: coverage-fanout
-          client-payload: '{"reference_language": "csharp", "pr_number": "${{ github.event.pull_request.number }}", "pr_url": "${{ github.event.pull_request.html_url }}"}'
+          client-payload: '{"reference_repo": "${{ github.repository }}", "pr_number": "${{ github.event.pull_request.number }}", "pr_url": "${{ github.event.pull_request.html_url }}"}'


### PR DESCRIPTION
Follow-up to #590. The coverage fan-out went **language-free** (databricks-driver-test#857): the reference is a **repo + PR**, and spec authoring derives the source subtree from the PR's own changed files — no language token.

This updates the post-merge sender payload:
```
- {"reference_language": "csharp", "pr_number": ..., "pr_url": ...}
+ {"reference_repo": "${{ github.repository }}", "pr_number": ..., "pr_url": ...}
```
`github.repository` is `adbc-drivers/databricks` here; the fan-out derives the csharp-vs-rust binding from which subtree the PR touched. No other change.

⚠️ Lands **lockstep** with databricks-driver-test#857 (the tracker now expects `reference_repo`).

This pull request and its description were written by Isaac.