### PR TITLE
fix(csharp): sEA GetPrimaryKeys row identifiers from server response, not input case

### DIFF
--- a/csharp/src/StatementExecution/StatementExecutionStatement.cs
+++ b/csharp/src/StatementExecution/StatementExecutionStatement.cs
@@ -1731,13 +1731,26 @@ namespace AdbcDrivers.Databricks.StatementExecution
                     var colNameArray = TryGetColumn<StringArray>(batch, "col_name");
                     var keyNameArray = TryGetColumn<StringArray>(batch, "constraintName");
                     var keySeqArray = TryGetColumn<Int32Array>(batch, "keySeq");
+                    // Read the identifier columns back from the SHOW KEYS response so
+                    // TABLE_CAT/TABLE_SCHEM/TABLE_NAME reflect the server's stored (canonical)
+                    // casing rather than echoing the caller's input case. Mirrors the JDBC
+                    // reference driver (PRIMARY_KEYS_COLUMNS maps TABLE_CAT→catalogName,
+                    // TABLE_SCHEM→namespace, TABLE_NAME→tableName) and this driver's own
+                    // FetchCrossReferenceAsync. Fall back to the input args when the server
+                    // omits a value, so behavior is never worse than before.
+                    var catalogArray = TryGetColumn<StringArray>(batch, "catalogName");
+                    var schemaArray = TryGetColumn<StringArray>(batch, "namespace");
+                    var tableArray = TryGetColumn<StringArray>(batch, "tableName");
                     if (colNameArray == null) continue;
                     for (int i = 0; i < batch.Length; i++)
                     {
                         if (colNameArray.IsNull(i)) continue;
                         int keySeq = keySeqArray != null && !keySeqArray.IsNull(i) ? keySeqArray.GetValue(i)!.Value : ++seq;
                         string pkName = keyNameArray != null && !keyNameArray.IsNull(i) ? keyNameArray.GetString(i) : "";
-                        keys.Add((catalog!, schema!, table!,
+                        string rowCatalog = catalogArray != null && !catalogArray.IsNull(i) ? catalogArray.GetString(i) : catalog!;
+                        string rowSchema = schemaArray != null && !schemaArray.IsNull(i) ? schemaArray.GetString(i) : schema!;
+                        string rowTable = tableArray != null && !tableArray.IsNull(i) ? tableArray.GetString(i) : table!;
+                        keys.Add((rowCatalog, rowSchema, rowTable,
                             colNameArray.GetString(i), keySeq, pkName));
                     }
                 }

--- a/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
@@ -342,11 +342,14 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
         // the server's stored (canonical, lowercase) casing — NOT the uppercase input echoed back.
         // Thrift and the JDBC reference driver both return the server's casing; SEA previously
         // echoed the input, diverging on every case-variant PK query. Regression guard for that fix.
+        // The bug is SEA-specific, so force the REST/SEA path explicitly (matching the #593 tests
+        // above) rather than relying on the run's configured protocol — on a Thrift-configured run
+        // the default connection would pass trivially without exercising the fixed code path.
         [SkippableFact]
         public async Task GetPrimaryKeys_UppercaseTableName_ReturnsServerCanonicalCasing()
         {
             SkipIfNotConfigured();
-            using var conn = CreateConnection();
+            using var conn = CreateConnection(RestProtocol);
             var rows = await ReadMetadata(
                 conn, "GetPrimaryKeys", TestCatalog, TestSchema, TestTable.ToUpperInvariant());
 

--- a/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
+++ b/csharp/test/E2E/StatementExecution/SeaMetadataE2ETests.cs
@@ -337,6 +337,34 @@ namespace AdbcDrivers.Databricks.Tests.E2E.StatementExecution
             Assert.Equal("c_int", rows[1]["COLUMN_NAME"]);
         }
 
+        // Case-variant input: querying with an uppercase table name must still match (identifiers
+        // are case-insensitive), and the result rows' TABLE_CAT/TABLE_SCHEM/TABLE_NAME must reflect
+        // the server's stored (canonical, lowercase) casing — NOT the uppercase input echoed back.
+        // Thrift and the JDBC reference driver both return the server's casing; SEA previously
+        // echoed the input, diverging on every case-variant PK query. Regression guard for that fix.
+        [SkippableFact]
+        public async Task GetPrimaryKeys_UppercaseTableName_ReturnsServerCanonicalCasing()
+        {
+            SkipIfNotConfigured();
+            using var conn = CreateConnection();
+            var rows = await ReadMetadata(
+                conn, "GetPrimaryKeys", TestCatalog, TestSchema, TestTable.ToUpperInvariant());
+
+            // Case-insensitive match still finds the two PK columns.
+            Assert.Equal(2, rows.Count);
+            Assert.Equal("c_string", rows[0]["COLUMN_NAME"]);
+            Assert.Equal("c_int", rows[1]["COLUMN_NAME"]);
+
+            // The identifier columns reflect the server's canonical (lowercase) values, not the
+            // uppercase input. TestTable/TestSchema/TestCatalog are the canonical lowercase forms.
+            foreach (var row in rows)
+            {
+                Assert.Equal(TestTable, row["TABLE_NAME"]);
+                Assert.Equal(TestSchema, row["TABLE_SCHEM"]);
+                Assert.Equal(TestCatalog, row["TABLE_CAT"]);
+            }
+        }
+
         // --- GetTableSchema ---
 
         [SkippableFact]


### PR DESCRIPTION
## Summary

SEA `GetPrimaryKeys` now populates `TABLE_CAT` / `TABLE_SCHEM` / `TABLE_NAME` from the **server's** `SHOW KEYS` response columns instead of echoing the caller's input case.

## The bug

`GetPrimaryKeysAsyncNoThrow` built each PK row as `keys.Add((catalog!, schema!, table!, ...))` — the **input args**. So a case-variant input (e.g. `TABLE = "TEST_RESULT_SET_TYPES"`) was echoed verbatim into the result rows, while Thrift returns the server's stored (canonical, lowercase) identifiers. In the comparator this surfaced as PK rows appearing "only on one side" (their `TABLE_NAME` case differed → the row keys didn't match) across every uppercase/hyphen case-variant PK query (~60 diffs).

## How JDBC handles it (the reference)

JDBC reads the identifiers back from the server response: `PRIMARY_KEYS_COLUMNS` maps `TABLE_CAT → catalogName`, `TABLE_SCHEM → namespace`, `TABLE_NAME → tableName`, and `getRows` fills each via `resultSet.getObject(serverColumnName)`. So JDBC surfaces the server's canonical casing and converges with Thrift regardless of input case.

This driver's own `FetchCrossReferenceAsync` (the XREF/FK side) **already** reads `catalogName`/`namespace`/`tableName` from the server response — the PK path was simply inconsistent with it.

## The fix

Read `catalogName` / `namespace` / `tableName` from the `SHOW KEYS` batch (confirmed present in SEA recordings) and use them for the row, falling back to the input args when the server omits a value — so behavior is never worse than before. Matches JDBC + Thrift + this driver's XREF path.

## Test plan

- [x] Build + PK/FK unit suite (35 pass). No existing test asserted the input-echo behavior.
- [ ] Comparator confirms the case-variant PK rows converge.

_Note: the row-value behavior needs a real `SHOW KEYS` response with rows to exercise; it isn't unit-testable at the HTTP-mock seam without full Arrow-response scaffolding (the unit mocks only produce empty/failed results). The comparator's case-variant PK matrix — which surfaced this diff — is the verification._

This pull request and its description were written by Isaac.
