### PR TITLE
fix(csharp): drain in-flight CloudFetch downloads on cancel to prevent leak

### DIFF
--- a/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -315,10 +315,14 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 long totalBytes = 0;
                 var overallStopwatch = Stopwatch.StartNew();
 
+                // Keep track of active download tasks. Hoisted to method scope so the
+                // finally block can drain in-flight downloads on the cancellation path
+                // (partial-read + dispose): otherwise those tasks are orphaned and their
+                // buffers + acquired memory outlive disposal, which looks like a leak.
+                var downloadTasks = new ConcurrentDictionary<Task, IDownloadResult>();
+
                 try
                 {
-                    // Keep track of active download tasks
-                    var downloadTasks = new ConcurrentDictionary<Task, IDownloadResult>();
                     var downloadTaskCompletionSource = new TaskCompletionSource<bool>();
 
                     // Process items from the download queue until it's completed
@@ -517,6 +521,29 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 }
                 finally
                 {
+                    // Drain any in-flight per-file download tasks before returning. On the
+                    // cancellation path (partial-read + dispose) the foreach above exits via
+                    // OperationCanceledException WITHOUT reaching the end-of-results
+                    // Task.WhenAll, so without this the downloads keep running orphaned —
+                    // their file buffers and acquired memory outlive Dispose and register as a
+                    // leak under load. Each task's continuation already releases the semaphore
+                    // and memory and removes itself from the dictionary; awaiting them here
+                    // makes disposal deterministic. Their DownloadResults remain in the queues,
+                    // which CloudFetchDownloadManager.Dispose drains and disposes.
+                    if (!downloadTasks.IsEmpty)
+                    {
+                        try
+                        {
+                            await Task.WhenAll(downloadTasks.Keys).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Individual tasks handle their own errors; a cancelled/faulted
+                            // in-flight download must not mask the original loop exit.
+                            activity?.AddException(ex, [new("error.context", "cloudfetch.drain_inflight_on_exit")]);
+                        }
+                    }
+
                     overallStopwatch.Stop();
 
                     activity?.AddEvent("cloudfetch.download_summary", [


### PR DESCRIPTION
## Summary

Fixes a CloudFetch download-pipeline leak on the **partial-read + dispose** path, which was intermittently failing `DriverResilienceTests.PartialRead_DisposeStatement_ShouldNotHangOrLeak` on the merge queue.

## Root cause

`CloudFetchDownloader.DownloadFilesAsync` runs a worker loop that spawns up to N parallel per-file `DownloadFileAsync` tasks, tracked in a local `downloadTasks` dictionary. It only awaits those in-flight tasks (`await Task.WhenAll(downloadTasks.Keys)`) when it reaches the **normal** end-of-results guard.

On a partial read where the caller disposes the reader/statement mid-stream, `CloudFetchDownloadManager.Dispose → StopAsync` cancels the pipeline token. The worker's `foreach (_downloadQueue.GetConsumingEnumerable(cancellationToken))` then throws `OperationCanceledException`, so the loop exits straight through `catch`/`finally` — **bypassing the `Task.WhenAll`**. The in-flight `DownloadFileAsync` tasks are orphaned: they keep running (HTTP body → `byte[]` → LZ4 decompress), holding their file buffers and acquired memory-manager permits past disposal. `StopAsync` awaits only the worker task, which returns immediately on cancel — not the per-file downloads.

Under load this reads as a memory leak. The test asserts managed-memory growth `< 20 MB` after abandoning 5 large result sets; on the merge queue (heavy parallelism, slower cancellation) it observed **+40 MB** and failed, while passing on lightly-loaded PR runs. The growth scales with how much download data is still in flight when the GC snapshot is taken (result size × parallelism × timing) — the signature of a load-dependent flake, not a deterministic regression.

## Fix

Hoist `downloadTasks` to method scope and, in the `finally`, `await Task.WhenAll(downloadTasks.Keys)` so in-flight downloads drain deterministically before the pipeline reports stopped. Each task's continuation already releases the semaphore + memory and removes itself from the dictionary; the awaited tasks' `DownloadResult`s remain in the queues, which `CloudFetchDownloadManager.Dispose` already drains and disposes. Exceptions from a cancelled/faulted in-flight download are swallowed (logged to the activity) so they can't mask the original loop exit.

## Verification (live SEA warehouse)

- A `RANGE(5,000,000)` partial-read repro (default parallelism) dropped from **+20.84 MB → +1.59 MB** growth.
- The real test `PartialRead_DisposeStatement_ShouldNotHangOrLeak` stays green (~-6 MB, memory decreases).
- Full `DriverResilienceTests` + `CloudFetch` E2E suite: **139 passed / 0 failed / 11 skipped**, no hang (the drain awaits complete cleanly).

This pull request and its description were written by Isaac.
