### PR TITLE
feat(csharp): validate exact-match args for SEA GetPrimaryKeys / GetCrossReference

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1660,10 +1660,18 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // so its legitimately-unspecified args return empty rather than being rejected.
         private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
         {
-            // Validate only when the PK/FK feature is actually engaged — the internal short-circuit
-            // (ShouldReturnEmptyPKFKResult) otherwise returns empty for these args, and the public
-            // command must match that (don't throw for a request the feature would no-op anyway).
-            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
+            // Throw only in the case the internal would otherwise reach a live fetch for: the
+            // feature engaged (else the internal short-circuits to empty via ShouldReturnEmptyPKFKResult),
+            // AND one of the two exact-match args the JDBC reference driver rejects client-side is bad
+            // (a missing table, or a catalog-set-schema-null request). These preconditions mirror the
+            // throws inside the block so an ordinary successful call — valid catalog with table and
+            // schema both set — never enters the block and never emits a spurious empty span.
+            bool willReject =
+                string.IsNullOrEmpty(_metadataTableName)
+                || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName));
+
+            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK)
+                && willReject)
             {
                 // Emit a span for a client-side rejection so the failure is captured in telemetry —
                 // the throw happens before GetPrimaryKeysAsyncInternal, so its own activity (with

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1580,22 +1580,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
             if (columnsResult.Stream == null)
                 return columnsResult;
 
-            // This is the internal columns-extended reuse, not the user-facing
-            // getprimarykeys command: a null schema (or other exact-match args the
-            // user-facing command rejects) is legitimate here. GetPrimaryKeysAsync
-            // throws on those, so guard and fall back to an empty PK result rather
-            // than letting the validation throw. (For a null schema GetPrimaryKeysAsync
-            // would return an empty result anyway, so this is behavior-preserving.)
-            QueryResult pkResult;
-            if (string.IsNullOrEmpty(_metadataTableName)
-                || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName)))
-            {
-                pkResult = MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
-            }
-            else
-            {
-                pkResult = await GetPrimaryKeysAsync(cancellationToken).ConfigureAwait(false);
-            }
+            // Internal columns-extended reuse, not the user-facing getprimarykeys command:
+            // a null schema (legitimately passed here while gathering PKs for a column set)
+            // must NOT be rejected. Call the non-throwing internal, which returns an empty PK
+            // result for such "unspecified" args instead of throwing.
+            var pkResult = await GetPrimaryKeysAsyncInternal(cancellationToken).ConfigureAwait(false);
 
             // Find FKs where the current table is the FK (child) side — null PK params to
             // match any parent, mirroring Thrift's GetCrossReferenceAsForeignTableAsync.
@@ -1658,11 +1647,37 @@ namespace AdbcDrivers.Databricks.StatementExecution
             return new QueryResult(totalRows, new HiveInfoArrowStream(combinedSchema, combinedData));
         }
 
-        // The user-facing getprimarykeys command. GetColumnsExtendedViaThreeCalls also
-        // gathers PKs for a column set, but it screens out the args this method rejects
-        // (e.g. a null schema) and calls CreateEmptyPrimaryKeysResult itself — so this
-        // method can always validate exact-match args without a caller-supplied flag.
+        // The user-facing getprimarykeys command. GetPrimaryKeys is an exact-match operation,
+        // so this wrapper validates the required args client-side (mirroring the JDBC reference
+        // driver's resolveKeyBasedParams) and throws a clean 42000 on a missing table / a
+        // catalog-set-schema-null request — instead of relying on the Thrift server round-trip
+        // (which surfaces an internal "GET_FUNCTIONS assertion failed" 08000 bug on schema-null).
+        // The actual fetch lives in GetPrimaryKeysAsyncInternal, which does NOT throw; the
+        // internal columns-extended reuse (GetColumnsExtendedViaThreeCalls) calls that directly
+        // so its legitimately-unspecified args return empty rather than being rejected.
         private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
+        {
+            // Validate only when the PK/FK feature is actually engaged — the internal short-circuit
+            // (ShouldReturnEmptyPKFKResult) otherwise returns empty for these args, and the public
+            // command must match that (don't throw for a request the feature would no-op anyway).
+            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
+            {
+                if (string.IsNullOrEmpty(_metadataTableName))
+                    throw NewInvalidArgumentException("tableName may not be null");
+
+                if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
+                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+            }
+
+            return await GetPrimaryKeysAsyncInternal(cancellationToken).ConfigureAwait(false);
+        }
+
+        // Non-throwing core of GetPrimaryKeys: issues SHOW KEYS and shapes the result, returning
+        // an empty result for unspecified/invalid args (null catalog/schema/table or a disabled
+        // feature) rather than throwing. Argument validation lives in the public GetPrimaryKeysAsync
+        // wrapper; this is safe to call directly from GetColumnsExtendedViaThreeCalls, which reuses
+        // it to gather PKs for a column set and legitimately passes a null schema.
+        private async Task<QueryResult> GetPrimaryKeysAsyncInternal(CancellationToken cancellationToken)
         {
             return await this.TraceActivityAsync(async activity =>
             {
@@ -1674,18 +1689,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
                     return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
 
-                // GetPrimaryKeys is an exact-match operation. Validate required args
-                // client-side (mirroring the JDBC reference driver's resolveKeyBasedParams):
-                //   - table null/empty          -> throw "tableName may not be null"
-                //   - catalog set + schema null -> throw "schema may not be null when catalog is specified"
-                // Validating here (before issuing SHOW KEYS) also avoids the Thrift server's
-                // internal "GET_FUNCTIONS assertion failed" bug on schema-null, and gives a
-                // clean, deterministic error instead of relying on a server round-trip.
-                if (string.IsNullOrEmpty(_metadataTableName))
-                    throw NewInvalidArgumentException("tableName may not be null");
-
-                if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
-                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+                // Unspecified args (any of catalog/schema/table null or empty) -> empty result,
+                // NOT a throw. The public wrapper has already rejected those it must reject.
+                if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName)
+                    || string.IsNullOrEmpty(_metadataTableName))
+                    return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
 
                 string sql = new ShowKeysCommand(_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!).Build();
                 activity?.SetTag("sql_query", sql);
@@ -1726,7 +1734,36 @@ namespace AdbcDrivers.Databricks.StatementExecution
             }, "GetPrimaryKeys").ConfigureAwait(false);
         }
 
+        // The user-facing getcrossreference command. Like GetPrimaryKeysAsync, this thin wrapper
+        // validates the one exact-match argument the JDBC reference driver rejects client-side
+        // (DatabricksMetadataQueryClient.resolveKeyBasedParams): a foreign catalog set with a null
+        // foreign schema -> clean 42000, instead of the Thrift server's internal "GET_FUNCTIONS
+        // assertion failed" 08000 bug. The actual work lives in GetCrossReferenceAsyncInternal,
+        // which does NOT throw; the columns-extended reuse goes through FetchCrossReferenceAsync
+        // directly so its legitimately-unspecified args return empty.
         private async Task<QueryResult> GetCrossReferenceAsync(CancellationToken cancellationToken)
