### PR TITLE
fix(csharp): make CloseOperation best-effort in DatabricksCompositeReader.Dispose

### DIFF
--- a/csharp/src/Reader/DatabricksCompositeReader.cs
+++ b/csharp/src/Reader/DatabricksCompositeReader.cs
@@ -276,9 +276,18 @@ namespace AdbcDrivers.Databricks.Reader
                             }
                             catch (Exception ex)
                             {
+                                // Best-effort close: the TCloseOperationReq is a teardown cleanup
+                                // RPC issued during Dispose, and the operation's results have
+                                // already been consumed by this point — a close failure cannot
+                                // invalidate them and is not actionable by the caller. Record it
+                                // (captured into CloseStatementRpcError below and surfaced via the
+                                // CLOSE_STATEMENT telemetry event + the trace exception) but do NOT
+                                // rethrow: throwing out of Dispose violates the .NET dispose
+                                // contract and would skip the remaining teardown (the active
+                                // reader's Dispose just below), leaking it. Mirrors the swallow
+                                // pattern in DatabricksStatement.Dispose's telemetry emit.
                                 closeError = ex;
                                 activity?.AddException(ex);
-                                throw;
                             }
                             finally
                             {


### PR DESCRIPTION
## Summary

Makes the `TCloseOperationReq` RPC best-effort in `DatabricksCompositeReader.Dispose`: record a close failure but do not rethrow it out of `Dispose`.

## The bug

During `Dispose`, the composite reader issues `CloseOperationAsync` (a teardown cleanup RPC) and the `catch` block **rethrew** any failure:

```csharp
catch (Exception ex)
{
    closeError = ex;
    activity?.AddException(ex);
    throw;   // ← removed
}
```

This is wrong for two reasons:

1. **Dispose should not throw.** The operation's results have already been consumed by the time `Dispose` runs, so a close-RPC failure (a transient network blip, an already-closed operation, etc.) cannot invalidate them and is not actionable by the caller — but the rethrow surfaced it as a hard error out of the caller's `using` block.
2. **It skipped the remaining teardown.** `_activeReader.Dispose()` runs *after* this `try`/`finally`; when the close rethrew, that line was skipped, leaking the active reader.

## The fix

Drop the `throw`. The `finally` block still runs on failure (it always did) and:
- captures the error into `CloseStatementRpcError` (surfaced via the `CLOSE_STATEMENT` telemetry event), and
- emits the `composite_reader.close_operation.completed` trace event.

So observability is unchanged — the failure is still recorded, just not propagated. This mirrors the swallow-and-log pattern already used in `DatabricksStatement.Dispose`'s telemetry emit.

## Impact

This also fixes an intermittent CI failure in the driver-test replay suite: `ResultFetchingTests.LazyFetchEmptyResultSet` occasionally saw a replay-proxy 404 on the teardown `CloseOperation` (the proxy returns 404 for an unmatched teardown RPC, explicitly assuming the caller tolerates it). The rethrow turned that tolerated 404 into a test failure; best-effort dispose makes the driver behave as the proxy (and .NET dispose semantics) expect.

## Test plan

- [x] 959 unit tests pass locally (`net8.0`).
- [x] No test asserted the throw-on-close behavior; `CloseOperationE2ETest` (which asserts the close trace event is still emitted) is unaffected — the `finally` still emits it.
- [ ] Merge-queue E2E.

This pull request and its description were written by Isaac.
