### PR TITLE
TEMP diag: isolate PartialRead in E2E (do not merge)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -254,6 +254,10 @@ jobs:
         shell: bash
         run: |
           export DATABRICKS_TEST_CONFIG_FILE="$HOME/.databricks/connection.json"
+          # TEMP DIAGNOSTIC (do not merge): isolate PartialRead to test whether it fails
+          # only when preceded by other tests in the same process (shared RMSM pool / process
+          # memory carryover) vs. failing standalone.
+          export TEST_FILTER="FullyQualifiedName~PartialRead_DisposeStatement_ShouldNotHangOrLeak"
           ./ci/scripts/csharp_test_databricks_e2e.sh "${{ github.workspace }}"
 
       # Always run, even on test failure or job cancellation, so we don't

--- a/csharp/src/Reader/CloudFetch/DownloadResult.cs
+++ b/csharp/src/Reader/CloudFetch/DownloadResult.cs
@@ -34,6 +34,13 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
     /// </summary>
     internal sealed class DownloadResult : IDownloadResult
     {
+        // TEMP DIAGNOSTIC: track live DownloadResult instances + outstanding bytes to
+        // deterministically detect whether partial-read+dispose leaks downloaded chunks.
+        internal static int s_liveCount;
+        internal static long s_liveBytes;
+        internal static int s_createdTotal;
+        internal static int s_disposedTotal;
+
         private readonly TaskCompletionSource<bool> _downloadCompletionSource;
         private readonly ICloudFetchMemoryBufferManager _memoryManager;
         private Stream? _dataStream;
@@ -74,6 +81,8 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
             _httpHeaders = httpHeaders;
             _downloadCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _size = byteCount;
+            System.Threading.Interlocked.Increment(ref s_createdTotal);
+            System.Threading.Interlocked.Increment(ref s_liveCount);
         }
 
         /// <summary>
@@ -182,6 +191,7 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
             ThrowIfDisposed();
             _dataStream = dataStream ?? throw new ArgumentNullException(nameof(dataStream));
             _downloadCompletionSource.TrySetResult(true);
+            System.Threading.Interlocked.Add(ref s_liveBytes, size - _size);
             _size = size;
         }
 
@@ -209,8 +219,12 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 if (_size > 0)
                 {
                     _memoryManager.ReleaseMemory(_size);
+                    System.Threading.Interlocked.Add(ref s_liveBytes, -_size);
                 }
             }
+
+            System.Threading.Interlocked.Increment(ref s_disposedTotal);
+            System.Threading.Interlocked.Decrement(ref s_liveCount);
 
             // Ensure any waiting tasks are completed if not already
             if (!_downloadCompletionSource.Task.IsCompleted)

--- a/csharp/src/Reader/CloudFetch/DownloadResult.cs
+++ b/csharp/src/Reader/CloudFetch/DownloadResult.cs
@@ -34,13 +34,6 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
     /// </summary>
     internal sealed class DownloadResult : IDownloadResult
     {
-        // TEMP DIAGNOSTIC: track live DownloadResult instances + outstanding bytes to
-        // deterministically detect whether partial-read+dispose leaks downloaded chunks.
-        internal static int s_liveCount;
-        internal static long s_liveBytes;
-        internal static int s_createdTotal;
-        internal static int s_disposedTotal;
-
         private readonly TaskCompletionSource<bool> _downloadCompletionSource;
         private readonly ICloudFetchMemoryBufferManager _memoryManager;
         private Stream? _dataStream;
@@ -81,8 +74,6 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
             _httpHeaders = httpHeaders;
             _downloadCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _size = byteCount;
-            System.Threading.Interlocked.Increment(ref s_createdTotal);
-            System.Threading.Interlocked.Increment(ref s_liveCount);
         }
 
         /// <summary>
@@ -191,7 +182,6 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
             ThrowIfDisposed();
             _dataStream = dataStream ?? throw new ArgumentNullException(nameof(dataStream));
             _downloadCompletionSource.TrySetResult(true);
-            System.Threading.Interlocked.Add(ref s_liveBytes, size - _size);
             _size = size;
         }
 