+        {
+            // Throw only in the case the internal would otherwise reach a live fetch for: the
+            // feature engaged (else the internal short-circuits to empty), a specified foreign
+            // table (else the internal returns empty — JDBC SEA inspects ONLY the foreign table),
+            // and a foreign catalog set with a null foreign schema. These preconditions mirror the
+            // internal's own early-returns so the two never diverge.
+            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, _metadataForeignCatalogName, _connection.EnablePKFK)
+                && !string.IsNullOrEmpty(_metadataForeignTableName)
+                && !string.IsNullOrEmpty(_metadataForeignCatalogName)
+                && string.IsNullOrEmpty(_metadataForeignSchemaName))
+                throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+
+            return await GetCrossReferenceAsyncInternal(cancellationToken).ConfigureAwait(false);
+        }
+
+        // Non-throwing core of GetCrossReference: reads the statement's PK/FK fields, short-circuits
+        // to empty for a disabled feature or an unspecified foreign table (JDBC SEA checks ONLY the
+        // foreign table — a null one is "unspecified" and returns empty, regardless of the parent
+        // table; live Thrift instead throws 42000 for both-tables-null, an intentional divergence
+        // the comparator whitelists), then delegates to the shared FetchCrossReferenceAsync core.
+        // Argument validation lives in the public GetCrossReferenceAsync wrapper.
+        private async Task<QueryResult> GetCrossReferenceAsyncInternal(CancellationToken cancellationToken)
         {
             return await this.TraceActivityAsync(async activity =>
             {
@@ -1738,31 +1775,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
                 activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
 
-                // When the PK/FK feature is disabled (or neither catalog is a valid PKFK
-                // catalog), short-circuit to an empty result BEFORE any argument validation,
-                // mirroring GetPrimaryKeysAsync. Otherwise this method would throw for a
-                // foreign-catalog-set/foreign-schema-null request while the sibling returns
-                // empty for the equivalent GetPrimaryKeys request, diverging from both the
-                // sibling method and the disabled-feature contract (MetadataUtilities.cs).
                 if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, _metadataForeignCatalogName, _connection.EnablePKFK))
                     return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
 
-                // Argument handling for the user-facing GetCrossReference, mirroring the JDBC
-                // reference driver's SEA path (DatabricksMetadataQueryClient.listCrossReferences):
-                //   - foreign table null -> empty result. JDBC SEA checks ONLY the foreign table
-                //     (it never inspects the parent table) and returns empty for "unspecified".
-                //     We match that: null foreign table -> empty, regardless of the parent table.
-                //     (Live Thrift instead throws 42000 when BOTH tables are null; ADBC SEA follows
-                //     JDBC SEA here, not Thrift, so the comparator whitelists that one input.)
-                //   - foreign catalog set + foreign schema null -> throw 42000, mirroring JDBC
-                //     SEA resolveKeyBasedParams "schema may not be null when catalog is specified"
-                //     (and avoiding Thrift's internal "GET_FUNCTIONS assertion failed" 08000 bug).
                 if (string.IsNullOrEmpty(_metadataForeignTableName))
                     return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
-
-                if (!string.IsNullOrEmpty(_metadataForeignCatalogName)
-                    && string.IsNullOrEmpty(_metadataForeignSchemaName))
-                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
 
                 var result = await FetchCrossReferenceAsync(
                     _metadataCatalogName, _metadataSchemaName, _metadataTableName,

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1687,10 +1687,6 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
                     throw NewInvalidArgumentException("schema may not be null when catalog is specified");
 
-                if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName)
-                    || string.IsNullOrEmpty(_metadataTableName))
-                    return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
-
                 string sql = new ShowKeysCommand(_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!).Build();
                 activity?.SetTag("sql_query", sql);
 

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1660,19 +1660,18 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // so its legitimately-unspecified args return empty rather than being rejected.
         private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
         {
-            // Short-circuit to an empty result before any argument validation when the feature is
-            // disabled or the catalog is one PK/FK metadata does not apply to (SPARK/hive_metastore/
-            // null) — mirroring GetPrimaryKeysAsyncInternal and the JDBC reference driver. Only once
-            // the feature is genuinely engaged do we validate the exact-match args the JDBC driver
-            // rejects client-side, so an ordinary successful call never emits a spurious empty span.
-            if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
-                return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
-
-            // One of the two exact-match args the JDBC reference driver rejects client-side is bad
-            // (a missing table, or a catalog-set-schema-null request). These conditions mirror the
-            // throws inside the block.
-            if (string.IsNullOrEmpty(_metadataTableName)
-                || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName)))
+            // Validate the exact-match args the JDBC reference driver rejects client-side (a missing
+            // table, or a catalog-set-schema-null request), but only when the feature is genuinely
+            // engaged — if it is disabled or the catalog is one PK/FK metadata does not apply to
+            // (SPARK/hive_metastore/null), skip validation and delegate: GetPrimaryKeysAsyncInternal
+            // short-circuits that case to an empty result *inside* its own TraceActivityAsync. We
+            // deliberately do NOT short-circuit here (mirroring GetCrossReferenceAsync) so the
+            // disabled-feature/invalid-catalog path still emits a span, keeping PK/FK telemetry
+            // symmetric across the two commands. The guard mirrors the internal's early-returns so
+            // the two never diverge.
+            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK)
+                && (string.IsNullOrEmpty(_metadataTableName)
+                    || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))))
             {
                 // Emit a span for a client-side rejection so the failure is captured in telemetry —
                 // the throw happens before GetPrimaryKeysAsyncInternal, so its own activity (with

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1660,18 +1660,19 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // so its legitimately-unspecified args return empty rather than being rejected.
         private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
         {
-            // Throw only in the case the internal would otherwise reach a live fetch for: the
-            // feature engaged (else the internal short-circuits to empty via ShouldReturnEmptyPKFKResult),
-            // AND one of the two exact-match args the JDBC reference driver rejects client-side is bad
-            // (a missing table, or a catalog-set-schema-null request). These preconditions mirror the
-            // throws inside the block so an ordinary successful call — valid catalog with table and
-            // schema both set — never enters the block and never emits a spurious empty span.
-            bool willReject =
-                string.IsNullOrEmpty(_metadataTableName)
-                || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName));
+            // Short-circuit to an empty result before any argument validation when the feature is
+            // disabled or the catalog is one PK/FK metadata does not apply to (SPARK/hive_metastore/
+            // null) — mirroring GetPrimaryKeysAsyncInternal and the JDBC reference driver. Only once
+            // the feature is genuinely engaged do we validate the exact-match args the JDBC driver
+            // rejects client-side, so an ordinary successful call never emits a spurious empty span.
+            if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
+                return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
 
-            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK)
-                && willReject)
+            // One of the two exact-match args the JDBC reference driver rejects client-side is bad
+            // (a missing table, or a catalog-set-schema-null request). These conditions mirror the
+            // throws inside the block.
+            if (string.IsNullOrEmpty(_metadataTableName)
+                || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName)))
             {
                 // Emit a span for a client-side rejection so the failure is captured in telemetry —
                 // the throw happens before GetPrimaryKeysAsyncInternal, so its own activity (with

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1665,27 +1665,23 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // command must match that (don't throw for a request the feature would no-op anyway).
             if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
             {
-                string? validationError = null;
-                if (string.IsNullOrEmpty(_metadataTableName))
-                    validationError = "tableName may not be null";
-                else if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
-                    validationError = "schema may not be null when catalog is specified";
-
-                if (validationError != null)
+                // Emit a span for a client-side rejection so the failure is captured in telemetry —
+                // the throw happens before GetPrimaryKeysAsyncInternal, so its own activity (with
+                // these tags) is never reached on this path. The synchronous TraceActivity sets the
+                // activity's status to Error, records the exception as an event, and rethrows.
+                this.TraceActivity(activity =>
                 {
-                    // Emit a span for the client-side rejection so the failure is captured in
-                    // telemetry — the throw happens before GetPrimaryKeysAsyncInternal, so its
-                    // own activity (with these tags) is never reached on this path.
-                    await this.TraceActivityAsync(async activity =>
-                    {
-                        activity?.SetTag("catalog", _metadataCatalogName ?? "(none)");
-                        activity?.SetTag("schema", _metadataSchemaName ?? "(none)");
-                        activity?.SetTag("table", _metadataTableName ?? "(none)");
-                        activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
-                        await Task.CompletedTask.ConfigureAwait(false);
-                        throw NewInvalidArgumentException(validationError);
-                    }, "GetPrimaryKeys").ConfigureAwait(false);
-                }
+                    activity?.SetTag("catalog", _metadataCatalogName ?? "(none)");
+                    activity?.SetTag("schema", _metadataSchemaName ?? "(none)");
+                    activity?.SetTag("table", _metadataTableName ?? "(none)");
+                    activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
+
+                    if (string.IsNullOrEmpty(_metadataTableName))
+                        throw NewInvalidArgumentException("tableName may not be null");
+
+                    if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
+                        throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+                }, "GetPrimaryKeys");
             }
 
             return await GetPrimaryKeysAsyncInternal(
@@ -1778,18 +1774,19 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 && !string.IsNullOrEmpty(_metadataForeignCatalogName)
                 && string.IsNullOrEmpty(_metadataForeignSchemaName))
             {
-                // Emit a span for the client-side rejection so the failure is captured in
-                // telemetry — the throw happens before GetCrossReferenceAsyncInternal, so its
-                // own activity (with these tags) is never reached on this path.
-                await this.TraceActivityAsync(async activity =>
+                // Emit a span for the client-side rejection so the failure is captured in telemetry —
+                // the throw happens before GetCrossReferenceAsyncInternal, so its own activity (with
+                // these tags) is never reached on this path. The synchronous TraceActivity sets the
+                // activity's status to Error, records the exception as an event, and rethrows.
+                this.TraceActivity(activity =>
                 {
                     activity?.SetTag("fk_catalog", _metadataForeignCatalogName ?? "(none)");
                     activity?.SetTag("fk_schema", _metadataForeignSchemaName ?? "(none)");
                     activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
                     activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
-                    await Task.CompletedTask.ConfigureAwait(false);
+
                     throw NewInvalidArgumentException("schema may not be null when catalog is specified");
-                }, "GetCrossReference").ConfigureAwait(false);
+                }, "GetCrossReference");
             }
 
             return await GetCrossReferenceAsyncInternal(

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1731,6 +1731,15 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
                 activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
 
+                // When the PK/FK feature is disabled (or neither catalog is a valid PKFK
+                // catalog), short-circuit to an empty result BEFORE any argument validation,
+                // mirroring GetPrimaryKeysAsync. Otherwise this method would throw for a
+                // foreign-catalog-set/foreign-schema-null request while the sibling returns
+                // empty for the equivalent GetPrimaryKeys request, diverging from both the
+                // sibling method and the disabled-feature contract (MetadataUtilities.cs).
+                if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, _metadataForeignCatalogName, _connection.EnablePKFK))
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
+
                 // Argument validation for the user-facing GetCrossReference, mirroring the
                 // JDBC reference driver's listCrossReferences + resolveKeyBasedParams:
                 //   - null foreign table  -> empty result (Thrift returns empty; "unspecified")

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1665,11 +1665,27 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // command must match that (don't throw for a request the feature would no-op anyway).
             if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
             {
+                string? validationError = null;
                 if (string.IsNullOrEmpty(_metadataTableName))
-                    throw NewInvalidArgumentException("tableName may not be null");
+                    validationError = "tableName may not be null";
+                else if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
+                    validationError = "schema may not be null when catalog is specified";
 
-                if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
-                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+                if (validationError != null)
+                {
+                    // Emit a span for the client-side rejection so the failure is captured in
+                    // telemetry — the throw happens before GetPrimaryKeysAsyncInternal, so its
+                    // own activity (with these tags) is never reached on this path.
+                    await this.TraceActivityAsync(async activity =>
+                    {
+                        activity?.SetTag("catalog", _metadataCatalogName ?? "(none)");
+                        activity?.SetTag("schema", _metadataSchemaName ?? "(none)");
+                        activity?.SetTag("table", _metadataTableName ?? "(none)");
+                        activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
+                        await Task.CompletedTask.ConfigureAwait(false);
+                        throw NewInvalidArgumentException(validationError);
+                    }, "GetPrimaryKeys").ConfigureAwait(false);
+                }
             }
 
             return await GetPrimaryKeysAsyncInternal(
@@ -1761,7 +1777,20 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 && !string.IsNullOrEmpty(_metadataForeignTableName)
                 && !string.IsNullOrEmpty(_metadataForeignCatalogName)
                 && string.IsNullOrEmpty(_metadataForeignSchemaName))
