### PR TITLE
ci(ci): add daily retrospective (rolling learning PR) + bump engine

### DIFF
--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -84,17 +84,16 @@ author:
     issue_number: ISSUE_NUMBER
     issue_title:  ISSUE_TITLE
     issue_body:   ISSUE_BODY
-  # Learning log: .claude/knowledge/learning.md — NO config key needed. BOTH bots
-  # auto-read everything under .claude/knowledge/**/*.md via their conventions
-  # readers (the engineer's read_repo_conventions + the reviewer's
-  # aggregate_repo_rules), so past lessons inform each bot with zero wiring. One
-  # log for the whole repo for now; can split per-language later.
-  # (Trade-off vs. the author.knowledge_log key: via the glob the log is delivered
-  # oldest-first and byte-capped like other conventions, NOT newest-first — fine
-  # while the log is small; add author.knowledge_log back if it grows past the cap
-  # and recent lessons start getting truncated. Auto-append on merge is a separate
-  # follow-up: needs a `retrospective:` block + a learning workflow, neither wired
-  # yet — grow this file by hand for now.)
+  # Learning log: .claude/knowledge/learning.md. Now that the daily retrospective
+  # is wired (see the `retrospective:` block below), it will GROW automatically, so
+  # we pin author.knowledge_log to it explicitly: this delivers the log to the
+  # author phase NEWEST-first and byte-capped (vs. the conventions glob, which
+  # delivers .claude/knowledge/**/*.md oldest-first) — the right ordering once the
+  # log outgrows the cap and recent lessons matter most. MUST match
+  # retrospective.log_path below (write half ↔ read half). Both bots still also
+  # auto-read the file via their conventions readers, so this is purely about
+  # ordering/capping, not enablement.
+  knowledge_log: .claude/knowledge/learning.md
 
 # Follow-up phase (engineer-bot-followup.yml): NO config block. The engine reads
 # no `followup:` key — bot_config.py parses only `author:` + the shared top-level
@@ -106,6 +105,25 @@ author:
 # "write a failing test → fix the CODE → re-run until green; don't weaken the
 # test" instruction and forces a {outcome, reason, red_green_tests} result.
 flow: bug-fix
+
+# Daily-cron learning extraction (retrospective flow). Run by engineer-bot-learning.yml
+# via `python -m databricks_bot_engine.engineer_bot.retrospective`: over an adaptive
+# look-back window the engine ITSELF gathers merged PRs (diff + review comments) AND
+# recent engineer-bot author-run logs, and if the model finds durable learnings opens
+# ONE rolling PR appending a dated section to log_path. Human-gated — never commits the
+# canonical log directly. Omitting this block makes the retrospective a no-op.
+#
+# No `system_prompt` override: the engine ships the authoritative batch-aware base
+# (engineer_prompts.RETRO_SYSTEM_PROMPT). No `context_files` — the daily-cron engine
+# enumerates its own sources via the GitHub API (context_files is an AUTHOR-phase key).
+# branch_prefix here is the LEARNING branch prefix (distinct from the top-level
+# `ai/bugfix-` fix-branch prefix); the rolling PR lands on the derived stable branch
+# `ai/learning-pr`.
+retrospective:
+  log_path: .claude/knowledge/learning.md   # MUST match author.knowledge_log above (the EXISTING log)
+  branch_prefix: ai/learning-pr-            # rolling PR lands on the derived stable branch `ai/learning-pr`
+  pr_label: engineer-bot-learning
+  author_workflow: engineer-bot.yaml        # Track B: which workflow's author runs to mine (NOTE: .yaml)
 
 # ─── Reviewer bots (review / review-followup) — NOT configured here ──────────
 # Documented for completeness (this file is the whole bot setup), but the reviewer

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -203,7 +203,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5fbcee18e479c58656a94e7704dabfe7edaf2b26
+          ENGINE_REF: d05dcb113332401b4aee8d6aa05c7107399ad44f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/engineer-bot-learning.yaml
+++ b/.github/workflows/engineer-bot-learning.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Engineer Bot — learning (retrospective) extraction — DAILY CRON.
 #
 # Over an adaptive look-back window the engine gathers merged PRs (diff + review