@@ -219,12 +209,8 @@ namespace AdbcDrivers.Databricks.Reader.CloudFetch
                 if (_size > 0)
                 {
                     _memoryManager.ReleaseMemory(_size);
-                    System.Threading.Interlocked.Add(ref s_liveBytes, -_size);
                 }
             }
-
-            System.Threading.Interlocked.Increment(ref s_disposedTotal);
-            System.Threading.Interlocked.Decrement(ref s_liveCount);
 
             // Ensure any waiting tasks are completed if not already
             if (!_downloadCompletionSource.Task.IsCompleted)

--- a/csharp/test/E2E/DriverResilienceTests.cs
+++ b/csharp/test/E2E/DriverResilienceTests.cs
@@ -55,48 +55,42 @@ namespace AdbcDrivers.Databricks.Tests
         [SkippableFact]
         public async Task PartialRead_DisposeStatement_ShouldNotHangOrLeak()
         {
-            // TEMP DIAGNOSTIC: deterministically track live DownloadResult instances + outstanding
-            // bytes (static counters in DownloadResult) around each partial-read+dispose. If live
-            // count/bytes DON'T return to their post-dispose baseline, the cancel path retains
-            // downloaded chunks (real leak); if they do, the GC-total "growth" was noise.
+            // TEMP DIAGNOSTIC: WeakReference test — the DEFINITIVE leak check. After each
+            // partial-read+dispose we capture a weak ref to the result-stream reader, then force
+            // full GC. If the weak refs are DEAD (!IsAlive) the driver retains nothing and the
+            // climbing GC.GetTotalMemory is pure LOH/heap accounting noise (→ test fix). If they
+            // stay ALIVE, something roots them (→ real leak; the rooted object names the holder).
             using var connection = NewConnection();
+            var readerRefs = new List<WeakReference>();
 
-            void Dump(string tag)
-            {
-                GC.Collect(2, GCCollectionMode.Forced, true);
-                GC.WaitForPendingFinalizers();
-                GC.Collect(2, GCCollectionMode.Forced, true);
-                Console.WriteLine(
-                    $"[dlr] {tag} live={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveCount} " +
-                    $"liveBytesMB={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveBytes / 1048576.0:F1} " +
-                    $"created={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_createdTotal} " +
-                    $"disposed={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_disposedTotal} " +
-                    $"GC={GC.GetTotalMemory(true) / 1048576.0:F1}");
-            }
-
-            async Task PartialReadOnce(int n)
+            for (int i = 1; i <= 7; i++)
             {
                 using (var statement = connection.CreateStatement())
                 {
                     statement.SqlQuery = "SELECT * FROM RANGE(1000000)";
-                    using var reader = statement.ExecuteQuery().Stream;
+                    var reader = statement.ExecuteQuery().Stream;
+                    readerRefs.Add(new WeakReference(reader));
                     var batch = await reader.ReadNextRecordBatchAsync();
                     Assert.NotNull(batch);
+                    reader.Dispose();
                 }
-                await Task.Delay(500); // let cancellation settle
-                Dump($"after-iter{n}");
+                await Task.Delay(300);
+                GC.Collect(2, GCCollectionMode.Forced, true);
+                GC.WaitForPendingFinalizers();
+                GC.Collect(2, GCCollectionMode.Forced, true);
+                int aliveReaders = readerRefs.Count(r => r.IsAlive);
+                Console.WriteLine($"[wref] after-iter{i} aliveReaders={aliveReaders}/{readerRefs.Count} GC={GC.GetTotalMemory(true) / 1048576.0:F1}MB");
             }
 
-            Dump("start");
-            for (int i = 1; i <= 7; i++)
-            {
-                await PartialReadOnce(i);
-            }
+            GC.Collect(2, GCCollectionMode.Forced, true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(2, GCCollectionMode.Forced, true);
+            int stillAlive = readerRefs.Count(r => r.IsAlive);
+            Console.WriteLine($"[wref] FINAL aliveReaders={stillAlive}/{readerRefs.Count}");
 
-            // The real invariant: after dispose+settle, live DownloadResults must return to ~0.
-            // (Diagnostic assertion — the numbers above tell the story regardless.)
-            Assert.True(AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveCount <= 2,
-                $"DownloadResult live count did not drain: {AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveCount}");
+            // The real invariant: disposed result-stream readers must be collectable.
+            Assert.True(stillAlive <= 1,
+                $"{stillAlive}/{readerRefs.Count} disposed result readers remained rooted — real leak.");
         }
 
         /// <summary>

--- a/csharp/test/E2E/DriverResilienceTests.cs
+++ b/csharp/test/E2E/DriverResilienceTests.cs
@@ -55,69 +55,48 @@ namespace AdbcDrivers.Databricks.Tests
         [SkippableFact]
         public async Task PartialRead_DisposeStatement_ShouldNotHangOrLeak()
         {
+            // TEMP DIAGNOSTIC: deterministically track live DownloadResult instances + outstanding
+            // bytes (static counters in DownloadResult) around each partial-read+dispose. If live
+            // count/bytes DON'T return to their post-dispose baseline, the cancel path retains
+            // downloaded chunks (real leak); if they do, the GC-total "growth" was noise.
             using var connection = NewConnection();
 
-            // This guards against a real per-iteration leak of abandoned CloudFetch buffers, but
-            // must not trip on two benign, non-leak memory effects that a raw before/after delta
-            // conflates with a leak (both verified empirically on the CI runner):
-            //   1. The managed heap — chiefly the Large Object Heap, where the >85KB decompressed
-            //      result arrays live — settles to a working-set plateau over the first couple of
-            //      iterations that is HIGHER than a single warm-up reaches, and .NET does not
-            //      compact the LOH by default, so GC.GetTotalMemory reports that one-time step.
-            //   2. LZ4 decompression parks reusable blocks in the shared RecyclableMemoryStream
-            //      pool's free list (never a leak; sized once and reused).
-            // A genuine leak grows on EVERY iteration; a plateau grows once then flattens. So we
-            // measure growth AFTER a 2-iteration warm-up and assert the post-warmup slope is flat,
-            // mirroring the CloudFetchStressTests.RepeatedLargeCloudFetch_MemoryShouldPlateau check.
-            async Task PartialReadOnce()
+            void Dump(string tag)
             {
-                using var statement = connection.CreateStatement();
-                statement.SqlQuery = "SELECT * FROM RANGE(1000000)";
-                using var reader = statement.ExecuteQuery().Stream;
-                // Read only the first batch, then let disposal cancel the CloudFetch pipeline.
-                var batch = await reader.ReadNextRecordBatchAsync();
-                Assert.NotNull(batch);
-            }
-
-            long MeasureSettled()
-            {
-                // One-time LOH compaction so a dead-but-uncompacted LOH segment isn't counted.
-                System.Runtime.GCSettings.LargeObjectHeapCompactionMode =
-                    System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
                 GC.Collect(2, GCCollectionMode.Forced, true);
                 GC.WaitForPendingFinalizers();
                 GC.Collect(2, GCCollectionMode.Forced, true);
-                return GC.GetTotalMemory(true);
+                Console.WriteLine(
+                    $"[dlr] {tag} live={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveCount} " +
+                    $"liveBytesMB={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveBytes / 1048576.0:F1} " +
+                    $"created={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_createdTotal} " +
+                    $"disposed={AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_disposedTotal} " +
+                    $"GC={GC.GetTotalMemory(true) / 1048576.0:F1}");
             }
 
-            const int warmupIterations = 2;   // let the heap reach its working-set plateau
-            const int measuredIterations = 5;
-
-            for (int i = 0; i < warmupIterations; i++)
+            async Task PartialReadOnce(int n)
             {
-                await PartialReadOnce();
+                using (var statement = connection.CreateStatement())
+                {
+                    statement.SqlQuery = "SELECT * FROM RANGE(1000000)";
+                    using var reader = statement.ExecuteQuery().Stream;
+                    var batch = await reader.ReadNextRecordBatchAsync();
+                    Assert.NotNull(batch);
+                }
+                await Task.Delay(500); // let cancellation settle
+                Dump($"after-iter{n}");
             }
-            await Task.Delay(1000);
-            long baseline = MeasureSettled();
 
-            for (int i = 0; i < measuredIterations; i++)
+            Dump("start");
+            for (int i = 1; i <= 7; i++)
             {
-                await PartialReadOnce();
-                OutputHelper?.WriteLine($"Iteration {i + 1}: read first batch, disposing remainder");
+                await PartialReadOnce(i);
             }
-            await Task.Delay(1000);
-            long final = MeasureSettled();
 
-            double postWarmupGrowthMB = (final - baseline) / 1024.0 / 1024.0;
-            OutputHelper?.WriteLine($"Post-warmup baseline: {baseline / 1048576.0:F2} MB");
-            OutputHelper?.WriteLine($"Final:                {final / 1048576.0:F2} MB");
-            OutputHelper?.WriteLine($"Post-warmup growth:   {postWarmupGrowthMB:F2} MB over {measuredIterations} iterations");
-
-            // After warm-up the heap has plateaued; a real leak would keep accumulating ~8MB per
-            // abandoned result set (~40MB over 5). Post-warmup growth must stay near zero.
-            Assert.True(postWarmupGrowthMB < 20.0,
-                $"Possible CloudFetch pipeline leak on partial consumption: {postWarmupGrowthMB:F2} MB " +
-                $"post-warmup growth over {measuredIterations} abandoned result sets.");
+            // The real invariant: after dispose+settle, live DownloadResults must return to ~0.
+            // (Diagnostic assertion — the numbers above tell the story regardless.)
+            Assert.True(AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveCount <= 2,
+                $"DownloadResult live count did not drain: {AdbcDrivers.Databricks.Reader.CloudFetch.DownloadResult.s_liveCount}");
         }
 
         /// <summary>

--- a/csharp/test/E2E/DriverResilienceTests.cs
+++ b/csharp/test/E2E/DriverResilienceTests.cs
@@ -55,73 +55,69 @@ namespace AdbcDrivers.Databricks.Tests
         [SkippableFact]
         public async Task PartialRead_DisposeStatement_ShouldNotHangOrLeak()
         {
-            // TEMP DIAGNOSTIC (not for merge). Runs isolated via TEST_FILTER in e2e-tests.yml.
-            // Attributes the CI growth per iteration using Console.WriteLine (OutputHelper is
-            // suppressed for passing tests). sIU=RMSM SmallPoolInUseSize (undisposed blocks),
-            // sFR=SmallPoolFreeSize (reusable free list), gen0/1/2 collection counts, LOH size.
-            var database = (DatabricksDatabase)NewDriver.Open(GetDriverParameters(TestConfiguration));
-            var pool = database.RecyclableMemoryStreamManager;
-            using var connection = database.Connect(new Dictionary<string, string>());
+            using var connection = NewConnection();
 
-            // Collect WITH one-time LOH compaction. The decompressed result arrays are >85KB and
-            // land on the Large Object Heap, which .NET does NOT compact by default — so dead LOH
-            // arrays leave committed, fragmented segments that GC.GetTotalMemory still counts.
-            // That is the entire source of the observed "growth" (verified: RMSM in-use=0, only LOH
-            // climbs). Compacting once before measuring reclaims that space so we measure a real leak.
-            void CollectCompact()
-            {
-                System.Runtime.GCSettings.LargeObjectHeapCompactionMode =
-                    System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
-                GC.Collect(2, GCCollectionMode.Forced, true);
-                GC.WaitForPendingFinalizers();
-                GC.Collect(2, GCCollectionMode.Forced, true);
-            }
-
-            void Dump(string tag)
-            {
-                CollectCompact();
-                double MB(long b) => b / 1048576.0;
-                long loh = GC.GetGCMemoryInfo().GenerationInfo is var gi && gi.Length > 3 ? gi[3].SizeAfterBytes : -1;
-                Console.WriteLine(
-                    $"[leakdiag] {tag} GC={MB(GC.GetTotalMemory(true)):F1} " +
-                    $"sIU={MB(pool.SmallPoolInUseSize):F1} sFR={MB(pool.SmallPoolFreeSize):F1} " +
-                    $"lIU={MB(pool.LargePoolInUseSize):F1} lFR={MB(pool.LargePoolFreeSize):F1} " +
-                    $"LOH={MB(loh):F1}");
-            }
-
+            // This guards against a real per-iteration leak of abandoned CloudFetch buffers, but
+            // must not trip on two benign, non-leak memory effects that a raw before/after delta
+            // conflates with a leak (both verified empirically on the CI runner):
+            //   1. The managed heap — chiefly the Large Object Heap, where the >85KB decompressed
+            //      result arrays live — settles to a working-set plateau over the first couple of
+            //      iterations that is HIGHER than a single warm-up reaches, and .NET does not
+            //      compact the LOH by default, so GC.GetTotalMemory reports that one-time step.
+            //   2. LZ4 decompression parks reusable blocks in the shared RecyclableMemoryStream
+            //      pool's free list (never a leak; sized once and reused).
+            // A genuine leak grows on EVERY iteration; a plateau grows once then flattens. So we
+            // measure growth AFTER a 2-iteration warm-up and assert the post-warmup slope is flat,
+            // mirroring the CloudFetchStressTests.RepeatedLargeCloudFetch_MemoryShouldPlateau check.
             async Task PartialReadOnce()
             {
                 using var statement = connection.CreateStatement();
                 statement.SqlQuery = "SELECT * FROM RANGE(1000000)";
                 using var reader = statement.ExecuteQuery().Stream;
+                // Read only the first batch, then let disposal cancel the CloudFetch pipeline.
                 var batch = await reader.ReadNextRecordBatchAsync();
                 Assert.NotNull(batch);
             }
 
-            Dump("start");
-            await PartialReadOnce();
-            await Task.Delay(500);
-            Dump("after-warmup1");
-
-            CollectCompact();
-            long memBefore = GC.GetTotalMemory(true);
-
-            for (int i = 0; i < 5; i++)
+            long MeasureSettled()
             {
-                await PartialReadOnce();
-                Dump($"iter{i + 1}");
+                // One-time LOH compaction so a dead-but-uncompacted LOH segment isn't counted.
+                System.Runtime.GCSettings.LargeObjectHeapCompactionMode =
+                    System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
+                GC.Collect(2, GCCollectionMode.Forced, true);
+                GC.WaitForPendingFinalizers();
+                GC.Collect(2, GCCollectionMode.Forced, true);
+                return GC.GetTotalMemory(true);
             }
 
+            const int warmupIterations = 2;   // let the heap reach its working-set plateau
+            const int measuredIterations = 5;
+
+            for (int i = 0; i < warmupIterations; i++)
+            {
+                await PartialReadOnce();
+            }
             await Task.Delay(1000);
-            Dump("final");
-            CollectCompact();
-            long memAfter = GC.GetTotalMemory(true);
+            long baseline = MeasureSettled();
 
-            double growthMB = (memAfter - memBefore) / 1024.0 / 1024.0;
-            Console.WriteLine($"[leakdiag] Growth: {growthMB:F2} MB");
+            for (int i = 0; i < measuredIterations; i++)
+            {
+                await PartialReadOnce();
+                OutputHelper?.WriteLine($"Iteration {i + 1}: read first batch, disposing remainder");
+            }
+            await Task.Delay(1000);
+            long final = MeasureSettled();
 
-            Assert.True(growthMB < 20.0,
-                $"Possible CloudFetch pipeline leak on partial consumption: {growthMB:F2} MB growth after 5 abandoned result sets.");
+            double postWarmupGrowthMB = (final - baseline) / 1024.0 / 1024.0;
+            OutputHelper?.WriteLine($"Post-warmup baseline: {baseline / 1048576.0:F2} MB");
+            OutputHelper?.WriteLine($"Final:                {final / 1048576.0:F2} MB");
+            OutputHelper?.WriteLine($"Post-warmup growth:   {postWarmupGrowthMB:F2} MB over {measuredIterations} iterations");
+
+            // After warm-up the heap has plateaued; a real leak would keep accumulating ~8MB per
+            // abandoned result set (~40MB over 5). Post-warmup growth must stay near zero.
+            Assert.True(postWarmupGrowthMB < 20.0,
+                $"Possible CloudFetch pipeline leak on partial consumption: {postWarmupGrowthMB:F2} MB " +
+                $"post-warmup growth over {measuredIterations} abandoned result sets.");
         }
 
         /// <summary>

--- a/csharp/test/E2E/DriverResilienceTests.cs
+++ b/csharp/test/E2E/DriverResilienceTests.cs
@@ -55,56 +55,58 @@ namespace AdbcDrivers.Databricks.Tests
         [SkippableFact]
         public async Task PartialRead_DisposeStatement_ShouldNotHangOrLeak()
         {
-            using var connection = NewConnection();
-            long memBefore, memAfter;
+            // TEMP DIAGNOSTIC (not for merge). Runs isolated via TEST_FILTER in e2e-tests.yml.
+            // Attributes the CI growth per iteration using Console.WriteLine (OutputHelper is
+            // suppressed for passing tests). sIU=RMSM SmallPoolInUseSize (undisposed blocks),
+            // sFR=SmallPoolFreeSize (reusable free list), gen0/1/2 collection counts, LOH size.
+            var database = (DatabricksDatabase)NewDriver.Open(GetDriverParameters(TestConfiguration));
+            var pool = database.RecyclableMemoryStreamManager;
+            using var connection = database.Connect(new Dictionary<string, string>());
 
-            // Warm-up: run one full read+dispose cycle BEFORE the baseline snapshot. The
-            // LZ4 decompression path pools buffers (RecyclableMemoryStreamManager + ArrayPool),
-            // and that pool sizes itself once to the peak footprint of a single result and then
-            // reuses it — a bounded, one-time cost, not a per-iteration leak (verified: growth
-            // plateaus across 5 vs 20 iterations, and disabling LZ4 removes it entirely). Sizing
-            // the pool before memBefore keeps that one-time allocation out of the measurement, so
-            // the loop below measures only per-iteration accumulation — i.e. an actual leak.
-            using (var warmup = connection.CreateStatement())
+            void Dump(string tag)
             {
-                warmup.SqlQuery = "SELECT * FROM RANGE(1000000)";
-                var warmupResult = warmup.ExecuteQuery();
-                using var warmupReader = warmupResult.Stream;
-                await warmupReader.ReadNextRecordBatchAsync();
+                GC.Collect(2, GCCollectionMode.Forced, true);
+                GC.WaitForPendingFinalizers();
+                GC.Collect(2, GCCollectionMode.Forced, true);
+                double MB(long b) => b / 1048576.0;
+                long loh = GC.GetGCMemoryInfo().GenerationInfo is var gi && gi.Length > 3 ? gi[3].SizeAfterBytes : -1;
+                Console.WriteLine(
+                    $"[leakdiag] {tag} GC={MB(GC.GetTotalMemory(true)):F1} " +
+                    $"sIU={MB(pool.SmallPoolInUseSize):F1} sFR={MB(pool.SmallPoolFreeSize):F1} " +
+                    $"lIU={MB(pool.LargePoolInUseSize):F1} lFR={MB(pool.LargePoolFreeSize):F1} " +
+                    $"LOH={MB(loh):F1}");
             }
 
-            GC.Collect(2, GCCollectionMode.Forced, true);
-            memBefore = GC.GetTotalMemory(true);
-
-            // Do this 5 times to amplify any leak
-            for (int i = 0; i < 5; i++)
+            async Task PartialReadOnce()
             {
                 using var statement = connection.CreateStatement();
                 statement.SqlQuery = "SELECT * FROM RANGE(1000000)";
-                var result = statement.ExecuteQuery();
-                using var reader = result.Stream;
-
-                // Read only the first batch, then let disposal clean up the rest
+                using var reader = statement.ExecuteQuery().Stream;
                 var batch = await reader.ReadNextRecordBatchAsync();
                 Assert.NotNull(batch);
-                OutputHelper?.WriteLine($"Iteration {i + 1}: read first batch ({batch!.Length} rows), disposing remainder");
-                // reader and statement dispose here — CloudFetch pipeline must cancel
             }
 
-            // Allow background tasks to settle
+            Dump("start");
+            await PartialReadOnce();
+            await Task.Delay(500);
+            Dump("after-warmup1");
+
+            GC.Collect(2, GCCollectionMode.Forced, true);
+            long memBefore = GC.GetTotalMemory(true);
+
+            for (int i = 0; i < 5; i++)
+            {
+                await PartialReadOnce();
+                Dump($"iter{i + 1}");
+            }
+
             await Task.Delay(1000);
-            GC.Collect(2, GCCollectionMode.Forced, true);
-            GC.WaitForPendingFinalizers();
-            GC.Collect(2, GCCollectionMode.Forced, true);
-            memAfter = GC.GetTotalMemory(true);
+            Dump("final");
+            long memAfter = GC.GetTotalMemory(true);
 
             double growthMB = (memAfter - memBefore) / 1024.0 / 1024.0;
-            OutputHelper?.WriteLine($"Memory before: {memBefore / 1024.0 / 1024.0:F2} MB");
-            OutputHelper?.WriteLine($"Memory after:  {memAfter / 1024.0 / 1024.0:F2} MB");
-            OutputHelper?.WriteLine($"Growth: {growthMB:F2} MB");
+            Console.WriteLine($"[leakdiag] Growth: {growthMB:F2} MB");
 
-            // Each abandoned result set is ~8MB of Arrow data (1M int64 values).
-            // If the pipeline leaks downloaded buffers, we'd see 40+ MB growth.
             Assert.True(growthMB < 20.0,
                 $"Possible CloudFetch pipeline leak on partial consumption: {growthMB:F2} MB growth after 5 abandoned result sets.");
         }

--- a/csharp/test/E2E/DriverResilienceTests.cs
+++ b/csharp/test/E2E/DriverResilienceTests.cs
@@ -63,11 +63,23 @@ namespace AdbcDrivers.Databricks.Tests
             var pool = database.RecyclableMemoryStreamManager;
             using var connection = database.Connect(new Dictionary<string, string>());
 
-            void Dump(string tag)
+            // Collect WITH one-time LOH compaction. The decompressed result arrays are >85KB and
+            // land on the Large Object Heap, which .NET does NOT compact by default — so dead LOH
+            // arrays leave committed, fragmented segments that GC.GetTotalMemory still counts.
+            // That is the entire source of the observed "growth" (verified: RMSM in-use=0, only LOH
+            // climbs). Compacting once before measuring reclaims that space so we measure a real leak.
+            void CollectCompact()
             {
+                System.Runtime.GCSettings.LargeObjectHeapCompactionMode =
+                    System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
                 GC.Collect(2, GCCollectionMode.Forced, true);
                 GC.WaitForPendingFinalizers();
                 GC.Collect(2, GCCollectionMode.Forced, true);
+            }
+
+            void Dump(string tag)
+            {
+                CollectCompact();
                 double MB(long b) => b / 1048576.0;
                 long loh = GC.GetGCMemoryInfo().GenerationInfo is var gi && gi.Length > 3 ? gi[3].SizeAfterBytes : -1;
                 Console.WriteLine(
@@ -91,7 +103,7 @@ namespace AdbcDrivers.Databricks.Tests
             await Task.Delay(500);
             Dump("after-warmup1");
 
-            GC.Collect(2, GCCollectionMode.Forced, true);
+            CollectCompact();
             long memBefore = GC.GetTotalMemory(true);
 
             for (int i = 0; i < 5; i++)
@@ -102,6 +114,7 @@ namespace AdbcDrivers.Databricks.Tests
 
             await Task.Delay(1000);
             Dump("final");
+            CollectCompact();
             long memAfter = GC.GetTotalMemory(true);
 
             double growthMB = (memAfter - memBefore) / 1024.0 / 1024.0;


### PR DESCRIPTION
Temporary: injects TEST_FILTER to run only PartialRead_DisposeStatement_ShouldNotHangOrLeak in the E2E job. If it passes isolated but fails in the full suite, the growth is process/pool carryover from earlier tests, not this test's own leak. Not for merge.