-                throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+            {
+                // Emit a span for the client-side rejection so the failure is captured in
+                // telemetry — the throw happens before GetCrossReferenceAsyncInternal, so its
+                // own activity (with these tags) is never reached on this path.
+                await this.TraceActivityAsync(async activity =>
+                {
+                    activity?.SetTag("fk_catalog", _metadataForeignCatalogName ?? "(none)");
+                    activity?.SetTag("fk_schema", _metadataForeignSchemaName ?? "(none)");
+                    activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
+                    activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
+                    await Task.CompletedTask.ConfigureAwait(false);
+                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+                }, "GetCrossReference").ConfigureAwait(false);
+            }
 
             return await GetCrossReferenceAsyncInternal(
                 _metadataCatalogName, _metadataSchemaName, _metadataTableName,

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1664,32 +1664,16 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // table, or a catalog-set-schema-null request), but only when the feature is genuinely
             // engaged — if it is disabled or the catalog is one PK/FK metadata does not apply to
             // (SPARK/hive_metastore/null), skip validation and delegate: GetPrimaryKeysAsyncNoThrow
-            // short-circuits that case to an empty result *inside* its own TraceActivityAsync. We
-            // deliberately do NOT short-circuit here (mirroring GetCrossReferenceAsync) so the
-            // disabled-feature/invalid-catalog path still emits a span, keeping PK/FK telemetry
-            // symmetric across the two commands. The guard mirrors the internal's early-returns so
-            // the two never diverge.
-            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK)
-                && (string.IsNullOrEmpty(_metadataTableName)
-                    || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))))
+            // returns an empty result for that case. The client-side rejection is a synchronous,
+            // deterministic check with no I/O; the thrown exception (type + SqlState + message) fully
+            // describes it, so it is not wrapped in a trace span.
+            if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
             {
-                // Emit a span for a client-side rejection so the failure is captured in telemetry —
-                // the throw happens before GetPrimaryKeysAsyncNoThrow, so its own activity (with
-                // these tags) is never reached on this path. The synchronous TraceActivity sets the
-                // activity's status to Error, records the exception as an event, and rethrows.
-                this.TraceActivity(activity =>
-                {
-                    activity?.SetTag("catalog", _metadataCatalogName ?? "(none)");
-                    activity?.SetTag("schema", _metadataSchemaName ?? "(none)");
-                    activity?.SetTag("table", _metadataTableName ?? "(none)");
-                    activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
+                if (string.IsNullOrEmpty(_metadataTableName))
+                    throw NewInvalidArgumentException("tableName may not be null");
 
-                    if (string.IsNullOrEmpty(_metadataTableName))
-                        throw NewInvalidArgumentException("tableName may not be null");
-
-                    if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
-                        throw NewInvalidArgumentException("schema may not be null when catalog is specified");
-                }, "GetPrimaryKeys");
+                if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
+                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
             }
 
             return await GetPrimaryKeysAsyncNoThrow(
@@ -1772,29 +1756,19 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // table as the FK side) so its legitimately-unspecified args return empty.
         private async Task<QueryResult> GetCrossReferenceAsync(CancellationToken cancellationToken)
         {
-            // Throw only in the case the internal would otherwise reach a live fetch for: the
-            // feature engaged (else the internal short-circuits to empty), a specified foreign
-            // table (else the internal returns empty — JDBC SEA inspects ONLY the foreign table),
-            // and a foreign catalog set with a null foreign schema. These preconditions mirror the
-            // internal's own early-returns so the two never diverge.
+            // Throw only in the case the internal would otherwise reach a live fetch for: the feature
+            // engaged (else the internal short-circuits to empty), a specified foreign table (else the
+            // internal returns empty — JDBC SEA inspects ONLY the foreign table), and a foreign catalog
+            // set with a null foreign schema. These preconditions mirror the internal's own
+            // early-returns so the two never diverge. The client-side rejection is a synchronous,
+            // deterministic check with no I/O; the thrown exception fully describes it, so it is not
+            // wrapped in a trace span.
             if (!MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, _metadataForeignCatalogName, _connection.EnablePKFK)
                 && !string.IsNullOrEmpty(_metadataForeignTableName)
                 && !string.IsNullOrEmpty(_metadataForeignCatalogName)
                 && string.IsNullOrEmpty(_metadataForeignSchemaName))
             {
-                // Emit a span for the client-side rejection so the failure is captured in telemetry —
-                // the throw happens before GetCrossReferenceAsyncNoThrow, so its own activity (with
-                // these tags) is never reached on this path. The synchronous TraceActivity sets the
-                // activity's status to Error, records the exception as an event, and rethrows.
-                this.TraceActivity(activity =>
-                {
-                    activity?.SetTag("fk_catalog", _metadataForeignCatalogName ?? "(none)");
-                    activity?.SetTag("fk_schema", _metadataForeignSchemaName ?? "(none)");
-                    activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
-                    activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
-
-                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
-                }, "GetCrossReference");
+                throw NewInvalidArgumentException("schema may not be null when catalog is specified");
             }
 
             return await GetCrossReferenceAsyncNoThrow(

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1584,11 +1584,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // a null schema (legitimately passed here while gathering PKs for a column set)
             // must NOT be rejected. Call the non-throwing internal, which returns an empty PK
             // result for such "unspecified" args instead of throwing.
-            var pkResult = await GetPrimaryKeysAsyncInternal(cancellationToken).ConfigureAwait(false);
+            var pkResult = await GetPrimaryKeysAsyncInternal(
+                _metadataCatalogName, _metadataSchemaName, _metadataTableName,
+                cancellationToken).ConfigureAwait(false);
 
             // Find FKs where the current table is the FK (child) side — null PK params to
-            // match any parent, mirroring Thrift's GetCrossReferenceAsForeignTableAsync.
-            var fkResult = await FetchCrossReferenceAsync(
+            // match any parent, mirroring Thrift's GetCrossReferenceAsForeignTableAsync. The
+            // non-throwing internal returns empty for the null PK side / any unspecified arg.
+            var fkResult = await GetCrossReferenceAsyncInternal(
                 pkCatalog: null, pkSchema: null, pkTable: null,
                 fkCatalog: _metadataCatalogName, fkSchema: _metadataSchemaName, fkTable: _metadataTableName,
                 cancellationToken).ConfigureAwait(false);
@@ -1669,33 +1672,39 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     throw NewInvalidArgumentException("schema may not be null when catalog is specified");
             }
 
-            return await GetPrimaryKeysAsyncInternal(cancellationToken).ConfigureAwait(false);
+            return await GetPrimaryKeysAsyncInternal(
+                _metadataCatalogName, _metadataSchemaName, _metadataTableName,
+                cancellationToken).ConfigureAwait(false);
         }
 
-        // Non-throwing core of GetPrimaryKeys: issues SHOW KEYS and shapes the result, returning
-        // an empty result for unspecified/invalid args (null catalog/schema/table or a disabled
-        // feature) rather than throwing. Argument validation lives in the public GetPrimaryKeysAsync
-        // wrapper; this is safe to call directly from GetColumnsExtendedViaThreeCalls, which reuses
-        // it to gather PKs for a column set and legitimately passes a null schema.
-        private async Task<QueryResult> GetPrimaryKeysAsyncInternal(CancellationToken cancellationToken)
+        /// <summary>
+        /// Non-throwing core of GetPrimaryKeys with explicit params: issues SHOW KEYS and shapes the
+        /// result, returning an empty result for unspecified/invalid args (null catalog/schema/table
+        /// or a disabled feature) rather than throwing. Argument validation lives in the public
+        /// GetPrimaryKeysAsync wrapper; this is safe to call directly from GetColumnsExtendedViaThreeCalls,
+        /// which reuses it to gather PKs for a column set and legitimately passes a null schema.
+        /// </summary>
+        private async Task<QueryResult> GetPrimaryKeysAsyncInternal(
+            string? catalog, string? schema, string? table,
+            CancellationToken cancellationToken)
         {
             return await this.TraceActivityAsync(async activity =>
             {
-                activity?.SetTag("catalog", _metadataCatalogName ?? "(none)");
-                activity?.SetTag("schema", _metadataSchemaName ?? "(none)");
-                activity?.SetTag("table", _metadataTableName ?? "(none)");
+                activity?.SetTag("catalog", catalog ?? "(none)");
+                activity?.SetTag("schema", schema ?? "(none)");
+                activity?.SetTag("table", table ?? "(none)");
                 activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
 
-                if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
+                if (MetadataUtilities.ShouldReturnEmptyPKFKResult(catalog, null, _connection.EnablePKFK))
                     return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
 
                 // Unspecified args (any of catalog/schema/table null or empty) -> empty result,
                 // NOT a throw. The public wrapper has already rejected those it must reject.
-                if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName)
-                    || string.IsNullOrEmpty(_metadataTableName))
+                if (string.IsNullOrEmpty(catalog) || string.IsNullOrEmpty(schema)
+                    || string.IsNullOrEmpty(table))
                     return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
 
-                string sql = new ShowKeysCommand(_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!).Build();
+                string sql = new ShowKeysCommand(catalog!, schema!, table!).Build();
                 activity?.SetTag("sql_query", sql);
 
                 List<RecordBatch> batches;
@@ -1724,7 +1733,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                         if (colNameArray.IsNull(i)) continue;
                         int keySeq = keySeqArray != null && !keySeqArray.IsNull(i) ? keySeqArray.GetValue(i)!.Value : ++seq;
                         string pkName = keyNameArray != null && !keyNameArray.IsNull(i) ? keyNameArray.GetString(i) : "";
-                        keys.Add((_metadataCatalogName!, _metadataSchemaName!, _metadataTableName!,
+                        keys.Add((catalog!, schema!, table!,
                             colNameArray.GetString(i), keySeq, pkName));
                     }
                 }
@@ -1739,8 +1748,8 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // (DatabricksMetadataQueryClient.resolveKeyBasedParams): a foreign catalog set with a null
         // foreign schema -> clean 42000, instead of the Thrift server's internal "GET_FUNCTIONS
         // assertion failed" 08000 bug. The actual work lives in GetCrossReferenceAsyncInternal,
-        // which does NOT throw; the columns-extended reuse goes through FetchCrossReferenceAsync
-        // directly so its legitimately-unspecified args return empty.
+        // which does NOT throw; the columns-extended reuse calls that directly (with the current
+        // table as the FK side) so its legitimately-unspecified args return empty.
         private async Task<QueryResult> GetCrossReferenceAsync(CancellationToken cancellationToken)
         {
             // Throw only in the case the internal would otherwise reach a live fetch for: the
@@ -1754,118 +1763,104 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 && string.IsNullOrEmpty(_metadataForeignSchemaName))
                 throw NewInvalidArgumentException("schema may not be null when catalog is specified");
 
-            return await GetCrossReferenceAsyncInternal(cancellationToken).ConfigureAwait(false);
-        }
-
-        // Non-throwing core of GetCrossReference: reads the statement's PK/FK fields, short-circuits
-        // to empty for a disabled feature or an unspecified foreign table (JDBC SEA checks ONLY the
-        // foreign table — a null one is "unspecified" and returns empty, regardless of the parent
-        // table; live Thrift instead throws 42000 for both-tables-null, an intentional divergence
-        // the comparator whitelists), then delegates to the shared FetchCrossReferenceAsync core.
-        // Argument validation lives in the public GetCrossReferenceAsync wrapper.
-        private async Task<QueryResult> GetCrossReferenceAsyncInternal(CancellationToken cancellationToken)
-        {
-            return await this.TraceActivityAsync(async activity =>
-            {
-                activity?.SetTag("pk_catalog", _metadataCatalogName ?? "(none)");
-                activity?.SetTag("pk_schema", _metadataSchemaName ?? "(none)");
-                activity?.SetTag("pk_table", _metadataTableName ?? "(none)");
-                activity?.SetTag("fk_catalog", _metadataForeignCatalogName ?? "(none)");
-                activity?.SetTag("fk_schema", _metadataForeignSchemaName ?? "(none)");
-                activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
-                activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
-
-                if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, _metadataForeignCatalogName, _connection.EnablePKFK))
-                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
-
-                if (string.IsNullOrEmpty(_metadataForeignTableName))
-                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
-
-                var result = await FetchCrossReferenceAsync(
-                    _metadataCatalogName, _metadataSchemaName, _metadataTableName,
-                    _metadataForeignCatalogName, _metadataForeignSchemaName, _metadataForeignTableName,
-                    cancellationToken).ConfigureAwait(false);
-
-                activity?.SetTag("result_count", result.RowCount);
-                return result;
-            }, "GetCrossReference").ConfigureAwait(false);
+            return await GetCrossReferenceAsyncInternal(
+                _metadataCatalogName, _metadataSchemaName, _metadataTableName,
+                _metadataForeignCatalogName, _metadataForeignSchemaName, _metadataForeignTableName,
+                cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Core cross-reference fetch with explicit params. Used by both GetCrossReferenceAsync
-        /// (user-facing, reads from statement fields) and GetColumnsExtendedViaThreeCalls
-        /// (passes current table as the FK side with null PK params to match any parent).
+        /// Non-throwing core of GetCrossReference with explicit params: issues SHOW FOREIGN KEYS
+        /// and shapes the result, returning an empty result for a disabled feature or any
+        /// unspecified foreign arg (JDBC SEA checks ONLY the foreign table — a null one is
+        /// "unspecified" and returns empty, regardless of the parent table; live Thrift instead
+        /// throws 42000 for both-tables-null, an intentional divergence the comparator whitelists)
+        /// rather than throwing. Argument validation lives in the public GetCrossReferenceAsync
+        /// wrapper; this is safe to call directly from GetColumnsExtendedViaThreeCalls, which passes
+        /// the current table as the FK side with null PK params to match any parent.
         /// </summary>
-        private async Task<QueryResult> FetchCrossReferenceAsync(
+        private async Task<QueryResult> GetCrossReferenceAsyncInternal(
             string? pkCatalog, string? pkSchema, string? pkTable,
             string? fkCatalog, string? fkSchema, string? fkTable,
             CancellationToken cancellationToken)
         {
-            if (MetadataUtilities.ShouldReturnEmptyPKFKResult(pkCatalog, fkCatalog, _connection.EnablePKFK))
-                return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
-
-            // NOTE: argument validation (foreign-table/foreign-schema) lives in the
-            // user-facing GetCrossReferenceAsync entry, NOT here — this core fetch is also
-            // called by GetColumnsExtendedViaThreeCalls with the current table as the FK
-            // side (which legitimately passes a null schema), and must not reject that.
-            if (string.IsNullOrEmpty(fkCatalog) || string.IsNullOrEmpty(fkSchema) || string.IsNullOrEmpty(fkTable))
-                return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
-
-            string sql = new ShowForeignKeysCommand(fkCatalog!, fkSchema!, fkTable!).Build();
-
-            List<RecordBatch> batches;
-            try
+            return await this.TraceActivityAsync(async activity =>
             {
-                batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
-            }
-            catch (DatabricksException ex) when (ex.IsObjectNotFoundException())
-            {
-                return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
-            }
+                activity?.SetTag("pk_catalog", pkCatalog ?? "(none)");
+                activity?.SetTag("pk_schema", pkSchema ?? "(none)");
+                activity?.SetTag("pk_table", pkTable ?? "(none)");
+                activity?.SetTag("fk_catalog", fkCatalog ?? "(none)");
+                activity?.SetTag("fk_schema", fkSchema ?? "(none)");
+                activity?.SetTag("fk_table", fkTable ?? "(none)");
+                activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
 
-            var refs = new List<(string, string, string, string, string, string, string, string, int, int, int, string, string?, int)>();
-            int seq = 0;
-            foreach (var batch in batches)
-            {
-                var pkCatalogArray = TryGetColumn<StringArray>(batch, "parentCatalogName");
-                var pkSchemaArray = TryGetColumn<StringArray>(batch, "parentNamespace");
-                var pkTableArray = TryGetColumn<StringArray>(batch, "parentTableName");
-                var pkColArray = TryGetColumn<StringArray>(batch, "parentColName");
-                var fkCatalogArray = TryGetColumn<StringArray>(batch, "catalogName");
-                var fkSchemaArray = TryGetColumn<StringArray>(batch, "namespace");
-                var fkTableArray = TryGetColumn<StringArray>(batch, "tableName");
-                var fkColArray = TryGetColumn<StringArray>(batch, "col_name");
-                var fkNameArray = TryGetColumn<StringArray>(batch, "constraintName");
-                var fkKeySeqArray = TryGetColumn<Int32Array>(batch, "keySeq");
-                var fkUpdateRuleArray = TryGetColumn<Int32Array>(batch, "updateRule");
-                var fkDeleteRuleArray = TryGetColumn<Int32Array>(batch, "deleteRule");
-                var fkDeferrabilityArray = TryGetColumn<Int32Array>(batch, "deferrability");
+                if (MetadataUtilities.ShouldReturnEmptyPKFKResult(pkCatalog, fkCatalog, _connection.EnablePKFK))
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
 
-                if (fkColArray == null) continue;
+                // Any unspecified foreign arg (foreign catalog/schema/table null or empty) -> empty
+                // result, NOT a throw. The public wrapper has already rejected the one case it must
+                // reject (foreign catalog set + foreign schema null with a specified foreign table).
+                if (string.IsNullOrEmpty(fkCatalog) || string.IsNullOrEmpty(fkSchema) || string.IsNullOrEmpty(fkTable))
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
 
-                for (int i = 0; i < batch.Length; i++)
+                string sql = new ShowForeignKeysCommand(fkCatalog!, fkSchema!, fkTable!).Build();
+                activity?.SetTag("sql_query", sql);
+
+                List<RecordBatch> batches;
+                try
                 {
-                    if (fkColArray.IsNull(i)) continue;
-                    refs.Add((
-                        pkCatalogArray != null && !pkCatalogArray.IsNull(i) ? pkCatalogArray.GetString(i) : pkCatalog ?? "",
-                        pkSchemaArray != null && !pkSchemaArray.IsNull(i) ? pkSchemaArray.GetString(i) : pkSchema ?? "",
-                        pkTableArray != null && !pkTableArray.IsNull(i) ? pkTableArray.GetString(i) : pkTable ?? "",
-                        pkColArray != null && !pkColArray.IsNull(i) ? pkColArray.GetString(i) : "",
-                        fkCatalogArray != null && !fkCatalogArray.IsNull(i) ? fkCatalogArray.GetString(i) : fkCatalog!,
-                        fkSchemaArray != null && !fkSchemaArray.IsNull(i) ? fkSchemaArray.GetString(i) : fkSchema!,
-                        fkTableArray != null && !fkTableArray.IsNull(i) ? fkTableArray.GetString(i) : fkTable!,
-                        fkColArray.GetString(i),
-                        fkKeySeqArray != null && !fkKeySeqArray.IsNull(i) ? fkKeySeqArray.GetValue(i)!.Value : ++seq,
-                        fkUpdateRuleArray != null && !fkUpdateRuleArray.IsNull(i) ? fkUpdateRuleArray.GetValue(i)!.Value : 0,
-                        fkDeleteRuleArray != null && !fkDeleteRuleArray.IsNull(i) ? fkDeleteRuleArray.GetValue(i)!.Value : 0,
-                        fkNameArray != null && !fkNameArray.IsNull(i) ? fkNameArray.GetString(i) : "",
-                        (string?)null,
-                        fkDeferrabilityArray != null && !fkDeferrabilityArray.IsNull(i) ? fkDeferrabilityArray.GetValue(i)!.Value : 5
-                    ));
+                    batches = await _connection.ExecuteMetadataSqlAsync(sql, cancellationToken).ConfigureAwait(false);
                 }
-            }
+                catch (DatabricksException ex) when (ex.IsObjectNotFoundException())
+                {
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
+                }
 
-            return MetadataSchemaFactory.BuildCrossReferenceResult(refs);
+                var refs = new List<(string, string, string, string, string, string, string, string, int, int, int, string, string?, int)>();
+                int seq = 0;
+                foreach (var batch in batches)
+                {
+                    var pkCatalogArray = TryGetColumn<StringArray>(batch, "parentCatalogName");
+                    var pkSchemaArray = TryGetColumn<StringArray>(batch, "parentNamespace");
+                    var pkTableArray = TryGetColumn<StringArray>(batch, "parentTableName");
+                    var pkColArray = TryGetColumn<StringArray>(batch, "parentColName");
+                    var fkCatalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                    var fkSchemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                    var fkTableArray = TryGetColumn<StringArray>(batch, "tableName");
+                    var fkColArray = TryGetColumn<StringArray>(batch, "col_name");
+                    var fkNameArray = TryGetColumn<StringArray>(batch, "constraintName");
+                    var fkKeySeqArray = TryGetColumn<Int32Array>(batch, "keySeq");
+                    var fkUpdateRuleArray = TryGetColumn<Int32Array>(batch, "updateRule");
+                    var fkDeleteRuleArray = TryGetColumn<Int32Array>(batch, "deleteRule");
+                    var fkDeferrabilityArray = TryGetColumn<Int32Array>(batch, "deferrability");
+
+                    if (fkColArray == null) continue;
+
+                    for (int i = 0; i < batch.Length; i++)
+                    {
+                        if (fkColArray.IsNull(i)) continue;
+                        refs.Add((
+                            pkCatalogArray != null && !pkCatalogArray.IsNull(i) ? pkCatalogArray.GetString(i) : pkCatalog ?? "",
+                            pkSchemaArray != null && !pkSchemaArray.IsNull(i) ? pkSchemaArray.GetString(i) : pkSchema ?? "",
+                            pkTableArray != null && !pkTableArray.IsNull(i) ? pkTableArray.GetString(i) : pkTable ?? "",
+                            pkColArray != null && !pkColArray.IsNull(i) ? pkColArray.GetString(i) : "",
+                            fkCatalogArray != null && !fkCatalogArray.IsNull(i) ? fkCatalogArray.GetString(i) : fkCatalog!,
+                            fkSchemaArray != null && !fkSchemaArray.IsNull(i) ? fkSchemaArray.GetString(i) : fkSchema!,
+                            fkTableArray != null && !fkTableArray.IsNull(i) ? fkTableArray.GetString(i) : fkTable!,
+                            fkColArray.GetString(i),
+                            fkKeySeqArray != null && !fkKeySeqArray.IsNull(i) ? fkKeySeqArray.GetValue(i)!.Value : ++seq,
+                            fkUpdateRuleArray != null && !fkUpdateRuleArray.IsNull(i) ? fkUpdateRuleArray.GetValue(i)!.Value : 0,
+                            fkDeleteRuleArray != null && !fkDeleteRuleArray.IsNull(i) ? fkDeleteRuleArray.GetValue(i)!.Value : 0,
+                            fkNameArray != null && !fkNameArray.IsNull(i) ? fkNameArray.GetString(i) : "",
+                            (string?)null,
+                            fkDeferrabilityArray != null && !fkDeferrabilityArray.IsNull(i) ? fkDeferrabilityArray.GetValue(i)!.Value : 5
+                        ));
+                    }
+                }
+
+                activity?.SetTag("result_count", refs.Count);
+                return MetadataSchemaFactory.BuildCrossReferenceResult(refs);
+            }, "GetCrossReference").ConfigureAwait(false);
         }
 
         private static T? TryGetColumn<T>(RecordBatch batch, string name) where T : class, IArrowArray

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1580,9 +1580,22 @@ namespace AdbcDrivers.Databricks.StatementExecution
             if (columnsResult.Stream == null)
                 return columnsResult;
 
-            // validateArgs: false — this is the internal columns-extended reuse, not the
-            // user-facing getprimarykeys command; a null schema here is legitimate.
-            var pkResult = await GetPrimaryKeysAsync(cancellationToken, validateArgs: false).ConfigureAwait(false);
+            // This is the internal columns-extended reuse, not the user-facing
+            // getprimarykeys command: a null schema (or other exact-match args the
+            // user-facing command rejects) is legitimate here. GetPrimaryKeysAsync
+            // throws on those, so guard and fall back to an empty PK result rather
+            // than letting the validation throw. (For a null schema GetPrimaryKeysAsync
+            // would return an empty result anyway, so this is behavior-preserving.)
+            QueryResult pkResult;
+            if (string.IsNullOrEmpty(_metadataTableName)
+                || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName)))
+            {
+                pkResult = MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
+            }
+            else
+            {
+                pkResult = await GetPrimaryKeysAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             // Find FKs where the current table is the FK (child) side — null PK params to
             // match any parent, mirroring Thrift's GetCrossReferenceAsForeignTableAsync.
@@ -1645,10 +1658,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
             return new QueryResult(totalRows, new HiveInfoArrowStream(combinedSchema, combinedData));
         }
 