--- a/.github/workflows/engineer-bot-learning.yaml
+++ b/.github/workflows/engineer-bot-learning.yaml
@@ -1,0 +1,123 @@
+# Engineer Bot — learning (retrospective) extraction — DAILY CRON.
+#
+# Over an adaptive look-back window the engine gathers merged PRs (diff + review
+# comments) AND recent engineer-bot author-run console logs ITSELF via the GitHub
+# API — no in-workflow context gathering, no per-PR trigger — and if the model
+# finds durable, reusable learnings, opens ONE ROLLING PR on a stable branch
+# (`ai/learning-pr`), appending a dated section per day until a human merges it.
+# Human-gated by design: it NEVER commits the canonical log directly.
+#
+# Setup mirrors engineer-bot.yaml (this repo's interim pattern): self-hosted
+# runner, python3.11 venv, PAT-installed engine pinned to ENGINE_REF. Opt-in is
+# purely via the `retrospective:` block in .bot/config.yaml + this workflow;
+# absent that block the engine phase is a clean no-op.
+#
+# Prereqs (already present for the other bots):
+#   - secrets BOT_ENGINE_PAT, ENGINEER_BOT_APP_ID/PRIVATE_KEY, DATABRICKS_HOST/TOKEN
+#   - the engineer-bot App installation must carry actions:read (Track B author-run mining)
+name: Engineer Bot — Learning (daily cron)
+
+on:
+  schedule:
+    # 17:23 UTC daily — off-peak, off-:00 minute (GitHub delays/drops on-the-hour crons).
+    - cron: "23 17 * * *"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'ISO lower bound to bound (shorten) the window and recover a wedged flow. Empty = adaptive cursor.'
+        type: string
+        default: ''
+      window-hours:
+        # STRING, not number: a `type: number` workflow_dispatch input fails the
+        # whole run at startup ("workflow file issue") when combined with `schedule`.
+        description: 'Fallback look-back window (hours) used only when there is no prior successful run.'
+        type: string
+        default: '24'
+
+permissions:
+  contents: write        # push the learning branch / open the learning PR
+  pull-requests: write
+  actions: read          # Track B lists engineer-bot author runs + logs via the App token;
+                         # the engineer-bot App installation must ALSO carry actions:read
+                         # (a missing scope surfaces as a 403 that fails the whole run).
+  id-token: write        # if your model endpoint uses OIDC; harmless otherwise
+
+concurrency:
+  group: engineer-bot-learning-cron
+  cancel-in-progress: false
+
+jobs:
+  learning:
+    runs-on: [self-hosted, Linux, X64, peco-driver]
+    timeout-minutes: 20
+    steps:
+      - name: Mint engineer-bot App token
+        id: token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.ENGINEER_BOT_APP_ID }}
+          private-key: ${{ secrets.ENGINEER_BOT_PRIVATE_KEY }}
+
+      # Checkout the default branch — the learning PR is cut from it. The token is
+      # persisted so the engine's `git push origin <branch>` authenticates as the bot.
+      - name: Checkout default branch (learning PR is cut from it)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          token: ${{ steps.token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Setup Python
+        shell: bash
+        # actions/setup-python can't provision on this self-hosted runner (no hosted
+        # tool-cache). The runner has system python3.11; use it via a venv so pip
+        # installs stay isolated and `pip` / `python -m` resolve to 3.11 later.
+        run: |
+          python3.11 -m venv "$RUNNER_TEMP/bot-venv"
+          echo "$RUNNER_TEMP/bot-venv/bin" >> "$GITHUB_PATH"
+
+      - name: Install bot engine (interim PAT git-install) + Claude SDK/CLI
+        env:
+          # Fine-grained PAT, read-only Contents on databricks/databricks-bot-engine.
+          ENGINE_PAT: ${{ secrets.BOT_ENGINE_PAT }}
+          # SUPPLY-CHAIN PIN: immutable commit SHA — never @main in a secret-bearing
+          # job. Bump to adopt engine changes; keep in lockstep with the other bots.
+          ENGINE_REF: d05dcb113332401b4aee8d6aa05c7107399ad44f
+        run: |
+          set -euo pipefail
+          : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"
+          python -m pip install --upgrade pip
+          pip install "databricks-bot-engine @ git+https://x-access-token:${ENGINE_PAT}@github.com/databricks/databricks-bot-engine@${ENGINE_REF}"
+          pip install claude-agent-sdk
+          export NPM_CONFIG_PREFIX="$RUNNER_TEMP/npm-global"
+          mkdir -p "$NPM_CONFIG_PREFIX/bin"
+          npm install -g @anthropic-ai/claude-code
+          echo "$RUNNER_TEMP/npm-global/bin" >> "$GITHUB_PATH"
+
+      # NOTE: no LIVE-connection / E2E config step — the retrospective only READS
+      # diffs + logs via the API and calls the model; it never builds or runs the
+      # driver, so it needs no warehouse connection (unlike engineer-bot.yaml).
+      # NOTE: no context-gather step — the daily-cron engine enumerates merged PRs
+      # + author runs itself over the adaptive window.
+      - name: Extract learnings + open rolling PR
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # The databricks-claude-opus-4-8 serving endpoint; DATABRICKS_TOKEN authenticates it.
+          # (sdk_agent.translate_endpoint keys on the `/serving-endpoints/` prefix; the model
+          # path segment is discarded, so the effective model is retrospective.model or the
+          # engine default.)
+          MODEL_ENDPOINT:   https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/databricks-claude-opus-4-8/invocations
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          RUNNER_TEMP: ${{ runner.temp }}
+          SINCE: ${{ inputs.since }}
+          WINDOW_HOURS: ${{ inputs.window-hours }}
+        # The checkout persisted the bot token, so the engine's `git push origin
+        # <branch>` authenticates as the bot (no set-url needed here). --since /
+        # --window-hours are passed only when provided via workflow_dispatch (the
+        # schedule trigger leaves them empty → the adaptive cursor drives the window).
+        run: |
+          args=(--repo-dir "$GITHUB_WORKSPACE")
+          [ -n "$SINCE" ] && args+=(--since "$SINCE")
+          [ -n "$WINDOW_HOURS" ] && args+=(--window-hours "$WINDOW_HOURS")
+          python -m databricks_bot_engine.engineer_bot.retrospective "${args[@]}"

--- a/.github/workflows/engineer-bot.yaml
+++ b/.github/workflows/engineer-bot.yaml
@@ -133,7 +133,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5fbcee18e479c58656a94e7704dabfe7edaf2b26
+          ENGINE_REF: d05dcb113332401b4aee8d6aa05c7107399ad44f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot-followup.yml
+++ b/.github/workflows/reviewer-bot-followup.yml
@@ -176,7 +176,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5fbcee18e479c58656a94e7704dabfe7edaf2b26
+          ENGINE_REF: d05dcb113332401b4aee8d6aa05c7107399ad44f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"

--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -107,7 +107,7 @@ jobs:
           # repo cuts one). claude-agent-sdk / @anthropic-ai/claude-code are left
           # unpinned to match the hub (databricks-driver-test); pin them to exact
           # versions here if you want full reproducibility.
-          ENGINE_REF: 5fbcee18e479c58656a94e7704dabfe7edaf2b26
+          ENGINE_REF: d05dcb113332401b4aee8d6aa05c7107399ad44f
         run: |
           set -euo pipefail
           : "${ENGINE_REF:?pin the engine to a tag/SHA before activation (refusing @main)}"


### PR DESCRIPTION
## Summary

Enables the **daily retrospective (learning-extraction) flow** — which `.bot/config.yaml` already anticipated (*"Auto-append on merge is a separate follow-up: needs a `retrospective:` block + a learning workflow, neither wired yet"*) — on the current engine `d05dcb1`, which maintains **one rolling learning PR** on a stable branch (`ai/learning-pr`) per [databricks-bot-engine#146](https://github.com/databricks/databricks-bot-engine/pull/146).

### What the retrospective does

On a daily cron, the engine gathers merged PRs (diff + review comments) and recent engineer-bot author-run logs over an adaptive look-back window, and if the model finds durable, reusable learnings, appends a dated section to a single rolling PR (`ai/learning-pr`) — human-gated, never committing the canonical log directly. The engineer author phase reads those learnings to steer future fixes.

### Changes

- **`.github/workflows/engineer-bot-learning.yaml`** (new): daily `schedule` + `workflow_dispatch` (`since`/`window-hours` recovery inputs). Mirrors this repo's `engineer-bot.yaml` setup exactly — self-hosted `peco-driver` runner, `python3.11` venv, interim `BOT_ENGINE_PAT` engine install pinned to `ENGINE_REF`. Grants **`actions: read`** for Track B (author-run mining). No live-connection/E2E step — the retrospective only reads diffs+logs and calls the model, so it needs no warehouse.
- **`.bot/config.yaml`**:
  - Add the `retrospective:` block. `log_path` points at the **existing** `.claude/knowledge/learning.md` (not a new file); engine-owned batch prompt (no override).
  - Pin **`author.knowledge_log`** to the same file — the documented upgrade the existing comment describes (*"add author.knowledge_log back if it grows past the cap"*): now that the log grows automatically, this delivers it to the author phase **newest-first** and capped, and closes the loop (`log_path == knowledge_log`).
- **Bump `ENGINE_REF` `5fbcee1` → `d05dcb1`** across all 4 bot workflows (keeps every bot on one engine version).

### Validation

- `.bot/config.yaml` loads via `load_bot`; the `retrospective:` block parses; **loop confirmed closed** (`log_path == author.knowledge_log`); `log_path` file exists; `author_workflow: engineer-bot.yaml` filename verified; `bot_login_prefix` present.
- `engineer-bot-learning.yaml` YAML parses; action refs match this repo's other bot workflows.

### Provisioning note

The engineer-bot GitHub App installation must carry **`actions: read`** for Track B. `BOT_ENGINE_PAT`, `ENGINEER_BOT_APP_ID`/`PRIVATE_KEY`, `DATABRICKS_HOST`/`TOKEN` are already in place from the existing bots.

This pull request and its description were written by Isaac.

---
<!-- GITHUB_MCP_FOOTER: This attribution is automatically appended by GitHub MCP. -->
_This PR was created with [GitHub MCP](http://go/mcps)._