-        // validateArgs=true for the user-facing getprimarykeys command; false when called
-        // internally by GetColumnsExtendedViaThreeCalls (which reuses this to gather PKs for
-        // a column set and legitimately passes a null schema — it must not be rejected).
-        private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken, bool validateArgs = true)
+        // The user-facing getprimarykeys command. GetColumnsExtendedViaThreeCalls also
+        // gathers PKs for a column set, but it screens out the args this method rejects
+        // (e.g. a null schema) and calls CreateEmptyPrimaryKeysResult itself — so this
+        // method can always validate exact-match args without a caller-supplied flag.
+        private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
         {
             return await this.TraceActivityAsync(async activity =>
             {
@@ -1667,14 +1681,11 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 // Validating here (before issuing SHOW KEYS) also avoids the Thrift server's
                 // internal "GET_FUNCTIONS assertion failed" bug on schema-null, and gives a
                 // clean, deterministic error instead of relying on a server round-trip.
-                if (validateArgs)
-                {
-                    if (string.IsNullOrEmpty(_metadataTableName))
-                        throw NewInvalidArgumentException("tableName may not be null");
+                if (string.IsNullOrEmpty(_metadataTableName))
+                    throw NewInvalidArgumentException("tableName may not be null");
 
-                    if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
-                        throw NewInvalidArgumentException("schema may not be null when catalog is specified");
-                }
+                if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
+                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
 
                 if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName)
                     || string.IsNullOrEmpty(_metadataTableName))

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1584,14 +1584,14 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // a null schema (legitimately passed here while gathering PKs for a column set)
             // must NOT be rejected. Call the non-throwing internal, which returns an empty PK
             // result for such "unspecified" args instead of throwing.
-            var pkResult = await GetPrimaryKeysAsyncInternal(
+            var pkResult = await GetPrimaryKeysAsyncNoThrow(
                 _metadataCatalogName, _metadataSchemaName, _metadataTableName,
                 cancellationToken).ConfigureAwait(false);
 
             // Find FKs where the current table is the FK (child) side — null PK params to
             // match any parent, mirroring Thrift's GetCrossReferenceAsForeignTableAsync. The
             // non-throwing internal returns empty for the null PK side / any unspecified arg.
-            var fkResult = await GetCrossReferenceAsyncInternal(
+            var fkResult = await GetCrossReferenceAsyncNoThrow(
                 pkCatalog: null, pkSchema: null, pkTable: null,
                 fkCatalog: _metadataCatalogName, fkSchema: _metadataSchemaName, fkTable: _metadataTableName,
                 cancellationToken).ConfigureAwait(false);
@@ -1655,7 +1655,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // driver's resolveKeyBasedParams) and throws a clean 42000 on a missing table / a
         // catalog-set-schema-null request — instead of relying on the Thrift server round-trip
         // (which surfaces an internal "GET_FUNCTIONS assertion failed" 08000 bug on schema-null).
-        // The actual fetch lives in GetPrimaryKeysAsyncInternal, which does NOT throw; the
+        // The actual fetch lives in GetPrimaryKeysAsyncNoThrow, which does NOT throw; the
         // internal columns-extended reuse (GetColumnsExtendedViaThreeCalls) calls that directly
         // so its legitimately-unspecified args return empty rather than being rejected.
         private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
@@ -1663,7 +1663,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
             // Validate the exact-match args the JDBC reference driver rejects client-side (a missing
             // table, or a catalog-set-schema-null request), but only when the feature is genuinely
             // engaged — if it is disabled or the catalog is one PK/FK metadata does not apply to
-            // (SPARK/hive_metastore/null), skip validation and delegate: GetPrimaryKeysAsyncInternal
+            // (SPARK/hive_metastore/null), skip validation and delegate: GetPrimaryKeysAsyncNoThrow
             // short-circuits that case to an empty result *inside* its own TraceActivityAsync. We
             // deliberately do NOT short-circuit here (mirroring GetCrossReferenceAsync) so the
             // disabled-feature/invalid-catalog path still emits a span, keeping PK/FK telemetry
@@ -1674,7 +1674,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     || (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))))
             {
                 // Emit a span for a client-side rejection so the failure is captured in telemetry —
-                // the throw happens before GetPrimaryKeysAsyncInternal, so its own activity (with
+                // the throw happens before GetPrimaryKeysAsyncNoThrow, so its own activity (with
                 // these tags) is never reached on this path. The synchronous TraceActivity sets the
                 // activity's status to Error, records the exception as an event, and rethrows.
                 this.TraceActivity(activity =>
@@ -1692,7 +1692,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 }, "GetPrimaryKeys");
             }
 
-            return await GetPrimaryKeysAsyncInternal(
+            return await GetPrimaryKeysAsyncNoThrow(
                 _metadataCatalogName, _metadataSchemaName, _metadataTableName,
                 cancellationToken).ConfigureAwait(false);
         }
@@ -1704,7 +1704,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// GetPrimaryKeysAsync wrapper; this is safe to call directly from GetColumnsExtendedViaThreeCalls,
         /// which reuses it to gather PKs for a column set and legitimately passes a null schema.
         /// </summary>
-        private async Task<QueryResult> GetPrimaryKeysAsyncInternal(
+        private async Task<QueryResult> GetPrimaryKeysAsyncNoThrow(
             string? catalog, string? schema, string? table,
             CancellationToken cancellationToken)
         {
@@ -1767,7 +1767,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         // validates the one exact-match argument the JDBC reference driver rejects client-side
         // (DatabricksMetadataQueryClient.resolveKeyBasedParams): a foreign catalog set with a null
         // foreign schema -> clean 42000, instead of the Thrift server's internal "GET_FUNCTIONS
-        // assertion failed" 08000 bug. The actual work lives in GetCrossReferenceAsyncInternal,
+        // assertion failed" 08000 bug. The actual work lives in GetCrossReferenceAsyncNoThrow,
         // which does NOT throw; the columns-extended reuse calls that directly (with the current
         // table as the FK side) so its legitimately-unspecified args return empty.
         private async Task<QueryResult> GetCrossReferenceAsync(CancellationToken cancellationToken)
@@ -1783,7 +1783,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 && string.IsNullOrEmpty(_metadataForeignSchemaName))
             {
                 // Emit a span for the client-side rejection so the failure is captured in telemetry —
-                // the throw happens before GetCrossReferenceAsyncInternal, so its own activity (with
+                // the throw happens before GetCrossReferenceAsyncNoThrow, so its own activity (with
                 // these tags) is never reached on this path. The synchronous TraceActivity sets the
                 // activity's status to Error, records the exception as an event, and rethrows.
                 this.TraceActivity(activity =>
@@ -1797,7 +1797,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 }, "GetCrossReference");
             }
 
-            return await GetCrossReferenceAsyncInternal(
+            return await GetCrossReferenceAsyncNoThrow(
                 _metadataCatalogName, _metadataSchemaName, _metadataTableName,
                 _metadataForeignCatalogName, _metadataForeignSchemaName, _metadataForeignTableName,
                 cancellationToken).ConfigureAwait(false);
@@ -1813,7 +1813,7 @@ namespace AdbcDrivers.Databricks.StatementExecution
         /// wrapper; this is safe to call directly from GetColumnsExtendedViaThreeCalls, which passes
         /// the current table as the FK side with null PK params to match any parent.
         /// </summary>
-        private async Task<QueryResult> GetCrossReferenceAsyncInternal(
+        private async Task<QueryResult> GetCrossReferenceAsyncNoThrow(
             string? pkCatalog, string? pkSchema, string? pkTable,
             string? fkCatalog, string? fkSchema, string? fkTable,
             CancellationToken cancellationToken)

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1740,11 +1740,16 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, _metadataForeignCatalogName, _connection.EnablePKFK))
                     return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
 
-                // Argument validation for the user-facing GetCrossReference, mirroring the
-                // JDBC reference driver's listCrossReferences + resolveKeyBasedParams:
-                //   - null foreign table  -> empty result (Thrift returns empty; "unspecified")
-                //   - foreign catalog set + foreign schema null -> throw (avoids Thrift's
-                //     internal "GET_FUNCTIONS assertion failed" and matches JDBC's clean error)
+                // Argument handling for the user-facing GetCrossReference, mirroring the JDBC
+                // reference driver's SEA path (DatabricksMetadataQueryClient.listCrossReferences):
+                //   - foreign table null -> empty result. JDBC SEA checks ONLY the foreign table
+                //     (it never inspects the parent table) and returns empty for "unspecified".
+                //     We match that: null foreign table -> empty, regardless of the parent table.
+                //     (Live Thrift instead throws 42000 when BOTH tables are null; ADBC SEA follows
+                //     JDBC SEA here, not Thrift, so the comparator whitelists that one input.)
+                //   - foreign catalog set + foreign schema null -> throw 42000, mirroring JDBC
+                //     SEA resolveKeyBasedParams "schema may not be null when catalog is specified"
+                //     (and avoiding Thrift's internal "GET_FUNCTIONS assertion failed" 08000 bug).
                 if (string.IsNullOrEmpty(_metadataForeignTableName))
                     return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
 

--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1120,6 +1120,22 @@ namespace AdbcDrivers.Databricks.StatementExecution
         }
 
         /// <summary>
+        /// Builds the exception SEA throws for a missing exact-match argument on
+        /// GetPrimaryKeys / GetCrossReference, matching the Thrift path: Thrift's
+        /// TGetPrimaryKeysReq / TGetCrossReferenceReq are rejected server-side with
+        /// AdbcStatusCode.InternalError, SqlState 42000. SEA throws its own
+        /// DatabricksException (the natural SEA type); the comparator treats any
+        /// AdbcException subclass as equivalent and compares Status + SqlState, so
+        /// those two must match the Thrift result (the concrete type need not).
+        /// </summary>
+        private static DatabricksException NewInvalidArgumentException(string detail)
+        {
+            var ex = new DatabricksException($"Invalid argument: {detail}", AdbcStatusCode.InternalError);
+            ex.SetSqlState("42000");
+            return ex;
+        }
+
+        /// <summary>
         /// Builds the exception thrown when a statement resolves to FAILED on the async
         /// polling path. Throws DatabricksException — the SAME concrete type as the
         /// synchronous FAILED path in StatementExecutionClient.ExecuteStatementAsync — so
@@ -1564,7 +1580,9 @@ namespace AdbcDrivers.Databricks.StatementExecution
             if (columnsResult.Stream == null)
                 return columnsResult;
 
-            var pkResult = await GetPrimaryKeysAsync(cancellationToken).ConfigureAwait(false);
+            // validateArgs: false — this is the internal columns-extended reuse, not the
+            // user-facing getprimarykeys command; a null schema here is legitimate.
+            var pkResult = await GetPrimaryKeysAsync(cancellationToken, validateArgs: false).ConfigureAwait(false);
 
             // Find FKs where the current table is the FK (child) side — null PK params to
             // match any parent, mirroring Thrift's GetCrossReferenceAsForeignTableAsync.
@@ -1627,7 +1645,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
             return new QueryResult(totalRows, new HiveInfoArrowStream(combinedSchema, combinedData));
         }
 
-        private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken)
+        // validateArgs=true for the user-facing getprimarykeys command; false when called
+        // internally by GetColumnsExtendedViaThreeCalls (which reuses this to gather PKs for
+        // a column set and legitimately passes a null schema — it must not be rejected).
+        private async Task<QueryResult> GetPrimaryKeysAsync(CancellationToken cancellationToken, bool validateArgs = true)
         {
             return await this.TraceActivityAsync(async activity =>
             {
@@ -1638,6 +1659,22 @@ namespace AdbcDrivers.Databricks.StatementExecution
 
                 if (MetadataUtilities.ShouldReturnEmptyPKFKResult(_metadataCatalogName, null, _connection.EnablePKFK))
                     return MetadataSchemaFactory.CreateEmptyPrimaryKeysResult();
+
+                // GetPrimaryKeys is an exact-match operation. Validate required args
+                // client-side (mirroring the JDBC reference driver's resolveKeyBasedParams):
+                //   - table null/empty          -> throw "tableName may not be null"
+                //   - catalog set + schema null -> throw "schema may not be null when catalog is specified"
+                // Validating here (before issuing SHOW KEYS) also avoids the Thrift server's
+                // internal "GET_FUNCTIONS assertion failed" bug on schema-null, and gives a
+                // clean, deterministic error instead of relying on a server round-trip.
+                if (validateArgs)
+                {
+                    if (string.IsNullOrEmpty(_metadataTableName))
+                        throw NewInvalidArgumentException("tableName may not be null");
+
+                    if (!string.IsNullOrEmpty(_metadataCatalogName) && string.IsNullOrEmpty(_metadataSchemaName))
+                        throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+                }
 
                 if (string.IsNullOrEmpty(_metadataCatalogName) || string.IsNullOrEmpty(_metadataSchemaName)
                     || string.IsNullOrEmpty(_metadataTableName))
@@ -1694,6 +1731,18 @@ namespace AdbcDrivers.Databricks.StatementExecution
                 activity?.SetTag("fk_table", _metadataForeignTableName ?? "(none)");
                 activity?.SetTag("pk_fk_enabled", _connection.EnablePKFK);
 
+                // Argument validation for the user-facing GetCrossReference, mirroring the
+                // JDBC reference driver's listCrossReferences + resolveKeyBasedParams:
+                //   - null foreign table  -> empty result (Thrift returns empty; "unspecified")
+                //   - foreign catalog set + foreign schema null -> throw (avoids Thrift's
+                //     internal "GET_FUNCTIONS assertion failed" and matches JDBC's clean error)
+                if (string.IsNullOrEmpty(_metadataForeignTableName))
+                    return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
+
+                if (!string.IsNullOrEmpty(_metadataForeignCatalogName)
+                    && string.IsNullOrEmpty(_metadataForeignSchemaName))
+                    throw NewInvalidArgumentException("schema may not be null when catalog is specified");
+
                 var result = await FetchCrossReferenceAsync(
                     _metadataCatalogName, _metadataSchemaName, _metadataTableName,
                     _metadataForeignCatalogName, _metadataForeignSchemaName, _metadataForeignTableName,
@@ -1717,6 +1766,10 @@ namespace AdbcDrivers.Databricks.StatementExecution
             if (MetadataUtilities.ShouldReturnEmptyPKFKResult(pkCatalog, fkCatalog, _connection.EnablePKFK))
                 return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
 
+            // NOTE: argument validation (foreign-table/foreign-schema) lives in the
+            // user-facing GetCrossReferenceAsync entry, NOT here — this core fetch is also
+            // called by GetColumnsExtendedViaThreeCalls with the current table as the FK
+            // side (which legitimately passes a null schema), and must not reject that.
             if (string.IsNullOrEmpty(fkCatalog) || string.IsNullOrEmpty(fkSchema) || string.IsNullOrEmpty(fkTable))
                 return MetadataSchemaFactory.CreateEmptyCrossReferenceResult();
 

--- a/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
@@ -464,13 +464,37 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
             Assert.Contains("SHOW SCHEMAS IN ALL CATALOGS", captured);
         }
 
-        // GetCrossReference with a null foreign table returns an EMPTY result (JDBC's
-        // listCrossReferences treats a null foreign table as "unspecified"; Thrift returns
-        // empty too). This holds independent of exact-match argument validation (which is
-        // added in a separate, stacked PR).
+        // ─── Exact-match ops throw on missing table, matching the Thrift path ─────────
+        // GetPrimaryKeys / GetCrossReference are exact-match (table required). Thrift's
+        // TGetPrimaryKeysReq / TGetCrossReferenceReq are rejected server-side with
+        // AdbcStatusCode.InternalError + SqlState 42000 when the table is null; SEA must
+        // throw an equivalent error instead of returning empty. SEA throws its own
+        // DatabricksException (the natural SEA type); the comparator treats any
+        // AdbcException subclass as equivalent and compares Status + SqlState, so those
+        // two are the load-bearing assertions here (not the concrete type).
+
+        [Fact]
+        public async Task GetPrimaryKeys_NullTable_ThrowsWithThriftStatusAndSqlState()
+        {
+            using var http = HttpClientCapturingStatements(new List<string>());
+            using var stmt = CreateMetadataStatement(http);
+            stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            stmt.SetOption(ApacheParameters.CatalogName, "main");
+            stmt.SetOption(ApacheParameters.SchemaName, "some_schema");
+            // TableName deliberately not set (null).
+            stmt.SqlQuery = "getprimarykeys";
+
+            var ex = await Assert.ThrowsAsync<DatabricksException>(
+                () => stmt.ExecuteQueryAsync(CancellationToken.None));
+            Assert.Equal(AdbcStatusCode.InternalError, ex.Status);
+            Assert.Equal("42000", ex.SqlState);
+        }
+
         [Fact]
         public async Task GetCrossReference_NullForeignTable_ReturnsEmpty()
         {
+            // JDBC (listCrossReferences): a null foreign table means "unspecified" and
+            // returns an EMPTY result (Thrift returns empty too) — it does NOT throw.
             using var http = HttpClientCapturingStatements(new List<string>());
             using var stmt = CreateMetadataStatement(http);
             stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
@@ -481,6 +505,46 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
 
             var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
             Assert.Equal(0, result.RowCount);
+        }
+
+        [Fact]
+        public async Task GetCrossReference_ForeignCatalogSetForeignSchemaNull_Throws()
+        {
+            // Foreign catalog set + foreign schema null (with a foreign table) → throw,
+            // mirroring JDBC resolveKeyBasedParams and avoiding Thrift's assertion-failed bug.
+            using var http = HttpClientCapturingStatements(new List<string>());
+            using var stmt = CreateMetadataStatement(http);
+            stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            stmt.SetOption(ApacheParameters.ForeignCatalogName, "main");
+            stmt.SetOption(ApacheParameters.ForeignTableName, "fk_child");
+            // Foreign schema deliberately not set (null) while foreign catalog IS set.
+            stmt.SqlQuery = "getcrossreference";
+
+            var ex = await Assert.ThrowsAsync<DatabricksException>(
+                () => stmt.ExecuteQueryAsync(CancellationToken.None));
+            Assert.Equal(AdbcStatusCode.InternalError, ex.Status);
+            Assert.Equal("42000", ex.SqlState);
+        }
+
+        // Exact-match ops also require schema when catalog is specified (mirroring the JDBC
+        // reference driver's resolveKeyBasedParams). Validating client-side gives a clean
+        // error and avoids the Thrift server's internal "GET_FUNCTIONS assertion failed" bug
+        // on a null schema.
+        [Fact]
+        public async Task GetPrimaryKeys_CatalogSetSchemaNull_Throws()
+        {
+            using var http = HttpClientCapturingStatements(new List<string>());
+            using var stmt = CreateMetadataStatement(http);
+            stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            stmt.SetOption(ApacheParameters.CatalogName, "main");
+            stmt.SetOption(ApacheParameters.TableName, "t");
+            // SchemaName deliberately not set (null) while catalog IS set.
+            stmt.SqlQuery = "getprimarykeys";
+
+            var ex = await Assert.ThrowsAsync<DatabricksException>(
+                () => stmt.ExecuteQueryAsync(CancellationToken.None));
+            Assert.Equal(AdbcStatusCode.InternalError, ex.Status);
+            Assert.Equal("42000", ex.SqlState);
         }
 
         // ─── Object-not-found errors are SWALLOWED to an empty result ────────────────

--- a/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
@@ -497,16 +497,41 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         }
 
         [Fact]
-        public async Task GetCrossReference_NullForeignTable_ReturnsEmpty()
+        public async Task GetCrossReference_BothTablesNull_ReturnsEmpty()
         {
-            // JDBC (listCrossReferences): a null foreign table means "unspecified" and
-            // returns an EMPTY result (Thrift returns empty too) — it does NOT throw.
+            // JDBC SEA (DatabricksMetadataQueryClient.listCrossReferences) checks ONLY the
+            // foreign table: a null foreign table means "unspecified" and returns an empty
+            // result — it never inspects the parent table. ADBC SEA mirrors JDBC SEA here, so
+            // BOTH tables null → empty (NOT a throw). Live Thrift instead throws 42000 for the
+            // both-null case; ADBC SEA follows JDBC SEA, and the comparator whitelists that one
+            // input as a Thrift-vs-SEA divergence.
             using var http = HttpClientCapturingStatements(new List<string>());
             using var stmt = CreateMetadataStatement(http);
             stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
             stmt.SetOption(ApacheParameters.ForeignCatalogName, "main");
             stmt.SetOption(ApacheParameters.ForeignSchemaName, "some_schema");
-            // Foreign table deliberately not set (null).
+            // Neither parent table nor foreign table set (both null).
+            stmt.SqlQuery = "getcrossreference";
+
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+            Assert.Equal(0, result.RowCount);
+        }
+
+        [Fact]
+        public async Task GetCrossReference_ParentTableSetForeignTableNull_ReturnsEmpty()
+        {
+            // JDBC SEA: a null foreign table returns empty regardless of the parent table
+            // (listCrossReferences short-circuits on foreignTable == null before looking at
+            // the parent side). SEA must return empty here too.
+            using var http = HttpClientCapturingStatements(new List<string>());
+            using var stmt = CreateMetadataStatement(http);
+            stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            stmt.SetOption(ApacheParameters.CatalogName, "main");
+            stmt.SetOption(ApacheParameters.SchemaName, "some_schema");
+            stmt.SetOption(ApacheParameters.TableName, "fk_parent");
+            stmt.SetOption(ApacheParameters.ForeignCatalogName, "main");
+            stmt.SetOption(ApacheParameters.ForeignSchemaName, "some_schema");
+            // Foreign table deliberately not set (null) while the parent table IS set.
             stmt.SqlQuery = "getcrossreference";
 
             var result = await stmt.ExecuteQueryAsync(CancellationToken.None);

--- a/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
@@ -437,6 +437,47 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         }
 
         [Fact]
+        public async Task GetColumnsExtended_ThreeCalls_NullSchema_ReuseInternals_NoThrowAndEmpty()
+        {
+            // Guards the central invariant of the columns-extended fallback path
+            // (GetColumnsExtendedViaThreeCalls): it must reuse the NON-throwing
+            // GetPrimaryKeysAsyncInternal / GetCrossReferenceAsyncInternal, which return
+            // empty for legitimately-unspecified args (here: catalog set + schema null),
+            // rather than the public getprimarykeys/getcrossreference wrappers that
+            // validate and throw a 42000 on that same catalog-set-schema-null shape.
+            //
+            // A future change that moved validation into the internals (or had the
+            // three-calls path call the throwing wrappers) would regress this without any
+            // unit failing today: the only other coverage is the E2E GetColumnsExtended
+            // tests, which are skipped in CI without a live warehouse. Pinned at the
+            // HttpMessageHandler seam like the sibling tests.
+            //
+            // UseDescTableExtended=false forces the three-calls fallback (the SEA default
+            // is DESC TABLE EXTENDED, which does not exercise the PK/FK internals).
+            var captured = new List<string>();
+            using var http = HttpClientCapturingStatements(captured);
+            using var stmt = CreateMetadataStatement(
+                http,
+                new Dictionary<string, string>
+                {
+                    { DatabricksParameters.UseDescTableExtended, "false" },
+                });
+            stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            // Catalog defaults to "main" (see CreateMetadataStatement); schema is left null.
+            stmt.SetOption(ApacheParameters.TableName, "t");
+            stmt.SqlQuery = "getcolumnsextended";
+
+            // Must NOT throw: the null schema flows through the non-throwing internals.
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+            Assert.Equal(0, result.RowCount);
+
+            // The null-schema PK/FK contribution short-circuits to empty inside the
+            // internals, so no SHOW KEYS / SHOW FOREIGN KEYS query is ever emitted.
+            Assert.DoesNotContain(captured, sql => sql.Contains("SHOW KEYS"));
+            Assert.DoesNotContain(captured, sql => sql.Contains("SHOW FOREIGN KEYS"));
+        }
+
+        [Fact]
         public async Task GetSchemas_StarCatalog_EscapeTrue_ReturnsEmpty()
         {
             // "*" is the Databricks alias for "%" in the match-all catalog wildcard

--- a/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
@@ -441,7 +441,7 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
         {
             // Guards the central invariant of the columns-extended fallback path
             // (GetColumnsExtendedViaThreeCalls): it must reuse the NON-throwing
-            // GetPrimaryKeysAsyncInternal / GetCrossReferenceAsyncInternal, which return
+            // GetPrimaryKeysAsyncNoThrow / GetCrossReferenceAsyncNoThrow, which return
             // empty for legitimately-unspecified args (here: catalog set + schema null),
             // rather than the public getprimarykeys/getcrossreference wrappers that
             // validate and throw a 42000 on that same catalog-set-schema-null shape.

--- a/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
+++ b/csharp/test/Unit/StatementExecution/StatementExecutionMetadataObjectNotFoundTests.cs
@@ -126,7 +126,8 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
             return new HttpClient(handler.Object);
         }
 
-        private static StatementExecutionStatement CreateMetadataStatement(HttpClient httpClient)
+        private static StatementExecutionStatement CreateMetadataStatement(
+            HttpClient httpClient, IReadOnlyDictionary<string, string>? extraProperties = null)
         {
             var properties = new Dictionary<string, string>
             {
@@ -134,6 +135,11 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 { DatabricksParameters.WarehouseId, "wh-1" },
                 { SparkParameters.AccessToken, "token" },
             };
+            if (extraProperties != null)
+            {
+                foreach (var kv in extraProperties)
+                    properties[kv.Key] = kv.Value;
+            }
 
             var connection = new StatementExecutionConnection(properties, httpClient);
             // The outer statement's IStatementExecutionClient is unused on the metadata
@@ -545,6 +551,44 @@ namespace AdbcDrivers.Databricks.Tests.Unit.StatementExecution
                 () => stmt.ExecuteQueryAsync(CancellationToken.None));
             Assert.Equal(AdbcStatusCode.InternalError, ex.Status);
             Assert.Equal("42000", ex.SqlState);
+        }
+
+        // When PK/FK is disabled, the driver returns empty PK/FK metadata uniformly, and
+        // the arg-validation throws must NOT fire — both exact-match ops behave the same.
+        // GetPrimaryKeysAsync already short-circuits before validation; this pins that
+        // GetCrossReferenceAsync does too (regression: it used to throw before the guard).
+
+        [Fact]
+        public async Task GetCrossReference_PKFKDisabled_ForeignCatalogSetForeignSchemaNull_ReturnsEmpty()
+        {
+            using var http = HttpClientCapturingStatements(new List<string>());
+            using var stmt = CreateMetadataStatement(http,
+                new Dictionary<string, string> { { DatabricksParameters.EnablePKFK, "false" } });
+            stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            stmt.SetOption(ApacheParameters.ForeignCatalogName, "main");
+            stmt.SetOption(ApacheParameters.ForeignTableName, "fk_child");
+            // Foreign schema deliberately null while foreign catalog IS set — would throw
+            // if PK/FK were enabled, but the disabled feature must short-circuit to empty.
+            stmt.SqlQuery = "getcrossreference";
+
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+            Assert.Equal(0, result.RowCount);
+        }
+
+        [Fact]
+        public async Task GetPrimaryKeys_PKFKDisabled_CatalogSetSchemaNull_ReturnsEmpty()
+        {
+            using var http = HttpClientCapturingStatements(new List<string>());
+            using var stmt = CreateMetadataStatement(http,
+                new Dictionary<string, string> { { DatabricksParameters.EnablePKFK, "false" } });
+            stmt.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            stmt.SetOption(ApacheParameters.CatalogName, "main");
+            stmt.SetOption(ApacheParameters.TableName, "t");
+            // SchemaName deliberately null while catalog IS set — the sibling of the above.
+            stmt.SqlQuery = "getprimarykeys";
+
+            var result = await stmt.ExecuteQueryAsync(CancellationToken.None);
+            Assert.Equal(0, result.RowCount);
         }
 
         // ─── Object-not-found errors are SWALLOWED to an empty result ────────────────


### PR DESCRIPTION
## Summary

Adds client-side argument validation to the SEA metadata **exact-match** operations
`GetPrimaryKeys` and `GetCrossReference`, mirroring the JDBC reference driver's
`resolveKeyBasedParams` / `listCrossReferences`. This gives clean, deterministic
errors and avoids relying on the Thrift server's inconsistent (and in one case buggy)
handling of missing arguments.

Split out of adbc-drivers/databricks#604 (which handles object-not-found → empty,
backslash escaping, and the exception-type pivot) because exact-match argument
validation is a distinct concern.

## Verified behavior (live thrift vs rest, + JDBC reference source)

Legend: **empty** = 0-row result, no throw. **throw** = AdbcException.

### GetPrimaryKeys(catalog, schema, table)

| input | Thrift (measured) | JDBC SEA (resolveKeyBasedParams) | ADBC SEA (this PR) |
|---|---|---|---|
| all set, object exists | rows | rows | rows |
| all set, object missing | **empty** | **empty** (isObjectNotFound catch) | **empty** |
| **table = null** | throw `42000` "tableName may not be null" | **throw** "tableName may not be null" | **throw `42000`** |
| **catalog set, schema = null** | throw `08000` "GET_FUNCTIONS assertion failed" (server bug) | **throw** "schema may not be null when catalog is specified" | **throw `42000`** (clean; matches JDBC intent) |
| catalog = null (schema/table set) | throw `08000` (server bug) | resolves from session, else throw | empty (no session default) |

### GetCrossReference(pk…, fk…)

| input | Thrift (measured) | JDBC SEA (listCrossReferences) | ADBC SEA (this PR) |
|---|---|---|---|
| foreign side fully set, exists | rows | rows | rows |
| **both parent table AND foreign table = null** | **throw `42000`** "foreignTable and parentTableName are both null" | **empty** ("unspecified") | **empty** (matches JDBC SEA — see note) |
| **≥1 table set, foreign table = null** (e.g. parent table set) | **empty** | **empty** ("unspecified") | **empty** |
| **foreign catalog set, foreign schema = null** (fk table set) | throw `08000` "GET_FUNCTIONS assertion failed" (server bug) | **throw** "schema may not be null when catalog is specified" | **throw `42000`** (clean; matches JDBC intent) |
| PK/FK feature disabled | (n/a) | empty | **empty** (short-circuit before validation; symmetric with GetPrimaryKeys) |
| object missing | empty | empty (isObjectNotFound catch) | empty |

> **Note on the both-null case:** ADBC SEA follows the **JDBC SEA** reference here, not Thrift.
> `DatabricksMetadataQueryClient.listCrossReferences` checks *only* the foreign table — a null
> foreign table is "unspecified" and returns an empty result; it never inspects the parent table.
> So both-tables-null returns **empty**. Measured against the live Thrift server, the same input
> throws a clean `42000` ("foreignTable and parentTableName are both null"), so this is an
> intentional Thrift-vs-SEA divergence, whitelisted in the comparator (databricks-driver-test#1047).
> When only the foreign table is null but a parent table is set, both Thrift and SEA return empty.

## Why validate client-side

1. **Thrift's `08000` on null-schema is a server bug** — it surfaces an internal
   `GET_FUNCTIONS assertion failed` (a connection-exception SQLSTATE) instead of a
   clean argument error. JDBC validates before the RPC and throws a clean error;
   this PR does the same so SEA doesn't depend on (or replicate) the buggy path.
2. **Deterministic, no round-trip** — the error is raised before issuing SHOW KEYS /
   SHOW FOREIGN KEYS.

## Scope / correctness notes

- Validation lives only on the **user-facing** command path. Each exact-match op is a
  thin public wrapper that reads the statement fields, validates, and throws
  (`GetPrimaryKeysAsync` / `GetCrossReferenceAsync`), over a **non-throwing** internal
  core that takes the key parts as explicit params and returns empty for
  unspecified/invalid args (`GetPrimaryKeysAsyncInternal(catalog, schema, table, …)` /
  `GetCrossReferenceAsyncInternal(pkCatalog, pkSchema, pkTable, fkCatalog, fkSchema, fkTable, …)`).
  `GetColumnsExtended`'s internal three-call fallback reuses the PK/FK fetch with a null
  schema on purpose (to gather keys for a column set); it calls the **internals**
  directly, so its legitimately-unspecified args return empty instead of being rejected.
  The wrappers throw only when the feature is engaged and the internal would otherwise
  reach a live fetch, so the two paths never diverge.
- Errors are `DatabricksException` (the SEA-natural type). The comparator compares
  `Status` + `SqlState`, not the concrete subclass, so this matches Thrift's path
  where Thrift returns a clean error, and is whitelisted where Thrift emits its
  `08000` bug.

## Comparator

The residual Thrift `08000`-vs-SEA `42000` sqlstate diffs (foreign/catalog schema-null)
are documented as a Thrift server bug in databricks-driver-test's test_case_filters
(schema-null exact-match skip). The both-tables-null case is also whitelisted there
(databricks-driver-test#1047): ADBC SEA now returns **empty** (matching JDBC SEA) while
Thrift throws `42000` — an intentional Thrift-vs-SEA divergence.

All behavior in the tables above was verified against the live Thrift server via a
throwaway E2E probe (`TGetPrimaryKeysReq` / `TGetCrossReferenceReq`), not inferred from
code or mocks.

This pull request and its description were written by Isaac.


